### PR TITLE
Fix #2131 Add preflight check for WSL2

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -29,6 +29,20 @@ const (
 	minSupportedLibvirtVersion = "3.4.0"
 )
 
+func checkRunningInsideWSL2() error {
+	version, err := ioutil.ReadFile("/proc/version")
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(string(version), "Microsoft") {
+		logging.Debugf("Running inside WSL2 environment")
+		return fmt.Errorf("CodeReady Containers is unsupported using WSL2")
+	}
+
+	return nil
+}
+
 func checkVirtualizationEnabled() error {
 	logging.Debug("Checking if the vmx/svm flags are present in /proc/cpuinfo")
 	// Check if the cpu flags vmx or svm is present

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -114,6 +114,14 @@ var vsockPreflightChecks = Check{
 	cleanup:            removeVsockCrcSettings,
 }
 
+var wsl2PreflightChecks = Check{
+	configKeySuffix:  "check-wsl2",
+	checkDescription: "Checking if running inside WSL2",
+	check:            checkRunningInsideWSL2,
+	fixDescription:   "CodeReady Containers is unsupported using WSL2",
+	flags:            NoFix,
+}
+
 const (
 	vsockUdevSystemRulesPath     = "/usr/lib/udev/rules.d/99-crc-vsock.rules"
 	vsockUdevLocalAdminRulesPath = "/etc/udev/rules.d/99-crc-vsock.rules"
@@ -220,13 +228,16 @@ func removeVsockCrcSettings() error {
 func getAllPreflightChecks() []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
 	checks := getPreflightChecksForDistro(distro(), network.SystemNetworkingMode, usingSystemdResolved == nil)
+	checks = append(checks, wsl2PreflightChecks)
 	checks = append(checks, vsockPreflightChecks)
 	return checks
 }
 
 func getPreflightChecks(_ bool, _ bool, networkMode network.Mode) []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
-	return getPreflightChecksForDistro(distro(), networkMode, usingSystemdResolved == nil)
+	checks := getPreflightChecksForDistro(distro(), networkMode, usingSystemdResolved == nil)
+	checks = append(checks, wsl2PreflightChecks)
+	return checks
 }
 
 func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {


### PR DESCRIPTION
**Fixes:** Issue #2131

## Solution/Idea

This checks the kernel version for the pattern `Microsoft` as is the case when the WSL2 provided kernel is used. Note: any custom compiled kernel is ignored,. but in that case we can assume a power-user is at work.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. The `start` command will fail when this is called from inside a WSL2 hosted distribution

## Testing

Use Windows 10 with WSL2

1. `start` fails with an error message

On a regular Linux setup (or VM)

1. `start` will check but succeed the test.

