### PR TITLE
[e2e] Test fetching podman bundle when behind proxy

### DIFF
--- a/test/e2e/features/proxy.feature
+++ b/test/e2e/features/proxy.feature
@@ -1,14 +1,13 @@
 @proxy @linux
 Feature: Behind proxy test
 
-    User starts CRC behind a proxy. They expect a successful start
-    and to be able to deploy an app and check its accessibility.
+    Check CRC use behind proxy
 
     Background: Setup the proxy container using podman
         * executing "podman run --name squid -d -p 3128:3128 quay.io/crcont/squid" succeeds
 
     @cleanup
-    Scenario: Start CRC behind proxy
+    Scenario: Start CRC behind proxy under openshift preset
         Given executing single crc setup command succeeds
         And  executing "crc config set http-proxy http://192.168.130.1:3128" succeeds
         Then executing "crc config set https-proxy http://192.168.130.1:3128" succeeds
@@ -29,3 +28,22 @@ Feature: Behind proxy test
         And executing crc cleanup command succeeds
 
 
+    Scenario: Cache podman bundle behind proxy under podman preset
+        * executing "crc config set http-proxy http://192.168.130.1:3128" succeeds
+        * executing "crc config set https-proxy http://192.168.130.1:3128" succeeds
+        * removing podman bundle from cache succeeds
+<<<<<<< HEAD
+        Given executing "crc config set preset podman" succeeds
+        Then executing single crc setup command succeeds
+        And podman bundle is cached
+        # cleanup proxy and preset settings from config
+        * executing "crc config unset http-proxy" succeeds
+        * executing "crc config unset https-proxy" succeeds
+        * executing "crc config unset preset" succeeds
+        * executing "podman stop squid" succeeds
+        * executing "podman rm squid" succeeds
+=======
+        * executing "crc config set preset podman" succeeds
+        When executing single crc setup command succeeds
+        Then executing "crc start" succeeds
+>>>>>>> 5c6d0b94 (Trying a pure start for podman preset)

--- a/test/e2e/features/proxy.feature
+++ b/test/e2e/features/proxy.feature
@@ -3,47 +3,20 @@ Feature: Behind proxy test
 
     Check CRC use behind proxy
 
-    Background: Setup the proxy container using podman
-        * executing "podman run --name squid -d -p 3128:3128 quay.io/crcont/squid" succeeds
-
+    # inherits @proxy tag from Feature
     @cleanup
     Scenario: Start CRC behind proxy under openshift preset
         Given executing single crc setup command succeeds
-        And  executing "crc config set http-proxy http://192.168.130.1:3128" succeeds
-        Then executing "crc config set https-proxy http://192.168.130.1:3128" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "eval $(crc oc-env)" succeeds
         When checking that CRC is running
         Then login to the oc cluster succeeds
-        # Remove the proxy container and host proxy env (which set because of oc-env)
-        Given executing "podman stop squid" succeeds
-        And executing "podman rm squid" succeeds
-        And executing "unset HTTP_PROXY HTTPS_PROXY NO_PROXY" succeeds
-        # CRC delete and remove proxy settings from config
-        When executing "crc delete -f" succeeds
-        Then stdout should contain "Deleted the instance"
-        And  executing "crc config unset http-proxy" succeeds
-        And executing "crc config unset https-proxy" succeeds
-        And executing crc cleanup command succeeds
 
-
+    # inherits @proxy tag from Feature
+    @cleanup @podman-preset
     Scenario: Cache podman bundle behind proxy under podman preset
-        * executing "crc config set http-proxy http://192.168.130.1:3128" succeeds
-        * executing "crc config set https-proxy http://192.168.130.1:3128" succeeds
         * removing podman bundle from cache succeeds
-<<<<<<< HEAD
-        Given executing "crc config set preset podman" succeeds
-        Then executing single crc setup command succeeds
-        And podman bundle is cached
-        # cleanup proxy and preset settings from config
-        * executing "crc config unset http-proxy" succeeds
-        * executing "crc config unset https-proxy" succeeds
-        * executing "crc config unset preset" succeeds
-        * executing "podman stop squid" succeeds
-        * executing "podman rm squid" succeeds
-=======
         * executing "crc config set preset podman" succeeds
         When executing single crc setup command succeeds
         Then executing "crc start" succeeds
->>>>>>> 5c6d0b94 (Trying a pure start for podman preset)

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -22,7 +22,6 @@ import (
 )
 
 var (
-	CRCHome            string
 	CRCExecutable      string
 	userProvidedBundle bool
 	bundleName         string
@@ -61,7 +60,7 @@ func InitializeTestSuite(tctx *godog.TestSuiteContext) {
 		}
 
 		usr, _ := user.Current()
-		CRCHome = filepath.Join(usr.HomeDir, ".crc")
+		util.CRCHome = filepath.Join(usr.HomeDir, ".crc")
 
 		// init CRCExecutable if no location provided by user
 		if CRCExecutable == "" {
@@ -108,7 +107,7 @@ func InitializeTestSuite(tctx *godog.TestSuiteContext) {
 
 		if cleanupHome {
 			// remove $HOME/.crc
-			err = util.RemoveCRCHome(CRCHome)
+			err = util.RemoveCRCHome()
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -452,7 +451,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 
 	// CRC related steps
 	s.Step(`^removing CRC home directory succeeds$`,
-		RemoveCRCHome)
+		util.RemoveCRCHome)
 	s.Step(`^starting CRC with default bundle (succeeds|fails)$`,
 		StartCRCWithDefaultBundleSucceedsOrFails)
 	s.Step(`^starting CRC with custom bundle (succeeds|fails)$`,
@@ -538,10 +537,6 @@ func WaitForClusterInState(state string) error {
 	return crcCmd.WaitForClusterInState(state)
 }
 
-func RemoveCRCHome() error {
-	return util.RemoveCRCHome(CRCHome)
-}
-
 func CheckHTTPResponseWithRetry(retryCount int, retryWait string, address string, expectedStatusCode int) error {
 	var err error
 
@@ -610,7 +605,7 @@ func CheckCRCStatus(state string) error {
 
 func DeleteFileFromCRCHome(fileName string) error {
 
-	theFile := filepath.Join(CRCHome, fileName)
+	theFile := filepath.Join(util.CRCHome, fileName)
 
 	if _, err := os.Stat(theFile); os.IsNotExist(err) {
 		return nil
@@ -624,7 +619,7 @@ func DeleteFileFromCRCHome(fileName string) error {
 
 func FileExistsInCRCHome(fileName string) error {
 
-	theFile := filepath.Join(CRCHome, fileName)
+	theFile := filepath.Join(util.CRCHome, fileName)
 
 	_, err := os.Stat(theFile)
 	if os.IsNotExist(err) {
@@ -668,7 +663,7 @@ func ConfigFileInCRCHomeContainsKeyMatchingValue(format string, configFile strin
 	if expectedValue == "current bundle" {
 		expectedValue = fmt.Sprintf(".*%s", bundleName)
 	}
-	configPath := filepath.Join(CRCHome, configFile)
+	configPath := filepath.Join(util.CRCHome, configFile)
 
 	config, err := util.GetFileContent(configPath)
 	if err != nil {
@@ -694,7 +689,7 @@ func ConfigFileInCRCHomeContainsKeyMatchingValue(format string, configFile strin
 
 func ConfigFileInCRCHomeContainsKey(format string, configFile string, condition string, keyPath string) error {
 
-	configPath := filepath.Join(CRCHome, configFile)
+	configPath := filepath.Join(util.CRCHome, configFile)
 
 	config, err := util.GetFileContent(configPath)
 	if err != nil {
@@ -854,7 +849,7 @@ func EnsureUserIsLoggedIntoClusterSucceedsOrFails(expected string) error {
 func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expected string) error {
 	if value == "current bundle" {
 		if !userProvidedBundle {
-			value = filepath.Join(CRCHome, "cache", bundleName)
+			value = filepath.Join(util.CRCHome, "cache", bundleName)
 		} else {
 			value = bundleLocation
 		}

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -13,6 +12,10 @@ import (
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/preset"
 	"github.com/crc-org/crc/pkg/download"
+)
+
+var (
+	CRCHome string
 )
 
 func CopyFilesToTestDir() error {
@@ -127,23 +130,23 @@ func DownloadBundle(bundleLocation string, bundleDestination string, bundleName 
 	return filename, nil
 }
 
-func RemoveCRCHome(crcHome string) error {
-	keepFile := filepath.Join(crcHome, ".keep")
+func RemoveCRCHome() error {
+	keepFile := filepath.Join(CRCHome, ".keep")
 	_, err := os.Stat(keepFile)
 	if err != nil { // cannot get keepFile's status
-		err = os.RemoveAll(crcHome)
+		err = os.RemoveAll(CRCHome)
 
 		if err != nil {
-			fmt.Printf("Problem deleting CRC home folder %s.\n", crcHome)
+			fmt.Printf("Problem deleting CRC home folder %s.\n", CRCHome)
 			return err
 		}
 
-		fmt.Printf("Deleted CRC home folder %s.\n", crcHome)
+		fmt.Printf("Deleted CRC home folder %s.\n", CRCHome)
 		return nil
 
 	}
 	// keepFile exists
-	return fmt.Errorf("folder %s not removed as per request: %s present", crcHome, keepFile)
+	return fmt.Errorf("folder %s not removed as per request: %s present", CRCHome, keepFile)
 }
 
 // MatchWithRetry will execute match function with expression as arg
@@ -180,11 +183,7 @@ func MatchRepetitionsWithRetry(expression string, match func(string) error, matc
 
 // GetBundlePath returns a path to the cached bundle, depending on the preset
 func GetBundlePath(preset preset.Preset) string {
-
-	usr, _ := user.Current()
-	crcHome := filepath.Join(usr.HomeDir, ".crc")
-
 	bundle := constants.GetDefaultBundle(preset)
-	return filepath.Join(crcHome, "cache", bundle)
+	return filepath.Join(CRCHome, "cache", bundle)
 
 }

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
 
+	"github.com/crc-org/crc/pkg/crc/constants"
+	"github.com/crc-org/crc/pkg/crc/preset"
 	"github.com/crc-org/crc/pkg/download"
 )
 
@@ -173,4 +176,15 @@ func MatchRepetitionsWithRetry(expression string, match func(string) error, matc
 			}
 		}
 	}
+}
+
+// GetBundlePath returns a path to the cached bundle, depending on the preset
+func GetBundlePath(preset preset.Preset) string {
+
+	usr, _ := user.Current()
+	crcHome := filepath.Join(usr.HomeDir, ".crc")
+
+	bundle := constants.GetDefaultBundle(preset)
+	return filepath.Join(crcHome, "cache", bundle)
+
 }


### PR DESCRIPTION
**Fixes:** Issue #3354 

- Should run as part of usual e2e tests without issues. 
- 2nd commit cleans up the Feature file and moves setup/cleanup to Before/After Scenario hooks

**Note**: there is no check that proxy isn't circumvented. This will be fine if proxy will be enforced through environment setup.

