### PR TITLE
cmd/version: OpenShift version should not be preset dependent

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -79,7 +79,7 @@ func runPrerun(cmd *cobra.Command) error {
 	}
 	logging.InitLogrus(logFile)
 
-	for _, str := range defaultVersion(crcConfig.GetPreset(config)).lines() {
+	for _, str := range defaultVersion().lines() {
 		logging.Debugf(str)
 	}
 	return nil

--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -22,7 +22,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print version information",
 	Long:  "Print version information",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runPrintVersion(os.Stdout, defaultVersion(crcConfig.GetPreset(config)), outputFormat)
+		return runPrintVersion(os.Stdout, defaultVersion(), outputFormat)
 	},
 }
 
@@ -40,11 +40,11 @@ type version struct {
 	PodmanVersion    string `json:"podmanVersion"`
 }
 
-func defaultVersion(preset crcPreset.Preset) *version {
+func defaultVersion() *version {
 	return &version{
 		Version:          crcversion.GetCRCVersion(),
 		Commit:           crcversion.GetCommitSha(),
-		OpenshiftVersion: crcversion.GetBundleVersion(preset),
+		OpenshiftVersion: crcversion.GetBundleVersion(crcPreset.OpenShift),
 		PodmanVersion:    crcversion.GetBundleVersion(crcPreset.Podman),
 	}
 }

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -137,7 +137,7 @@ func (h *Handler) GetVersion(c *context) error {
 	return c.JSON(http.StatusOK, &client.VersionResult{
 		CrcVersion:       version.GetCRCVersion(),
 		CommitSha:        version.GetCommitSha(),
-		OpenshiftVersion: version.GetBundleVersion(crcConfig.GetPreset(h.Config)),
+		OpenshiftVersion: version.GetBundleVersion(preset.OpenShift),
 		PodmanVersion:    version.GetBundleVersion(preset.Podman),
 	})
 }


### PR DESCRIPTION
This fixes this:
$ crc config set preset podman
$ crc version
CRC version: 2.10.2+e04852790
OpenShift version: 4.2.0
Podman version: 4.2.0

Even taking into account OKD, an OKD version is not a valid OpenShift
version, so it's misleading to show it as such.