### PR TITLE
Remove use of io/ioutil

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -46,7 +45,7 @@ func runEmbed(args []string) {
 	var err error
 	executablePath := args[0]
 	if cacheDir == "" {
-		cacheDir, err = ioutil.TempDir("", "crc-embedder")
+		cacheDir, err = os.MkdirTemp("", "crc-embedder")
 		if err != nil {
 			logging.Fatalf("Failed to create temporary directory: %v", err)
 		}

--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -193,7 +193,7 @@ func run(configuration *types.Configuration) error {
 
 	if watchdog {
 		go func() {
-			if _, err := ioutil.ReadAll(os.Stdin); err != nil {
+			if _, err := io.ReadAll(os.Stdin); err != nil {
 				logging.Errorf("unexpected error while reading stdin: %v", err)
 			}
 			logging.Error("stdin is closed, shutdown...")

--- a/cmd/crc/cmd/status_test.go
+++ b/cmd/crc/cmd/status_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -51,7 +51,7 @@ func TestPlainStatus(t *testing.T) {
 
 	client := setUpClient(t)
 
-	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
 
 	out := new(bytes.Buffer)
 	assert.NoError(t, runStatus(out, &daemonclient.Client{
@@ -73,7 +73,7 @@ func TestStatusWithoutPodman(t *testing.T) {
 	cacheDir := t.TempDir()
 
 	client := mocks.NewClient(t)
-	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
 
 	client.On("Status").Return(apiClient.ClusterStatusResult{
 		CrcStatus:        string(state.Running),
@@ -104,7 +104,7 @@ func TestJsonStatus(t *testing.T) {
 
 	client := setUpClient(t)
 
-	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
 
 	out := new(bytes.Buffer)
 	assert.NoError(t, runStatus(out, &daemonclient.Client{
@@ -132,7 +132,7 @@ func TestPlainStatusWithError(t *testing.T) {
 
 	client := setUpFailingClient(t)
 
-	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
 
 	out := new(bytes.Buffer)
 	assert.EqualError(t, runStatus(out, &daemonclient.Client{
@@ -146,7 +146,7 @@ func TestJsonStatusWithError(t *testing.T) {
 
 	client := setUpFailingClient(t)
 
-	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
 
 	out := new(bytes.Buffer)
 	assert.NoError(t, runStatus(out, &daemonclient.Client{
@@ -166,7 +166,7 @@ func TestStatusWithMemoryPodman(t *testing.T) {
 	cacheDir := t.TempDir()
 
 	client := mocks.NewClient(t)
-	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
 
 	client.On("Status").Return(apiClient.ClusterStatusResult{
 		CrcStatus:        string(state.Running),

--- a/pkg/compress/compress_test.go
+++ b/pkg/compress/compress_test.go
@@ -2,7 +2,6 @@ package compress
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -121,7 +120,7 @@ func checkFiles(destDir string, files fileMap) error {
 		}
 		delete(files, archivePath)
 
-		data, err := ioutil.ReadFile(path) // #nosec G304
+		data, err := os.ReadFile(path) // #nosec G304
 		if err != nil {
 			return err
 		}

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -1,9 +1,9 @@
 package api
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -277,7 +277,7 @@ func TestPullSecret(t *testing.T) {
 	assert.False(t, defined)
 
 	pullSecretFile := filepath.Join(dir, "pull-secret.json")
-	assert.NoError(t, ioutil.WriteFile(pullSecretFile, []byte(constants.OkdPullSecret), 0600))
+	assert.NoError(t, os.WriteFile(pullSecretFile, []byte(constants.OkdPullSecret), 0600))
 	_, err = config.Set(crcConfig.PullSecretFile, pullSecretFile)
 	assert.NoError(t, err)
 

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -27,7 +26,7 @@ type mockServer struct {
 }
 
 func createDummyPullSecret(t *testing.T) string {
-	f, err := ioutil.TempFile("", "kubeconfig")
+	f, err := os.CreateTemp("", "kubeconfig")
 	assert.NoError(t, err)
 	_, err = f.WriteString(constants.OkdPullSecret)
 	assert.NoError(t, err)
@@ -464,7 +463,7 @@ func testOne(t *testing.T, testCase *testCase, server *mockServer) {
 	require.Equal(t, testCase.response.statusCode, resp.StatusCode, testCase.request)
 	require.Equal(t, testCase.response.protoMajor, resp.ProtoMajor, testCase.request)
 	require.Equal(t, testCase.response.protoMinor, resp.ProtoMinor, testCase.request)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err, testCase.request)
 	require.Equal(t, testCase.response.body, string(body), testCase.request)
 	fmt.Println("-----")

--- a/pkg/crc/api/client/client.go
+++ b/pkg/crc/api/client/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -218,7 +217,7 @@ func (c *client) sendGetRequest(url string) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Unknown error reading response: %w", err)
 	}
@@ -267,7 +266,7 @@ func (c *client) sendRequest(url string, method string, data io.Reader) ([]byte,
 		}
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Unknown error reading response: %w", err)
 	}

--- a/pkg/crc/api/helpers.go
+++ b/pkg/crc/api/helpers.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -99,7 +99,7 @@ func (s *server) Handler() http.Handler {
 		}
 		s.routesLock.RUnlock()
 
-		requestBody, err := ioutil.ReadAll(r.Body)
+		requestBody, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,7 +107,7 @@ func (c *Cache) CacheExecutable() error {
 	}
 
 	// Create tmp dir to download the requested tarball
-	tmpDir, err := ioutil.TempDir("", "crc")
+	tmpDir, err := os.MkdirTemp("", "crc")
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -105,7 +105,7 @@ func GetRAMUsage(sshRunner *ssh.Runner) (int64, int64, error) {
 }
 
 func EnsureSSHKeyPresentInTheCluster(ctx context.Context, ocConfig oc.Config, sshPublicKeyPath string) error {
-	sshPublicKeyByte, err := ioutil.ReadFile(sshPublicKeyPath)
+	sshPublicKeyByte, err := os.ReadFile(sshPublicKeyPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/cluster/clusteroperator_test.go
+++ b/pkg/crc/cluster/clusteroperator_test.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,7 +40,7 @@ type mockLister struct {
 }
 
 func (r *mockLister) List(ctx context.Context, opts metav1.ListOptions) (*v1.ClusterOperatorList, error) {
-	bin, err := ioutil.ReadFile(r.file)
+	bin, err := os.ReadFile(r.file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crc/cluster/kubeadmin_password.go
+++ b/pkg/crc/cluster/kubeadmin_password.go
@@ -7,8 +7,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"strings"
 
 	"github.com/crc-org/crc/pkg/crc/constants"
@@ -25,14 +25,14 @@ func GenerateKubeAdminUserPassword() error {
 	if err != nil {
 		return fmt.Errorf("Cannot generate the kubeadmin user password: %w", err)
 	}
-	return ioutil.WriteFile(kubeAdminPasswordFile, []byte(kubeAdminPassword), 0600)
+	return os.WriteFile(kubeAdminPasswordFile, []byte(kubeAdminPassword), 0600)
 }
 
 // UpdateKubeAdminUserPassword updates the htpasswd secret
 func UpdateKubeAdminUserPassword(ctx context.Context, ocConfig oc.Config, newPassword string) error {
 	if newPassword != "" {
 		logging.Infof("Overriding password for kubeadmin user")
-		if err := ioutil.WriteFile(constants.GetKubeAdminPasswordPath(), []byte(strings.TrimSpace(newPassword)), 0600); err != nil {
+		if err := os.WriteFile(constants.GetKubeAdminPasswordPath(), []byte(strings.TrimSpace(newPassword)), 0600); err != nil {
 			return err
 		}
 	}
@@ -79,7 +79,7 @@ func UpdateKubeAdminUserPassword(ctx context.Context, ocConfig oc.Config, newPas
 
 func GetKubeadminPassword() (string, error) {
 	kubeAdminPasswordFile := constants.GetKubeAdminPasswordPath()
-	rawData, err := ioutil.ReadFile(kubeAdminPasswordFile)
+	rawData, err := os.ReadFile(kubeAdminPasswordFile)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	crcConfig "github.com/crc-org/crc/pkg/crc/config"
@@ -156,7 +156,7 @@ func loadFile(path string) (string, error) {
 	if path == "" {
 		return "", errors.New("empty path")
 	}
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crc/cluster/pullsecret_test.go
+++ b/pkg/crc/cluster/pullsecret_test.go
@@ -1,7 +1,7 @@
 package cluster
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,7 +39,7 @@ func TestLoadPullSecret(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, secret3, val)
 
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file2"), []byte(secret2), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "file2"), []byte(secret2), 0600))
 	_, err = cfg.Set(config.PullSecretFile, filepath.Join(dir, "file2"))
 	assert.NoError(t, err)
 
@@ -47,7 +47,7 @@ func TestLoadPullSecret(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, secret2, val)
 
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file2"), []byte(secret1), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "file2"), []byte(secret1), 0600))
 
 	val, err = loader.Value()
 	assert.NoError(t, err)

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,7 +67,7 @@ func (c *ViperStorage) Set(key string, value interface{}) error {
 	if err := ensureConfigFileExists(c.configFile); err != nil {
 		return err
 	}
-	in, err := ioutil.ReadFile(c.configFile)
+	in, err := os.ReadFile(c.configFile)
 	if err != nil {
 		return err
 	}
@@ -90,7 +89,7 @@ func (c *ViperStorage) Unset(key string) error {
 	if err := ensureConfigFileExists(c.configFile); err != nil {
 		return err
 	}
-	in, err := ioutil.ReadFile(c.configFile)
+	in, err := os.ReadFile(c.configFile)
 	if err != nil {
 		return err
 	}
@@ -118,7 +117,7 @@ func (c *ViperStorage) BindFlagSet(flagSet *pflag.FlagSet) error {
 func ensureConfigFileExists(file string) error {
 	_, err := os.Stat(file)
 	if os.IsNotExist(err) {
-		return ioutil.WriteFile(file, []byte("{}\n"), 0600)
+		return os.WriteFile(file, []byte("{}\n"), 0600)
 	}
 	return err
 }
@@ -126,7 +125,7 @@ func ensureConfigFileExists(file string) error {
 func atomicWrite(bin []byte, configFile string) error {
 	ext := filepath.Ext(configFile)
 	pattern := fmt.Sprintf("%s*%s", strings.TrimSuffix(filepath.Base(configFile), ext), ext)
-	tmpFile, err := ioutil.TempFile(filepath.Dir(configFile), pattern)
+	tmpFile, err := os.CreateTemp(filepath.Dir(configFile), pattern)
 	if err != nil {
 		return err
 	}
@@ -136,7 +135,7 @@ func atomicWrite(bin []byte, configFile string) error {
 	if err := tmpFile.Close(); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(tmpFile.Name(), bin, 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), bin, 0600); err != nil {
 		return err
 	}
 	return os.Rename(tmpFile.Name(), configFile)

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -59,7 +59,7 @@ func TestViperConfigSetAndGet(t *testing.T) {
 		IsDefault: false,
 	}, config.Get(cpus))
 
-	bin, err := ioutil.ReadFile(configFile)
+	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"cpus":5}`, string(bin))
 }
@@ -67,7 +67,7 @@ func TestViperConfigSetAndGet(t *testing.T) {
 func TestViperConfigUnsetAndGet(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
-	assert.NoError(t, ioutil.WriteFile(configFile, []byte("{\"cpus\": 5}"), 0600))
+	assert.NoError(t, os.WriteFile(configFile, []byte("{\"cpus\": 5}"), 0600))
 
 	config, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestViperConfigUnsetAndGet(t *testing.T) {
 		IsDefault: true,
 	}, config.Get(cpus))
 
-	bin, err := ioutil.ReadFile(configFile)
+	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.Equal(t, "{}", string(bin))
 }
@@ -119,7 +119,7 @@ func TestViperConfigLoadDefaultValue(t *testing.T) {
 	_, err = config.Set(cpus, 4)
 	assert.NoError(t, err)
 
-	bin, err := ioutil.ReadFile(configFile)
+	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"cpus":4}`, string(bin))
 
@@ -176,7 +176,7 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	_, err = config.Set(cpus, "6")
 	assert.NoError(t, err)
 
-	bin, err := ioutil.ReadFile(configFile)
+	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"cpus":6}`, string(bin))
 }
@@ -199,7 +199,7 @@ func TestViperConfigCastSet(t *testing.T) {
 		IsDefault: false,
 	}, config.Get(cpus))
 
-	bin, err := ioutil.ReadFile(configFile)
+	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"cpus": 5}`, string(bin))
 }
@@ -218,7 +218,7 @@ func TestCannotSetWithWrongType(t *testing.T) {
 func TestCannotGetWithWrongType(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
-	assert.NoError(t, ioutil.WriteFile(configFile, []byte("{\"cpus\": \"hello\"}"), 0600))
+	assert.NoError(t, os.WriteFile(configFile, []byte("{\"cpus\": \"hello\"}"), 0600))
 
 	config, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
@@ -239,7 +239,7 @@ func TestTwoInstancesSharingSameConfiguration(t *testing.T) {
 	_, err = config1.Set(cpus, 5)
 	require.NoError(t, err)
 
-	bin, err := ioutil.ReadFile(configFile)
+	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"cpus":5}`, string(bin))
 
@@ -269,7 +269,7 @@ func TestTwoInstancesWriteSameConfiguration(t *testing.T) {
 	_, err = config2.Set(nameServer, "1.1.1.1")
 	require.NoError(t, err)
 
-	bin, err := ioutil.ReadFile(configFile)
+	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"cpus":5, "nameservers":"1.1.1.1"}`, string(bin))
 
@@ -296,7 +296,7 @@ func TestTwoInstancesSetAndUnsetSameConfiguration(t *testing.T) {
 	_, err = config2.Unset(cpus)
 	require.NoError(t, err)
 
-	bin, err := ioutil.ReadFile(configFile)
+	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{}`, string(bin))
 

--- a/pkg/crc/machine/bundle/copier.go
+++ b/pkg/crc/machine/bundle/copier.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,7 +118,7 @@ func (copier *Copier) GenerateBundle(bundleName string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(copier.resolvePath("crc-bundle-info.json"), bundleContent, 0600)
+	err = os.WriteFile(copier.resolvePath("crc-bundle-info.json"), bundleContent, 0600)
 	if err != nil {
 		return fmt.Errorf("error copying bundle metadata  %w", err)
 	}

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,7 +36,7 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 		return nil, errors.Wrapf(err, "could not find cached bundle info in %s", path)
 	}
 	jsonFilepath := filepath.Join(path, metadataFilename)
-	content, err := ioutil.ReadFile(jsonFilepath)
+	content, err := os.ReadFile(jsonFilepath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %s file", jsonFilepath)
 	}
@@ -153,7 +152,7 @@ func (repo *Repository) Extract(path string) error {
 }
 
 func (repo *Repository) List() ([]CrcBundleInfo, error) {
-	files, err := ioutil.ReadDir(repo.CacheDir)
+	files, err := os.ReadDir(repo.CacheDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crc/machine/bundle/repository_test.go
+++ b/pkg/crc/machine/bundle/repository_test.go
@@ -1,7 +1,6 @@
 package bundle
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -26,7 +25,7 @@ func TestUse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "4.6.1", bundle.ClusterInfo.OpenShiftVersion.String())
 
-	bin, err := ioutil.ReadFile(filepath.Join(ocBinDir, constants.OcExecutableName))
+	bin, err := os.ReadFile(filepath.Join(ocBinDir, constants.OcExecutableName))
 	assert.NoError(t, err)
 	assert.Equal(t, "openshift-client", string(bin))
 }
@@ -123,10 +122,10 @@ func TestListBundles(t *testing.T) {
 func createDummyBundleContent(t *testing.T, dir, name, version string) {
 	bundleDir := filepath.Join(dir, name)
 	assert.NoError(t, os.MkdirAll(bundleDir, 0755))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(bundleDir, metadataFilename), []byte(jsonForBundleWithVersion(version, name)), 0600))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(bundleDir, constants.OcExecutableName), []byte("openshift-client"), 0600))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(bundleDir, "kubeadmin-password"), []byte("kubeadmin-password"), 0600))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(bundleDir, "kubeconfig"), []byte("kubeconfig"), 0600))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(bundleDir, "id_ecdsa_crc"), []byte("id_ecdsa_crc"), 0600))
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(bundleDir, "crc.qcow2"), []byte("crc.qcow2"), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(bundleDir, metadataFilename), []byte(jsonForBundleWithVersion(version, name)), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(bundleDir, constants.OcExecutableName), []byte("openshift-client"), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(bundleDir, "kubeadmin-password"), []byte("kubeadmin-password"), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(bundleDir, "kubeconfig"), []byte("kubeconfig"), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(bundleDir, "id_ecdsa_crc"), []byte("id_ecdsa_crc"), 0600))
+	assert.NoError(t, os.WriteFile(filepath.Join(bundleDir, "crc.qcow2"), []byte("crc.qcow2"), 0600))
 }

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -2,7 +2,6 @@ package machine
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -52,7 +51,7 @@ func (client *client) GenerateBundle(forceStop bool) error {
 		return errors.New("VM is still running")
 	}
 
-	tmpBaseDir, err := ioutil.TempDir(constants.MachineCacheDir, "crc_custom_bundle")
+	tmpBaseDir, err := os.MkdirTemp(constants.MachineCacheDir, "crc_custom_bundle")
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/machine/kubeconfig_test.go
+++ b/pkg/crc/machine/kubeconfig_test.go
@@ -1,7 +1,7 @@
 package machine
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,7 +29,7 @@ users:
 `
 
 func TestCertificateAuthority(t *testing.T) {
-	f, err := ioutil.TempFile("", "kubeconfig")
+	f, err := os.CreateTemp("", "kubeconfig")
 	assert.NoError(t, err, "")
 	_, err = f.WriteString(dummyKubeconfigFileContent)
 	assert.NoError(t, err, "")
@@ -43,15 +43,15 @@ func TestCleanKubeconfig(t *testing.T) {
 	dir := t.TempDir()
 
 	assert.NoError(t, cleanKubeconfig(filepath.Join("testdata", "kubeconfig.in"), filepath.Join(dir, "kubeconfig")))
-	actual, err := ioutil.ReadFile(filepath.Join(dir, "kubeconfig"))
+	actual, err := os.ReadFile(filepath.Join(dir, "kubeconfig"))
 	assert.NoError(t, err)
-	expected, err := ioutil.ReadFile(filepath.Join("testdata", "kubeconfig.out"))
+	expected, err := os.ReadFile(filepath.Join("testdata", "kubeconfig.out"))
 	assert.NoError(t, err)
 	assert.YAMLEq(t, string(expected), string(actual))
 }
 
 func TestUpdateUserCaAndKeyToKubeconfig(t *testing.T) {
-	f, err := ioutil.TempFile("", "kubeconfig")
+	f, err := os.CreateTemp("", "kubeconfig")
 	assert.NoError(t, err, "")
 	err = updateClientCrtAndKeyToKubeconfig([]byte("dummykey"), []byte("dummycert"), filepath.Join("testdata", "kubeconfig.in"), f.Name())
 	assert.NoError(t, err)

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -698,7 +697,7 @@ func addNameServerToInstance(sshRunner *crcssh.Runner, ns string) error {
 
 func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	// Read generated public key
-	publicKey, err := ioutil.ReadFile(constants.GetPublicKeyPath())
+	publicKey, err := os.ReadFile(constants.GetPublicKeyPath())
 	if err != nil {
 		return err
 	}
@@ -891,7 +890,7 @@ func updateCockpitConsoleBearerToken(sshRunner *crcssh.Runner) error {
 	tokenPath := filepath.Join(constants.MachineInstanceDir, constants.DefaultName, "cockpit-bearer-token")
 	token := cluster.GenerateCockpitBearerToken()
 
-	if err := ioutil.WriteFile(tokenPath, []byte(token), 0600); err != nil {
+	if err := os.WriteFile(tokenPath, []byte(token), 0600); err != nil {
 		return fmt.Errorf("failed to write cockpit bearer token: %w", err)
 	}
 

--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/crc-org/crc/pkg/crc/ssh"
@@ -63,7 +63,7 @@ func addNameserverToInstance(sshRunner *ssh.Runner, nameserver NameServer) error
 
 func GetResolvValuesFromHost() (*ResolvFileValues, error) {
 	// TODO: we need to add runtime OS in case of windows.
-	out, err := ioutil.ReadFile("/etc/resolv.conf")
+	out, err := os.ReadFile("/etc/resolv.conf")
 	/*
 		if crcos.CurrentOS() == crcos.WINDOWS {
 			// TODO: we need to add logic in case of windows.

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -44,7 +43,7 @@ func readProxyCAData(proxyCAFile string) (string, error) {
 	if proxyCAFile == "" {
 		return "", nil
 	}
-	proxyCACert, err := ioutil.ReadFile(proxyCAFile)
+	proxyCACert, err := os.ReadFile(proxyCAFile)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -3,7 +3,6 @@ package preflight
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -30,7 +29,7 @@ const (
 )
 
 func checkRunningInsideWSL2() error {
-	version, err := ioutil.ReadFile("/proc/version")
+	version, err := os.ReadFile("/proc/version")
 	if err != nil {
 		return err
 	}
@@ -371,7 +370,7 @@ func fixSystemdUnit(unitName string, unitContent string, shouldBeRunning bool) e
 	unitPath := systemd.UserUnitPath(unitName)
 	if crcos.FileContentMatches(unitPath, []byte(unitContent)) != nil {
 		logging.Debugf("Creating %s", unitPath)
-		if err := ioutil.WriteFile(unitPath, []byte(unitContent), 0600); err != nil {
+		if err := os.WriteFile(unitPath, []byte(unitContent), 0600); err != nil {
 			return err
 		}
 		_ = sd.DaemonReload()
@@ -687,7 +686,7 @@ func fixLibvirtCrcNetworkActive() error {
 
 func getCPUFlags() (string, error) {
 	// Check if the cpu flags vmx or svm is present
-	out, err := ioutil.ReadFile("/proc/cpuinfo")
+	out, err := os.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		logging.Debugf("Failed to read /proc/cpuinfo: %v", err)
 		return "", fmt.Errorf("Failed to read /proc/cpuinfo")

--- a/pkg/crc/preflight/preflight_ubuntu_linux.go
+++ b/pkg/crc/preflight/preflight_ubuntu_linux.go
@@ -6,7 +6,6 @@ package preflight
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,11 +18,11 @@ var ubuntuPreflightChecks = []Check{
 	{
 		configKeySuffix:    "check-apparmor-profile-setup",
 		checkDescription:   "Checking if AppArmor is configured",
-		check:              checkAppArmorExceptionIsPresent(ioutil.ReadFile),
+		check:              checkAppArmorExceptionIsPresent(os.ReadFile),
 		fixDescription:     "Updating AppArmor configuration",
-		fix:                addAppArmorExceptionForQcowDisks(ioutil.ReadFile, crcos.WriteToFileAsRoot),
+		fix:                addAppArmorExceptionForQcowDisks(os.ReadFile, crcos.WriteToFileAsRoot),
 		cleanupDescription: "Cleaning up AppArmor configuration",
-		cleanup:            removeAppArmorExceptionForQcowDisks(ioutil.ReadFile, crcos.WriteToFileAsRoot),
+		cleanup:            removeAppArmorExceptionForQcowDisks(os.ReadFile, crcos.WriteToFileAsRoot),
 
 		labels: labels{Os: Linux, Distro: UbuntuLike},
 	},

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -131,7 +130,7 @@ func readIdentifyHash(identifyHashPath string) (uint64, error) {
 		return 0, nil
 	}
 
-	cachedHashBytes, err := ioutil.ReadFile(identifyHashPath)
+	cachedHashBytes, err := os.ReadFile(identifyHashPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return 0, nil
@@ -150,7 +149,7 @@ func writeIdentifyHash(client *Client) error {
 	hashBytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(hashBytes, client.identifyHash)
 
-	return ioutil.WriteFile(client.identifyHashPath, hashBytes, 0600)
+	return os.WriteFile(client.identifyHashPath, hashBytes, 0600)
 }
 
 func (c *Client) identifyNew() *analytics.Identify {
@@ -229,14 +228,14 @@ func getUserIdentity(telemetryFilePath string) (string, error) {
 		return "", err
 	}
 	if _, err := os.Stat(telemetryFilePath); !os.IsNotExist(err) {
-		id, err = ioutil.ReadFile(telemetryFilePath)
+		id, err = os.ReadFile(telemetryFilePath)
 		if err != nil {
 			return "", err
 		}
 	}
 	if uuid.Parse(strings.TrimSpace(string(id))) == nil {
 		id = []byte(uuid.NewRandom().String())
-		if err := ioutil.WriteFile(telemetryFilePath, id, 0600); err != nil {
+		if err := os.WriteFile(telemetryFilePath, id, 0600); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/crc/segment/segment_test.go
+++ b/pkg/crc/segment/segment_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -46,7 +46,7 @@ func mockServer() (chan []byte, *httptest.Server) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
-		bin, err := ioutil.ReadAll(r.Body)
+		bin, err := io.ReadAll(r.Body)
 		if err != nil {
 			logging.Error(err)
 			return
@@ -93,7 +93,7 @@ func TestClientUploadWithConsentAndWithSerializableError(t *testing.T) {
 	require.NoError(t, c.UploadCmd(context.Background(), "start", time.Minute, crcErr.ToSerializableError(crcErr.VMNotExist)))
 	require.NoError(t, c.Close())
 
-	uuid, err := ioutil.ReadFile(uuidFile)
+	uuid, err := os.ReadFile(uuidFile)
 	require.NoError(t, err)
 
 	select {

--- a/pkg/crc/ssh/client.go
+++ b/pkg/crc/ssh/client.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"time"
 
@@ -43,7 +43,7 @@ func clientConfig(user string, keys []string) (*ssh.ClientConfig, error) {
 	)
 
 	for _, k := range keys {
-		key, err := ioutil.ReadFile(k)
+		key, err := os.ReadFile(k)
 		if err != nil {
 			continue
 		}

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -74,7 +73,7 @@ func (runner *Runner) CopyData(data []byte, destFilename string, mode os.FileMod
 }
 
 func (runner *Runner) CopyFile(srcFilename string, destFilename string, mode os.FileMode) error {
-	data, err := ioutil.ReadFile(srcFilename)
+	data, err := os.ReadFile(srcFilename)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -3,7 +3,7 @@ package version
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -124,7 +124,7 @@ func GetCRCLatestVersionFromMirror(transport http.RoundTripper) (*CrcReleaseInfo
 		return nil, fmt.Errorf("HTTP error: %s: %d", response.Status, response.StatusCode)
 	}
 
-	releaseMetaData, err := ioutil.ReadAll(response.Body)
+	releaseMetaData, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drivers/vfkit/driver_darwin.go
+++ b/pkg/drivers/vfkit/driver_darwin.go
@@ -19,7 +19,6 @@ package vfkit
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -420,7 +419,7 @@ func (d *Driver) findVfkitProcess() (*process.Process, error) {
 }
 
 func readPidFromFile(filename string) (int, error) {
-	bs, err := ioutil.ReadFile(filename)
+	bs, err := os.ReadFile(filename)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -2,7 +2,6 @@ package extract
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,7 +106,7 @@ func checkFiles(destDir string, files fileMap) error {
 		}
 		delete(files, archivePath)
 
-		data, err := ioutil.ReadFile(path) // #nosec G304
+		data, err := os.ReadFile(path) // #nosec G304
 		if err != nil {
 			return err
 		}

--- a/pkg/libmachine/persist/filestore.go
+++ b/pkg/libmachine/persist/filestore.go
@@ -3,7 +3,6 @@ package persist
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -23,16 +22,16 @@ func NewFilestore(path string) *Filestore {
 
 func (s Filestore) saveToFile(data []byte, file string) error {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		return ioutil.WriteFile(file, data, 0600)
+		return os.WriteFile(file, data, 0600)
 	}
 
-	tmpfi, err := ioutil.TempFile(filepath.Dir(file), "config.json.tmp")
+	tmpfi, err := os.CreateTemp(filepath.Dir(file), "config.json.tmp")
 	if err != nil {
 		return err
 	}
 	defer os.Remove(tmpfi.Name())
 
-	if err = ioutil.WriteFile(tmpfi.Name(), data, 0600); err != nil {
+	if err = os.WriteFile(tmpfi.Name(), data, 0600); err != nil {
 		return err
 	}
 
@@ -101,7 +100,7 @@ func (s Filestore) Load(name string) (*host.Host, error) {
 	if _, err := os.Stat(hostPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("machine %s does not exist", name)
 	}
-	data, err := ioutil.ReadFile(filepath.Join(s.MachinesDir, name, "config.json"))
+	data, err := os.ReadFile(filepath.Join(s.MachinesDir, name, "config.json"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/libmachine/persist/filestore_test.go
+++ b/pkg/libmachine/persist/filestore_test.go
@@ -2,7 +2,7 @@ package persist
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -37,7 +37,7 @@ func TestStoreSaveOmitRawDriver(t *testing.T) {
 
 	configJSONPath := filepath.Join(store.MachinesDir, h.Name, "config.json")
 
-	configData, err := ioutil.ReadFile(configJSONPath)
+	configData, err := os.ReadFile(configJSONPath)
 	assert.NoError(t, err)
 
 	fakeHost := make(map[string]interface{})

--- a/pkg/os/copy_test.go
+++ b/pkg/os/copy_test.go
@@ -1,7 +1,6 @@
 package os
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,7 +9,7 @@ import (
 func TestCopyFile(t *testing.T) {
 	testStr := "test-machine"
 
-	srcFile, err := ioutil.TempFile("", "machine-test-")
+	srcFile, err := os.CreateTemp("", "machine-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +23,7 @@ func TestCopyFile(t *testing.T) {
 
 	srcFilePath := filepath.Join(os.TempDir(), srcFi.Name())
 
-	destFile, err := ioutil.TempFile("", "machine-copy-test-")
+	destFile, err := os.CreateTemp("", "machine-copy-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +41,7 @@ func TestCopyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := ioutil.ReadFile(destFilePath)
+	data, err := os.ReadFile(destFilePath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/os/launchd/launchd_darwin.go
+++ b/pkg/os/launchd/launchd_darwin.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	goos "os"
 	"os/exec"
 	"path/filepath"
@@ -96,7 +95,7 @@ func CreatePlist(config AgentConfig) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(getPlistPath(config.Label), plist, 0600)
+	err = goos.WriteFile(getPlistPath(config.Label), plist, 0600)
 	return err
 }
 

--- a/pkg/os/linux/release_info.go
+++ b/pkg/os/linux/release_info.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -103,7 +102,7 @@ func GetOsRelease() (*OsRelease, error) {
 	if _, err := os.Stat(releaseFile); os.IsNotExist(err) {
 		return nil, fmt.Errorf("%s doesn't exist", releaseFile)
 	}
-	content, err := ioutil.ReadFile(releaseFile)
+	content, err := os.ReadFile(releaseFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,7 +67,7 @@ func FileContentMatches(path string, expectedContent []byte) error {
 	if err != nil {
 		return fmt.Errorf("File not found: %s: %s", path, err.Error())
 	}
-	content, err := ioutil.ReadFile(filepath.Clean(path))
+	content, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return fmt.Errorf("Error opening file: %s: %s", path, err.Error())
 	}
@@ -86,7 +85,8 @@ func WriteFileIfContentChanged(path string, newContent []byte, perm os.FileMode)
 	}
 
 	/* Intentionally ignore errors, just try to write the file if we can't read it */
-	err = ioutil.WriteFile(path, newContent, perm)
+	err = os.WriteFile(path, newContent, perm)
+
 	if err != nil {
 		return false, err
 	}

--- a/pkg/os/util_windows.go
+++ b/pkg/os/util_windows.go
@@ -3,7 +3,8 @@ package os
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
+	"os"
 	"os/user"
 	"strings"
 
@@ -16,7 +17,7 @@ import (
 // file directly without this would result in malformed texts
 func ReadFileUTF16LE(filename string) ([]byte, error) {
 	// Read the file into a []byte
-	raw, err := ioutil.ReadFile(filename)
+	raw, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +29,7 @@ func ReadFileUTF16LE(filename string) ([]byte, error) {
 
 	// Make a Reader that uses utf16bom
 	unicodeReader := transform.NewReader(bytes.NewReader(raw), utf16bom)
-	decoded, err := ioutil.ReadAll(unicodeReader)
+	decoded, err := io.ReadAll(unicodeReader)
 	return decoded, err
 }
 

--- a/pkg/os/windows/powershell/powershell_windows.go
+++ b/pkg/os/windows/powershell/powershell_windows.go
@@ -2,7 +2,6 @@ package powershell
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,7 +61,7 @@ func ExecuteAsAdmin(reason, cmd string) (string, string, error) {
 	}
 	scriptContent := strings.Join(append(runAsCmds(powershell), cmd), "\n")
 
-	tempDir, err := ioutil.TempDir("", "crcScripts")
+	tempDir, err := os.MkdirTemp("", "crcScripts")
 	if err != nil {
 		return "", "", err
 	}
@@ -75,7 +74,7 @@ func ExecuteAsAdmin(reason, cmd string) (string, string, error) {
 	filename := filepath.Join(tempDir, "runAsAdmin.ps1")
 
 	// #nosec G306
-	if err := ioutil.WriteFile(filename, append([]byte{0xef, 0xbb, 0xbf}, []byte(scriptContent)...), 0666); err != nil {
+	if err := os.WriteFile(filename, append([]byte{0xef, 0xbb, 0xbf}, []byte(scriptContent)...), 0666); err != nil {
 		return "", "", err
 	}
 

--- a/test/extended/util/collect.go
+++ b/test/extended/util/collect.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -139,7 +138,7 @@ type FileCollector struct {
 }
 
 func (collector *FileCollector) Collect(w Writer) error {
-	bin, err := ioutil.ReadFile(collector.Source)
+	bin, err := os.ReadFile(collector.Source)
 	if err != nil {
 		return err
 	}

--- a/test/extended/util/e2e_logger.go
+++ b/test/extended/util/e2e_logger.go
@@ -18,7 +18,7 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -38,7 +38,7 @@ var (
 
 func init() {
 	// Make sure there is a log, even before StartLog is called
-	E2eLog = log.New(ioutil.Discard, "", 0)
+	E2eLog = log.New(io.Discard, "", 0)
 }
 
 func StartLog(logPath string) error {

--- a/test/extended/util/fileops.go
+++ b/test/extended/util/fileops.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -71,7 +70,7 @@ func FileExist(fileName string) error {
 }
 
 func GetFileContent(path string) (string, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("cannot read file: %v", err)
 	}

--- a/test/extended/util/prepare.go
+++ b/test/extended/util/prepare.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -31,7 +30,7 @@ func PrepareForE2eTest() error {
 
 	var err error
 	if TestDir == "" {
-		TestDir, err = ioutil.TempDir("", "crc-e2e-test-")
+		TestDir, err = os.MkdirTemp("", "crc-e2e-test-")
 		if err != nil {
 			return fmt.Errorf("error creating temporary directory for test run: %v", err)
 		}
@@ -92,7 +91,7 @@ func PrepareTestRunDir() error {
 }
 
 func CleanTestRunDir() error {
-	files, err := ioutil.ReadDir(TestRunDir)
+	files, err := os.ReadDir(TestRunDir)
 	if err != nil {
 		return err
 	}

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -36,7 +35,7 @@ func CopyFilesToTestDir() error {
 }
 
 func CopyResourcesFromPath(resourcesPath string) error {
-	files, err := ioutil.ReadDir(resourcesPath)
+	files, err := os.ReadDir(resourcesPath)
 	if err != nil {
 		fmt.Printf("Error occurred loading data files: %s", err)
 		return err


### PR DESCRIPTION
This is a follow-up to #3403
io/ioutil has been deprecated since go 1.16
There are replacements for the functions it provides either in io or os.