### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/crc/cmd/delete_test.go
+++ b/cmd/crc/cmd/delete_test.go
@@ -2,50 +2,42 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/crc-org/crc/pkg/crc/machine/fakemachine"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPlainDelete(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	out := new(bytes.Buffer)
 	assert.NoError(t, runDelete(out, fakemachine.NewClient(), true, cacheDir, true, true, ""))
 	assert.Equal(t, "Deleted the instance\n", out.String())
 
-	_, err = os.Stat(cacheDir)
+	_, err := os.Stat(cacheDir)
 	assert.True(t, os.IsNotExist(err))
 }
 
 func TestNonForceDelete(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	out := new(bytes.Buffer)
 	assert.NoError(t, runDelete(out, fakemachine.NewClient(), true, cacheDir, true, false, ""))
 	assert.Equal(t, "", out.String())
 
-	_, err = os.Stat(cacheDir)
+	_, err := os.Stat(cacheDir)
 	assert.NoError(t, err)
 }
 
 func TestJSONDelete(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	out := new(bytes.Buffer)
 	assert.NoError(t, runDelete(out, fakemachine.NewClient(), true, cacheDir, false, true, jsonFormat))
 	assert.JSONEq(t, `{"success": true}`, out.String())
 
-	_, err = os.Stat(cacheDir)
+	_, err := os.Stat(cacheDir)
 	assert.True(t, os.IsNotExist(err))
 }

--- a/cmd/crc/cmd/status_test.go
+++ b/cmd/crc/cmd/status_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -48,9 +47,7 @@ func setUpFailingClient(t *testing.T) *mocks.Client {
 }
 
 func TestPlainStatus(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	client := setUpClient(t)
 
@@ -73,9 +70,7 @@ Cache Directory: %s
 }
 
 func TestStatusWithoutPodman(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	client := mocks.NewClient(t)
 	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
@@ -105,9 +100,7 @@ Cache Directory: %s
 }
 
 func TestJsonStatus(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	client := setUpClient(t)
 
@@ -135,9 +128,7 @@ func TestJsonStatus(t *testing.T) {
 }
 
 func TestPlainStatusWithError(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	client := setUpFailingClient(t)
 
@@ -151,9 +142,7 @@ func TestPlainStatusWithError(t *testing.T) {
 }
 
 func TestJsonStatusWithError(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	client := setUpFailingClient(t)
 
@@ -174,9 +163,7 @@ func TestJsonStatusWithError(t *testing.T) {
 }
 
 func TestStatusWithMemoryPodman(t *testing.T) {
-	cacheDir, err := ioutil.TempDir("", "cache")
-	require.NoError(t, err)
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	client := mocks.NewClient(t)
 	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))

--- a/pkg/compress/compress_test.go
+++ b/pkg/compress/compress_test.go
@@ -32,9 +32,7 @@ func testCompress(t *testing.T, baseDir string) {
 	require.NoError(t, Compress(baseDir, testArchiveName))
 	defer os.Remove(testArchiveName)
 
-	destDir, err := ioutil.TempDir("", "testdata-extracted")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
 	fileList, err := extract.Uncompress(testArchiveName, destDir, false)
 	require.NoError(t, err)

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -263,9 +262,7 @@ func TestTelemetry(t *testing.T) {
 }
 
 func TestPullSecret(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-pull-secret")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	fakeMachine := fakemachine.NewClient()
 	config := setupNewInMemoryConfig()

--- a/pkg/crc/cluster/pullsecret_test.go
+++ b/pkg/crc/cluster/pullsecret_test.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,9 +20,7 @@ const (
 func TestLoadPullSecret(t *testing.T) {
 	keyring.MockInit()
 
-	dir, err := ioutil.TempDir("", "pull-secret")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cfg := config.New(config.NewEmptyInMemoryStorage(), config.NewEmptyInMemorySecretStorage())
 	config.RegisterSettings(cfg)
@@ -33,7 +30,7 @@ func TestLoadPullSecret(t *testing.T) {
 		path:   filepath.Join(dir, "file1"),
 	}
 
-	_, err = loader.Value()
+	_, err := loader.Value()
 	assert.Error(t, err)
 
 	assert.NoError(t, StoreInKeyring(secret3))

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -34,9 +33,7 @@ func newTestConfig(configFile, envPrefix string) (*Config, error) {
 }
 
 func TestViperConfigUnknown(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config, err := newTestConfig(configFile, "CRC")
@@ -48,9 +45,7 @@ func TestViperConfigUnknown(t *testing.T) {
 }
 
 func TestViperConfigSetAndGet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config, err := newTestConfig(configFile, "CRC")
@@ -70,9 +65,7 @@ func TestViperConfigSetAndGet(t *testing.T) {
 }
 
 func TestViperConfigUnsetAndGet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 	assert.NoError(t, ioutil.WriteFile(configFile, []byte("{\"cpus\": 5}"), 0600))
 
@@ -93,9 +86,7 @@ func TestViperConfigUnsetAndGet(t *testing.T) {
 }
 
 func TestViperConfigSetReloadAndGet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config, err := newTestConfig(configFile, "CRC")
@@ -114,9 +105,7 @@ func TestViperConfigSetReloadAndGet(t *testing.T) {
 }
 
 func TestViperConfigLoadDefaultValue(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config, err := newTestConfig(configFile, "CRC")
@@ -149,9 +138,7 @@ func TestViperConfigLoadDefaultValue(t *testing.T) {
 }
 
 func TestViperConfigBindFlagSet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	validateCPUs := func(value interface{}) (bool, string) {
@@ -195,9 +182,7 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 }
 
 func TestViperConfigCastSet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config, err := newTestConfig(configFile, "CRC")
@@ -220,9 +205,7 @@ func TestViperConfigCastSet(t *testing.T) {
 }
 
 func TestCannotSetWithWrongType(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config, err := newTestConfig(configFile, "CRC")
@@ -233,9 +216,7 @@ func TestCannotSetWithWrongType(t *testing.T) {
 }
 
 func TestCannotGetWithWrongType(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 	assert.NoError(t, ioutil.WriteFile(configFile, []byte("{\"cpus\": \"hello\"}"), 0600))
 
@@ -246,9 +227,7 @@ func TestCannotGetWithWrongType(t *testing.T) {
 }
 
 func TestTwoInstancesSharingSameConfiguration(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config1, err := newTestConfig(configFile, "CRC")
@@ -275,9 +254,7 @@ func TestTwoInstancesSharingSameConfiguration(t *testing.T) {
 }
 
 func TestTwoInstancesWriteSameConfiguration(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config1, err := newTestConfig(configFile, "CRC")
@@ -304,9 +281,7 @@ func TestTwoInstancesWriteSameConfiguration(t *testing.T) {
 }
 
 func TestTwoInstancesSetAndUnsetSameConfiguration(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
 	config1, err := newTestConfig(configFile, "CRC")

--- a/pkg/crc/machine/bundle/copier_test.go
+++ b/pkg/crc/machine/bundle/copier_test.go
@@ -3,7 +3,6 @@ package bundle
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,16 +15,12 @@ func TestGenerateBundle(t *testing.T) {
 	var b CrcBundleInfo
 	assert.NoError(t, json.Unmarshal([]byte(jsonForBundle("crc_4.7.1")), &b))
 
-	tmpBundleDir, err := ioutil.TempDir("", "bundle_data")
-	assert.NoError(t, err)
+	tmpBundleDir := t.TempDir()
 	b.cachedPath = filepath.Join(tmpBundleDir, b.Name)
-	defer os.RemoveAll(tmpBundleDir)
 
 	createDummyBundleFiles(t, &b)
 
-	srcDir, err := ioutil.TempDir("", "testdata")
-	assert.NoError(t, err)
-	defer os.RemoveAll(srcDir)
+	srcDir := t.TempDir()
 
 	customBundleName := "custom_bundle"
 	copier, err := NewCopier(&b, srcDir, customBundleName)

--- a/pkg/crc/machine/bundle/repository_test.go
+++ b/pkg/crc/machine/bundle/repository_test.go
@@ -12,13 +12,8 @@ import (
 )
 
 func TestUse(t *testing.T) {
-	dir, err := ioutil.TempDir("", "repo")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	ocBinDir, err := ioutil.TempDir("", "oc-bin-dir")
-	assert.NoError(t, err)
-	defer os.RemoveAll(ocBinDir)
+	dir := t.TempDir()
+	ocBinDir := t.TempDir()
 
 	createDummyBundleContent(t, dir, "crc_libvirt_4.6.1", "1.0")
 
@@ -37,13 +32,8 @@ func TestUse(t *testing.T) {
 }
 
 func TestExtract(t *testing.T) {
-	dir, err := ioutil.TempDir("", "repo")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	ocBinDir, err := ioutil.TempDir("", "oc-bin-dir")
-	assert.NoError(t, err)
-	defer os.RemoveAll(ocBinDir)
+	dir := t.TempDir()
+	ocBinDir := t.TempDir()
 
 	repo := &Repository{
 		CacheDir: dir,
@@ -77,9 +67,7 @@ func testBundle(t *testing.T) string {
 }
 
 func TestVersionCheck(t *testing.T) {
-	dir, err := ioutil.TempDir("", "repo")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	repo := &Repository{
 		CacheDir: dir,
@@ -87,7 +75,7 @@ func TestVersionCheck(t *testing.T) {
 
 	bundlePath := filepath.Join(dir, "crc_libvirt_4.6.1")
 	createDummyBundleContent(t, dir, "crc_libvirt_4.6.1", "0.9")
-	_, err = repo.Get("crc_libvirt_4.6.1.crcbundle")
+	_, err := repo.Get("crc_libvirt_4.6.1.crcbundle")
 	assert.EqualError(t, err, "cannot use bundle with version 0.9, bundle version must satisfy ^1.0 constraint")
 	os.RemoveAll(bundlePath)
 
@@ -103,13 +91,8 @@ func TestVersionCheck(t *testing.T) {
 }
 
 func TestListBundles(t *testing.T) {
-	dir, err := ioutil.TempDir("", "repo")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	ocBinDir, err := ioutil.TempDir("", "oc-bin-dir")
-	assert.NoError(t, err)
-	defer os.RemoveAll(ocBinDir)
+	dir := t.TempDir()
+	ocBinDir := t.TempDir()
 
 	createDummyBundleContent(t, dir, "crc_libvirt_4.6.15", "1.0")
 	createDummyBundleContent(t, dir, "crc_libvirt_4.7.0", "1.0")

--- a/pkg/crc/machine/kubeconfig_test.go
+++ b/pkg/crc/machine/kubeconfig_test.go
@@ -2,7 +2,6 @@ package machine
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -41,9 +40,7 @@ func TestCertificateAuthority(t *testing.T) {
 }
 
 func TestCleanKubeconfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "clean")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	assert.NoError(t, cleanKubeconfig(filepath.Join("testdata", "kubeconfig.in"), filepath.Join(dir, "kubeconfig")))
 	actual, err := ioutil.ReadFile(filepath.Join(dir, "kubeconfig"))

--- a/pkg/crc/segment/segment_test.go
+++ b/pkg/crc/segment/segment_test.go
@@ -80,9 +80,7 @@ func TestClientUploadWithConsentAndWithSerializableError(t *testing.T) {
 	require.NoError(t, os.Setenv("SSH_TTY", "test"))
 	defer os.Unsetenv("SSH_TTY")
 
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	config, err := newTestConfig("yes")
 	require.NoError(t, err)
@@ -122,9 +120,7 @@ func TestClientUploadWithConsentAndWithoutSerializableError(t *testing.T) {
 	defer server.Close()
 	defer close(body)
 
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	config, err := newTestConfig("yes")
 	require.NoError(t, err)
@@ -157,9 +153,7 @@ func TestClientUploadWithContext(t *testing.T) {
 	defer server.Close()
 	defer close(body)
 
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	config, err := newTestConfig("yes")
 	require.NoError(t, err)
@@ -187,9 +181,7 @@ func TestClientUploadWithOutConsent(t *testing.T) {
 	defer server.Close()
 	defer close(body)
 
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	config, err := newTestConfig("no")
 	require.NoError(t, err)
@@ -212,9 +204,7 @@ func TestClientUploadWithConsentAndCachedIdentify(t *testing.T) {
 	defer server.Close()
 	defer close(body)
 
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	config, err := newTestConfig("yes")
 	require.NoError(t, err)

--- a/pkg/crc/ssh/keys_unix.go
+++ b/pkg/crc/ssh/keys_unix.go
@@ -30,6 +30,7 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 		if err != nil {
 			return ErrUnableToWriteFile
 		}
+		defer f.Close()
 
 		if _, err := f.Write(v.Value); err != nil {
 			return ErrUnableToWriteFile

--- a/pkg/crc/ssh/keys_windows.go
+++ b/pkg/crc/ssh/keys_windows.go
@@ -29,6 +29,7 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 		if err != nil {
 			return ErrUnableToWriteFile
 		}
+		defer f.Close()
 
 		if _, err := f.Write(v.Value); err != nil {
 			return ErrUnableToWriteFile
@@ -37,7 +38,6 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 		if err := acl.Chmod(v.File, 0600); err != nil {
 			return err
 		}
-
 	}
 
 	return nil

--- a/pkg/crc/ssh/ssh_test.go
+++ b/pkg/crc/ssh/ssh_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -24,9 +23,7 @@ import (
 )
 
 func TestRunner(t *testing.T) {
-	dir, err := ioutil.TempDir("", "ssh")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	clientKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	require.NoError(t, err)
@@ -173,10 +170,7 @@ func portFor(addr string) int {
 }
 
 func TestGenerateSSHKey(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "machine-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpDir := t.TempDir()
 
 	filename := filepath.Join(tmpDir, "sshkey")
 
@@ -187,7 +181,4 @@ func TestGenerateSSHKey(t *testing.T) {
 	if _, err := os.Stat(filename); err != nil {
 		t.Fatalf("expected ssh key at %s", filename)
 	}
-
-	// cleanup
-	_ = os.RemoveAll(tmpDir)
 }

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -34,21 +34,19 @@ var (
 
 func TestUncompress(t *testing.T) {
 	for _, archive := range archives {
-		assert.NoError(t, testUncompress(filepath.Join("testdata", archive), nil, files))
-		assert.NoError(t, testUncompress(filepath.Join("testdata", archive), fileFilter, filteredFiles))
+		assert.NoError(t, testUncompress(t, filepath.Join("testdata", archive), nil, files))
+		assert.NoError(t, testUncompress(t, filepath.Join("testdata", archive), fileFilter, filteredFiles))
 	}
 }
 
 func TestUnCompressBundle(t *testing.T) {
-	dir, err := ioutil.TempDir("", "bundles")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bundle := filepath.Join(dir, "test.crcbundle")
 	for _, archive := range archives {
 		require.NoError(t, crcos.CopyFileContents(filepath.Join("testdata", archive), bundle, 0600))
-		assert.NoError(t, testUncompress(bundle, nil, files))
-		assert.NoError(t, testUncompress(bundle, fileFilter, filteredFiles))
+		assert.NoError(t, testUncompress(t, bundle, nil, files))
+		assert.NoError(t, testUncompress(t, bundle, fileFilter, filteredFiles))
 	}
 }
 
@@ -129,14 +127,11 @@ func checkFiles(destDir string, files fileMap) error {
 	return nil
 }
 
-func testUncompress(archiveName string, fileFilter func(string) bool, files fileMap) error {
-	destDir, err := ioutil.TempDir("", "crc-extract-test")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(destDir)
+func testUncompress(t *testing.T, archiveName string, fileFilter func(string) bool, files fileMap) error {
+	destDir := t.TempDir()
 
 	var fileList []string
+	var err error
 	if fileFilter != nil {
 		fileList, err = UncompressWithFilter(archiveName, destDir, false, fileFilter)
 	} else {

--- a/pkg/libmachine/persist/filestore_test.go
+++ b/pkg/libmachine/persist/filestore_test.go
@@ -3,7 +3,6 @@ package persist
 import (
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,22 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestStore() (Filestore, func(), error) {
-	tmpDir, err := ioutil.TempDir("", "machine-test-")
-	if err != nil {
-		return Filestore{}, nil, err
-	}
+func getTestStore(t *testing.T) Filestore {
 	return Filestore{
-			MachinesDir: tmpDir,
-		}, func() {
-			os.RemoveAll(tmpDir)
-		}, nil
+		MachinesDir: t.TempDir(),
+	}
 }
 
 func TestStoreSave(t *testing.T) {
-	store, cleanup, err := getTestStore()
-	assert.NoError(t, err)
-	defer cleanup()
+	store := getTestStore(t)
 
 	h := testHost()
 
@@ -38,9 +29,7 @@ func TestStoreSave(t *testing.T) {
 }
 
 func TestStoreSaveOmitRawDriver(t *testing.T) {
-	store, cleanup, err := getTestStore()
-	assert.NoError(t, err)
-	defer cleanup()
+	store := getTestStore(t)
 
 	h := testHost()
 
@@ -60,9 +49,7 @@ func TestStoreSaveOmitRawDriver(t *testing.T) {
 }
 
 func TestStoreRemove(t *testing.T) {
-	store, cleanup, err := getTestStore()
-	assert.NoError(t, err)
-	defer cleanup()
+	store := getTestStore(t)
 
 	h := testHost()
 
@@ -71,16 +58,14 @@ func TestStoreRemove(t *testing.T) {
 	path := filepath.Join(store.MachinesDir, h.Name)
 	assert.DirExists(t, path)
 
-	err = store.Remove(h.Name)
+	err := store.Remove(h.Name)
 	assert.NoError(t, err)
 
 	assert.NoDirExists(t, path)
 }
 
 func TestStoreExists(t *testing.T) {
-	store, cleanup, err := getTestStore()
-	assert.NoError(t, err)
-	defer cleanup()
+	store := getTestStore(t)
 
 	h := testHost()
 
@@ -104,14 +89,13 @@ func TestStoreExists(t *testing.T) {
 }
 
 func TestStoreLoad(t *testing.T) {
-	store, cleanup, err := getTestStore()
-	assert.NoError(t, err)
-	defer cleanup()
+	store := getTestStore(t)
 
 	h := testHost()
 
 	assert.NoError(t, store.Save(h))
 
+	var err error
 	h, err = store.Load(h.Name)
 	assert.NoError(t, err)
 

--- a/pkg/os/util_test.go
+++ b/pkg/os/util_test.go
@@ -1,13 +1,11 @@
 package os
 
 import (
-	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	"os/user"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -30,9 +28,7 @@ func TestAddEnv(t *testing.T) {
 }
 
 func TestFileContentFuncs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "filecontent")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := filepath.Join(dir, "testfile")
 
@@ -58,12 +54,10 @@ func TestFileContentFuncs(t *testing.T) {
 }
 
 func TestFileExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "fileexists")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := filepath.Join(dir, "testfile1")
-	_, err = WriteFileIfContentChanged(filename, []byte("content"), 0644)
+	_, err := WriteFileIfContentChanged(filename, []byte("content"), 0644)
 	assert.NoError(t, err)
 	assert.True(t, FileExists(filename))
 
@@ -81,6 +75,10 @@ func TestFileExists(t *testing.T) {
 
 	err = os.Chmod(dirname, 0000)
 	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.Chmod(dirname, 0777))
+	}()
+
 	if runtime.GOOS == "windows" {
 		assert.True(t, FileExists(filename))
 	} else {


### PR DESCRIPTION
## Solution/Idea

A testing cleanup. 

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

## Proposed changes

Replace `ioutil.TempDir` with `t.TempDir` in all `*_test.go` files.

## Testing
