### PR TITLE
Support WSL2 distros accessing private (apiserver, ssh, cockpit) services

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -21,6 +21,7 @@ import (
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/daemonclient"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/crc/machine"
 	"github.com/docker/go-units"
 	"github.com/gorilla/handlers"
 	"github.com/pkg/errors"
@@ -238,7 +239,10 @@ func gatewayAPIMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/hosts/add", func(w http.ResponseWriter, r *http.Request) {
 		acceptJSONStringArray(w, r, func(hostnames []string) error {
-			return adminhelper.AddToHostsFile("127.0.0.1", hostnames...)
+			// Most of the time we will add a hosts entry to resolve this to 127.0.0.1
+			// On a Windows machine running WSL this is the "IP" of the machine within the WSL2 network,
+			// so it is accessible from both WSL2 and Windows
+			return adminhelper.AddToHostsFile(machine.VsockPrivateAddress(), hostnames...)
 		})
 	})
 	mux.HandleFunc("/hosts/remove", func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -69,6 +69,9 @@ func init() {
 	rootCmd.AddCommand(cmdBundle.GetBundleCmd(config))
 
 	logging.AddLogLevelFlag(rootCmd.PersistentFlags())
+
+	// wsl-network-access
+	constants.WSLNetworkAccess = config.Get(crcConfig.WSLNetworkAccess).AsBool()
 }
 
 func runPrerun(cmd *cobra.Command) error {

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -37,6 +37,7 @@ const (
 	EmergencyLogin           = "enable-emergency-login"
 	PersistentVolumeSize     = "persistent-volume-size"
 	EnableBundleQuayFallback = "enable-bundle-quay-fallback"
+	WSLNetworkAccess         = "wsl-network-access"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -96,13 +97,15 @@ func RegisterSettings(cfg *Config) {
 	cfg.AddSetting(PersistentVolumeSize, constants.DefaultPersistentVolumeSize, validatePersistentVolumeSize, SuccessfullyApplied,
 		fmt.Sprintf("Total size in GiB of the persistent volume used by the CSI driver for %s preset (must be greater than or equal to '%d')", preset.Microshift, constants.DefaultPersistentVolumeSize))
 
-	// Shared directories configs
 	if runtime.GOOS == "windows" {
+		// Shared directories configs
 		cfg.AddSetting(SharedDirPassword, Secret(""), validateString, SuccessfullyApplied,
 			"Password used while using CIFS/SMB file sharing (It is the password for the current logged in user)")
-
 		cfg.AddSetting(EnableSharedDirs, false, validateSmbSharedDirs, SuccessfullyApplied,
 			"Mounts host's user profile folder at '/' in the CRC VM (true/false, default: false)")
+		// Setting to enable access to CRC vm from wsl
+		cfg.AddSetting(WSLNetworkAccess, false, ValidateBool, SuccessfullyApplied,
+			"Enable access to CRC VM within WSL environment (true/false, default: false)")
 	} else {
 		cfg.AddSetting(EnableSharedDirs, true, ValidateBool, SuccessfullyApplied,
 			"Mounts host's home directory at '/' in the CRC VM (true/false, default: true)")

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crc-org/crc/v2/pkg/crc/network"
 	"github.com/crc-org/crc/v2/pkg/crc/preset"
 	"github.com/crc-org/crc/v2/pkg/crc/version"
+	"github.com/spf13/cast"
 )
 
 const (
@@ -148,10 +149,17 @@ func RegisterSettings(cfg *Config) {
 	if err := cfg.RegisterNotifier(Preset, presetChanged); err != nil {
 		logging.Debugf("Failed to register notifier for Preset: %v", err)
 	}
+	if err := cfg.RegisterNotifier(WSLNetworkAccess, wslNetworkAccessChanged); err != nil {
+		logging.Debugf("Failed to register notifier for wsl-network-access: %v", err)
+	}
 }
 
 func presetChanged(cfg *Config, _ string, _ interface{}) {
 	UpdateDefaults(cfg)
+}
+
+func wslNetworkAccessChanged(_ *Config, _ string, value interface{}) {
+	constants.WSLNetworkAccess = cast.ToBool(value)
 }
 
 func defaultCPUs(cfg Storage) int {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -114,6 +114,7 @@ var (
 	DaemonSocketPath   = filepath.Join(CrcBaseDir, "crc.sock")
 	KubeconfigFilePath = filepath.Join(MachineInstanceDir, DefaultName, "kubeconfig")
 	PasswdFilePath     = filepath.Join(MachineInstanceDir, DefaultName, "passwd")
+	WSLNetworkAccess   = false
 )
 
 func GetDefaultBundlePath(preset crcpreset.Preset) string {

--- a/pkg/crc/machine/virtualmachine.go
+++ b/pkg/crc/machine/virtualmachine.go
@@ -89,7 +89,7 @@ func (vm *virtualMachine) State() (state.State, error) {
 
 func (vm *virtualMachine) IP() (string, error) {
 	if vm.vsock {
-		return "127.0.0.1", nil
+		return VsockPrivateAddress(), nil
 	}
 	return vm.Driver.GetIP()
 }

--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -92,10 +92,15 @@ func vsockPorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint)
 		socketProtocol = types.NPIPE
 		socketLocal = constants.DefaultPodmanNamedPipe
 	}
+
+	// API, Cockpit and Internal SSH are all bound to a private address, usually 127.0.0.1
+	// On Windows, where WSL2 is active, it's bound to the Windows machine's address within the private WSL2 network
+	privateIP := VsockPrivateAddress()
+
 	exposeRequest := []types.ExposeRequest{
 		{
 			Protocol: "tcp",
-			Local:    net.JoinHostPort(localIP, strconv.Itoa(constants.VsockSSHPort)),
+			Local:    net.JoinHostPort(privateIP, strconv.Itoa(constants.VsockSSHPort)),
 			Remote:   net.JoinHostPort(virtualMachineIP, internalSSHPort),
 		},
 		{
@@ -110,7 +115,7 @@ func vsockPorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint)
 		exposeRequest = append(exposeRequest,
 			types.ExposeRequest{
 				Protocol: "tcp",
-				Local:    net.JoinHostPort(localIP, apiPort),
+				Local:    net.JoinHostPort(privateIP, apiPort),
 				Remote:   net.JoinHostPort(virtualMachineIP, apiPort),
 			},
 			types.ExposeRequest{
@@ -127,7 +132,7 @@ func vsockPorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint)
 		exposeRequest = append(exposeRequest,
 			types.ExposeRequest{
 				Protocol: "tcp",
-				Local:    net.JoinHostPort(localIP, cockpitPort),
+				Local:    net.JoinHostPort(privateIP, cockpitPort),
 				Remote:   net.JoinHostPort(virtualMachineIP, cockpitPort),
 			})
 	default:

--- a/pkg/crc/machine/vsockprivateaddress_unix.go
+++ b/pkg/crc/machine/vsockprivateaddress_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package machine
+
+func VsockPrivateAddress() (addrStr string) {
+	return "127.0.0.1"
+}

--- a/pkg/crc/machine/vsockprivateaddress_windows.go
+++ b/pkg/crc/machine/vsockprivateaddress_windows.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/os/windows/powershell"
 )
@@ -16,6 +17,9 @@ const (
 // On Windows it would be useful if WSL2 can access VSock resources as well
 // This address should work on both the windows side and the WSL2 side
 func VsockPrivateAddress() (addrStr string) {
+	if !constants.WSLNetworkAccess {
+		return fallbackPrivateAddress
+	}
 	cmd := fmt.Sprintf(`(Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias "%s").IPAddress`, adapterName)
 	stdout, stderr, err := powershell.Execute(cmd)
 	if err != nil {

--- a/pkg/crc/machine/vsockprivateaddress_windows.go
+++ b/pkg/crc/machine/vsockprivateaddress_windows.go
@@ -1,0 +1,29 @@
+package machine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/os/windows/powershell"
+)
+
+const (
+	fallbackPrivateAddress = "127.0.0.1"
+	adapterName            = "vEthernet (WSL)"
+)
+
+// On Windows it would be useful if WSL2 can access VSock resources as well
+// This address should work on both the windows side and the WSL2 side
+func VsockPrivateAddress() (addrStr string) {
+	cmd := fmt.Sprintf(`(Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias "%s").IPAddress`, adapterName)
+	stdout, stderr, err := powershell.Execute(cmd)
+	if err != nil {
+		logging.Debugf("Unable to find IP address for WSL vswitch: %v: %s", err, stderr)
+		return fallbackPrivateAddress
+	}
+	if strings.TrimSpace(stdout) == "" {
+		return fallbackPrivateAddress
+	}
+	return strings.TrimSpace(stdout)
+}


### PR DESCRIPTION
**Addresses:** Issue #374


## Solution/Idea

Bind Windows host-side vSock ports to the Window's machines IP on the WSL2 network, allowing both Windows host and WSL2 to connect to VM services that aren't shared publically.

## Proposed changes

Adds decision-making on the "local" address for API Server, SSH server and DNS resolution of routes when these are using vsock as transport on windows. 

In addition, the injected DNS routes point to the WSL2 host address, as these additions are automatically* (see caveats) added into WSL2 so that the domains work across both Windows and WSL2.

## Testing

After successfully running `start` and `setup` you are able to run tooling from within WSL 2.

```shell
zed@THINKZED:~/development/oss/crc$ uname -a
Linux THINKZED 5.10.102.1-microsoft-standard-WSL2 #1 SMP Wed Mar 2 00:30:59 UTC 2022 x86_64 GNU/Linux
zed@THINKZED:~/development/oss/crc$ oc status
In project default on server https://api.crc.testing:6443

svc/openshift - kubernetes.default.svc.cluster.local
svc/kubernetes - 10.217.4.1:443 -> 6443

View details with 'oc describe <resource>/<name>' or list resources with 'oc get all'.
zed@THINKZED:~/development/oss/crc$ kubectl cluster-info
Kubernetes control plane is running at https://api.crc.testing:6443

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
```

## Caveats

Changes to the Window's hosts files are not always automatically picked up by WSL2 distributions. After a `crc start`, if the DNS entries were not already present, WSL2 may need to be restarted with `wsl --shutdown`.