### PR TITLE
[e2e] e2e container fix ssh cmd for linux platform

### DIFF
--- a/images/build-e2e/entrypoint.sh
+++ b/images/build-e2e/entrypoint.sh
@@ -108,17 +108,17 @@ fi
 if [ "${CLEANUP_HOME}" = "false" ]; then
     OPTIONS+="--cleanup-home=false "
 fi
-if [ -n "${INSTALLER_PATH}" ]; then
-    OPTIONS+="--installer-path=${INSTALLER_PATH} "
+
+TAGS="@${PLATFORM}"
+if [ -n "${E2E_TAG_EXPRESSION}" ]; then
+    TAGS+=" && ${E2E_TAG_EXPRESSION}"
 fi
-if [ -n "${USER_PASSWORD}" ]; then
-    OPTIONS+="--user-password=${USER_PASSWORD} "
-fi
-OPTIONS+="--godog.tags=\"@${PLATFORM} && ${E2E_TAG_EXPRESSION}\" --godog.format=junit "
-if [[ ${PLATFORM} == 'windows' ]]; then
-    BINARY_EXEC+="cd ${EXECUTION_FOLDER}/bin && ./${BINARY} ${OPTIONS} > ${RESULTS_FILE}.results"
+if [[ ${PLATFORM} == 'darwin' ]]; then
+    OPTIONS+="--godog.tags=\\\"${TAGS}\\\" --godog.format=junit "
+    BINARY_EXEC+="sudo su - ${TARGET_HOST_USERNAME} -c \"PATH=\$PATH:/usr/local/bin && cd ${EXECUTION_FOLDER}/bin && ./${BINARY} ${OPTIONS} > ${RESULTS_FILE}.results\""
 else
-    BINARY_EXEC+="sudo su - ${TARGET_HOST_USERNAME} -c \"cd ${EXECUTION_FOLDER}/bin && ./${BINARY} ${OPTIONS} > ${RESULTS_FILE}.results\""
+    OPTIONS+="--godog.tags=\"${TAGS}\" --godog.format=junit "
+    BINARY_EXEC+="cd ${EXECUTION_FOLDER}/bin && ./${BINARY} ${OPTIONS} > ${RESULTS_FILE}.results"
 fi
 # Execute command remote
 $SSH ${REMOTE} ${BINARY_EXEC}


### PR DESCRIPTION
this is a following PR for #3347 where ssh command tried to emulate a local session with `su`, that approach is working fine on darwin platform but is not working for linux. This PR will use that approach only for darwin and leave windows and linux as they were before PR #3347


