### PR TITLE
Disable checkpoints and automatic start of hyperv vm

### DIFF
--- a/pkg/drivers/hyperv/hyperv_windows.go
+++ b/pkg/drivers/hyperv/hyperv_windows.go
@@ -199,6 +199,16 @@ func (d *Driver) Create() error {
 		}
 	}
 
+	// Disables creating checkpoints and Automatic Start
+	// Shuts down the VM when host shuts down
+	if err := cmd("Hyper-V\\Set-VM",
+		"-VMName", d.MachineName,
+		"-AutomaticStartAction", "Nothing",
+		"-AutomaticStopAction", "ShutDown",
+		"-CheckpointType", "Disabled"); err != nil {
+		return err
+	}
+
 	return cmd("Hyper-V\\Add-VMHardDiskDrive",
 		"-VMName", d.MachineName,
 		"-Path", quote(d.getDiskPath()))


### PR DESCRIPTION
since crc's resource consumption is high we disable the automatic
start of the crc vm when the host starts up which is the default
behaviour, also disables creating checkpoints as we don't use them
When the host shuts down its good to also shutdown the vm to prevent
any errors on later start
