### PR TITLE
docs: Clarify processor architecture requirement

### DIFF
--- a/docs/source/topics/ref_minimum-system-requirements.adoc
+++ b/docs/source/topics/ref_minimum-system-requirements.adoc
@@ -14,6 +14,7 @@
 
 {prod} is supported only on AMD64 and Intel 64 processor architectures.
 {prod} does not support the ARM-based M1 architecture.
+{prod} does not support nested virtualization.
 
 [NOTE]
 ====


### PR DESCRIPTION
**Fixes:** Issue #2821, issue #2080

## Solution/Idea

This PR clarifies that CodeReady Containers requires an x86-64 processor architecture (following Red Hat guidelines, we refer to this architecture as "AMD64 and Intel 64") and is explicitly _not_ supported on the recent M1 processor architecture utilized by newer Apple computers.