### PR TITLE
[e2e] fix SCC constraints on deployments 

### DIFF
--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -13,7 +13,7 @@ Feature: 3 Openshift stories
 		#And ensuring user is logged in succeeds
 		Given checking that CRC is running
 		Then executing "oc new-project testproj" succeeds
-		And executing "oc create deployment httpd-example --image=registry.access.redhat.com/ubi8/httpd-24 --port=8080" succeeds
+		And executing "oc apply -f httpd-example.yaml" succeeds
 		When executing "oc rollout status deployment httpd-example" succeeds
 		Then stdout should contain "successfully rolled out"
 		When executing "oc create configmap www-content --from-file=index.html=httpd-example-index.html" succeeds
@@ -38,7 +38,7 @@ Feature: 3 Openshift stories
 
 	# Old: Local image to image-registry feature
 
-	@linux
+	@linux @testdata
 	Scenario: Create local image, push to registry, deploy
 		Given checking that CRC is running
 		And executing "podman pull quay.io/centos7/httpd-24-centos7" succeeds
@@ -46,7 +46,7 @@ Feature: 3 Openshift stories
 		And executing "podman login -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-registry.apps-crc.testing --tls-verify=false" succeeds
 		And executing "podman tag quay.io/centos7/httpd-24-centos7 default-route-openshift-image-registry.apps-crc.testing/testproj-img/hello:test" succeeds
 		And executing "podman push default-route-openshift-image-registry.apps-crc.testing/testproj-img/hello:test --tls-verify=false" succeeds
-		And executing "oc new-app testproj-img/hello:test" succeeds
+		And executing "oc apply -f hello.yaml" succeeds
 		When executing "oc rollout status deployment hello" succeeds
 		Then stdout should contain "successfully rolled out"
 		And executing "oc get pods" succeeds

--- a/test/testdata/hello.yaml
+++ b/test/testdata/hello.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hello
+    app.kubernetes.io/component: hello
+    app.kubernetes.io/instance: hello
+  name: hello
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      deployment: hello
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        deployment: hello
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/testproj-img/hello:test
+        imagePullPolicy: IfNotPresent
+        name: hello
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        - containerPort: 8443
+          protocol: TCP
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        securityContext: 
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: 
+        runAsNonRoot: true
+        seccompProfile:
+          type: "RuntimeDefault"
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello
+    app.kubernetes.io/component: hello
+    app.kubernetes.io/instance: hello
+  name: hello
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: 8443-tcp
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    deployment: hello
+  sessionAffinity: None
+  type: ClusterIP
+

--- a/test/testdata/httpd-example.yaml
+++ b/test/testdata/httpd-example.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpd-example
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scc-nonroot-v2
+rules:
+- apiGroups: 
+  - security.openshift.io
+  resources: 
+  - securitycontextconstraints
+  resourceNames: 
+  - nonroot-v2
+  verbs:  
+  - use
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: httpd-example-anyuid
+subjects:
+- kind: ServiceAccount
+  name: httpd-example
+roleRef:
+  kind: Role
+  name: scc-nonroot-v2
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: httpd-example
+  name: httpd-example
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: httpd-example
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: httpd-example
+    spec:
+      containers:
+      - image: registry.access.redhat.com/ubi8/httpd-24
+        imagePullPolicy: Always
+        name: httpd-24
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        securityContext: 
+          runAsUser: 1001
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      serviceAccountName: httpd-example
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: 
+        runAsNonRoot: true
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
previously e2e samples use default templates to create deployments, now with new [SCC contraints](https://cloud.redhat.com/blog/pod-security-admission-in-openshift-4.11) there are some extra information on security context which can not be added from oc cli. To be able to add the required security context requirements this PR switches from using oc templating mechanism to fixed specs.


