### PR TITLE
update 4.11.13 bundle hash

### DIFF
--- a/pkg/crc/machine/bundle/constants.go
+++ b/pkg/crc/machine/bundle/constants.go
@@ -9,22 +9,22 @@ var bundleLocations = map[string]bundlesDownloadInfo{
 	"amd64": {
 		"darwin": {
 			preset.OpenShift: download.NewRemoteFile("https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/openshift/4.11.13/crc_vfkit_4.11.13_amd64.crcbundle",
-				"5e86e132e9a2d441dbbfa696c4f3256ade2018de66391d932f560bd5afa1415a"),
+				"bec15ed8f86bd8951940f4e23cbe918594c53accd2dd67fe45b66576bd8de98f"),
 		},
 
 		"linux": {
 			preset.OpenShift: download.NewRemoteFile("https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/openshift/4.11.13/crc_libvirt_4.11.13_amd64.crcbundle",
-				"f5e3fb8be91dff8b573edcf915d0234314199a8547316ebf1b9bd467121c88db"),
+				"a9ffe4453be67969e501b97d6c8477907deaf268a4a967045450fca5cbb26b41"),
 		},
 		"windows": {
 			preset.OpenShift: download.NewRemoteFile("https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/openshift/4.11.13/crc_hyperv_4.11.13_amd64.crcbundle",
-				"e622db3f985d42e29c1029f7f7d02997feac2a13930faa2ed6580139570f4d30"),
+				"494e770c9a6e64f54148463932dcb16392176c6fc3e625fab46be5b7bb473963"),
 		},
 	},
 	"arm64": {
 		"darwin": {
 			preset.OpenShift: download.NewRemoteFile("https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/openshift/4.11.13/crc_vfkit_4.11.13_arm64.crcbundle",
-				"86ce28ad5acf79e9eb2bd189d9059056fb1bb9689326abaf1db83aa456427e2c"),
+				"dbb6a2c8fbd09b0b26470938a15d97743a49656dfbc4919a128554ff3b06d284"),
 		},
 	},
 }


### PR DESCRIPTION
we had to regenerate 4.11.13 bundles after https://github.com/crc-org/snc/pull/605
