### PR TITLE
e2e: fix httpd test case

### DIFF
--- a/test/testdata/httpd-example-index.html
+++ b/test/testdata/httpd-example-index.html
@@ -1,0 +1,2 @@
+Hello CRC!
+


### PR DESCRIPTION
quay.io/bitnami/nginx is no longer available, which breaks the test case. 
The changes are more involved than just changing the image name, as 
registry.access.redhat.com/ubi8/httpd-24 needs html data to be provided in
/var/www/html. This is done using a pvc (PersistentVolumeClaim) and using
it with our httpd-example deployment. Then `oc exec` is used to create an
empty `index.html` file at that location.