### PR TITLE
Remove "Wildcard DNS check failed" warning when it is expected

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -469,7 +469,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 
 	// Check DNS lookup from host to VM
 	logging.Info("Check DNS query from host...")
-	if err := network.CheckCRCLocalDNSReachableFromHost(vm.bundle.GetAPIHostname(),
+	if err := dns.CheckCRCLocalDNSReachableFromHost(vm.bundle.GetAPIHostname(),
 		vm.bundle.GetAppHostname("foo"), vm.bundle.ClusterInfo.AppsDomain, instanceIP); err != nil {
 		if !client.useVSock() {
 			return nil, errors.Wrap(err, "Failed to query DNS from host")

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -49,6 +49,7 @@ func getCrcBundleInfo(preset crcPreset.Preset, bundleName, bundlePath string) (*
 		return bundleInfo, nil
 	}
 	logging.Debugf("Failed to load bundle %s: %v", bundleName, err)
+	logging.Infof("Downloading bundle: %s...", bundleName)
 	bundlePath, err = bundle.Download(preset, bundlePath)
 	if err != nil {
 		return nil, err

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -469,8 +469,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 
 	// Check DNS lookup from host to VM
 	logging.Info("Check DNS query from host...")
-	if err := dns.CheckCRCLocalDNSReachableFromHost(vm.bundle.GetAPIHostname(),
-		vm.bundle.GetAppHostname("foo"), vm.bundle.ClusterInfo.AppsDomain, instanceIP); err != nil {
+	if err := dns.CheckCRCLocalDNSReachableFromHost(vm.bundle, instanceIP); err != nil {
 		if !client.useVSock() {
 			return nil, errors.Wrap(err, "Failed to query DNS from host")
 		}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -469,7 +469,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 
 	// Check DNS lookup from host to VM
 	logging.Info("Check DNS query from host...")
-	if err := dns.CheckCRCLocalDNSReachableFromHost(vm.bundle, instanceIP); err != nil {
+	if err := dns.CheckCRCLocalDNSReachableFromHost(servicePostStartConfig); err != nil {
 		if !client.useVSock() {
 			return nil, errors.Wrap(err, "Failed to query DNS from host")
 		}

--- a/pkg/crc/network/utils.go
+++ b/pkg/crc/network/utils.go
@@ -2,11 +2,7 @@ package network
 
 import (
 	"fmt"
-	"net"
 	"net/url"
-	"runtime"
-
-	"github.com/crc-org/crc/pkg/crc/logging"
 )
 
 func URIStringForDisplay(uri string) (string, error) {
@@ -18,48 +14,4 @@ func URIStringForDisplay(uri string) (string, error) {
 		return fmt.Sprintf("%s://%s:xxx@%s", u.Scheme, u.User.Username(), u.Host), nil
 	}
 	return uri, nil
-}
-
-func matchIP(ips []net.IP, expectedIP string) bool {
-	for _, ip := range ips {
-		if ip.String() == expectedIP {
-			return true
-		}
-	}
-
-	return false
-}
-func CheckCRCLocalDNSReachableFromHost(apiHostname, appsHostname, appsDomain, expectedIP string) error {
-	ip, err := net.LookupIP(apiHostname)
-	if err != nil {
-		return err
-	}
-	logging.Debugf("%s resolved to %s", apiHostname, ip)
-	if !matchIP(ip, expectedIP) {
-		logging.Warnf("%s resolved to %s but %s was expected", apiHostname, ip, expectedIP)
-		return fmt.Errorf("Invalid IP for %s", apiHostname)
-	}
-
-	if runtime.GOOS != "darwin" {
-		/* This check will fail with !CGO_ENABLED builds on darwin as
-		 * in this case, /etc/resolver/ will not be used, so we won't
-		 * have wildcard DNS for our domains
-		 */
-		ip, err = net.LookupIP(appsHostname)
-		if err != nil {
-			// Right now admin helper fallback is not implemented on windows so
-			// this check should still return an error.
-			if runtime.GOOS == "windows" {
-				return err
-			}
-			logging.Warnf("Wildcard DNS resolution for %s does not appear to be working", appsDomain)
-			return nil
-		}
-		logging.Debugf("%s resolved to %s", appsHostname, ip)
-		if !matchIP(ip, expectedIP) {
-			logging.Warnf("%s resolved to %s but %s was expected", appsHostname, ip, expectedIP)
-			return fmt.Errorf("Invalid IP for %s", appsHostname)
-		}
-	}
-	return nil
 }

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -98,6 +98,7 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset) func() error
 		}
 
 		var err error
+		logging.Infof("Downloading bundle: %s...", bundlePath)
 		if bundlePath, err = bundle.Download(preset, bundlePath); err != nil {
 			return err
 		}

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -11,7 +11,6 @@ import (
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/errors"
 	"github.com/crc-org/crc/pkg/crc/logging"
-	"github.com/crc-org/crc/pkg/crc/machine/bundle"
 	"github.com/crc-org/crc/pkg/crc/network"
 	"github.com/crc-org/crc/pkg/crc/services"
 	"github.com/crc-org/crc/pkg/crc/systemd"
@@ -146,15 +145,16 @@ func CheckCRCPublicDNSReachable(serviceConfig services.ServicePostStartConfig) (
 	return stdout, err
 }
 
-func CheckCRCLocalDNSReachableFromHost(bundle *bundle.CrcBundleInfo, expectedIP string) error {
+func CheckCRCLocalDNSReachableFromHost(serviceConfig services.ServicePostStartConfig) error {
+	bundle := serviceConfig.BundleMetadata
 	apiHostname := bundle.GetAPIHostname()
 	ip, err := net.LookupIP(apiHostname)
 	if err != nil {
 		return err
 	}
 	logging.Debugf("%s resolved to %s", apiHostname, ip)
-	if !matchIP(ip, expectedIP) {
-		logging.Warnf("%s resolved to %s but %s was expected", apiHostname, ip, expectedIP)
+	if !matchIP(ip, serviceConfig.IP) {
+		logging.Warnf("%s resolved to %s but %s was expected", apiHostname, ip, serviceConfig.IP)
 		return fmt.Errorf("Invalid IP for %s", apiHostname)
 	}
 
@@ -175,8 +175,8 @@ func CheckCRCLocalDNSReachableFromHost(bundle *bundle.CrcBundleInfo, expectedIP 
 			return nil
 		}
 		logging.Debugf("%s resolved to %s", appsHostname, ip)
-		if !matchIP(ip, expectedIP) {
-			logging.Warnf("%s resolved to %s but %s was expected", appsHostname, ip, expectedIP)
+		if !matchIP(ip, serviceConfig.IP) {
+			logging.Warnf("%s resolved to %s but %s was expected", appsHostname, ip, serviceConfig.IP)
 			return fmt.Errorf("Invalid IP for %s", appsHostname)
 		}
 	}

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -158,6 +158,12 @@ func CheckCRCLocalDNSReachableFromHost(serviceConfig services.ServicePostStartCo
 		return fmt.Errorf("Invalid IP for %s", apiHostname)
 	}
 
+	if serviceConfig.NetworkMode == network.UserNetworkingMode {
+		// user-mode networking does not setup wildcard DNS on the host. It relies on admin-helper
+		// to create entries in /etc/hosts for routes defined in the cluster.
+		return nil
+	}
+
 	if runtime.GOOS != "darwin" {
 		/* This check will fail with !CGO_ENABLED builds on darwin as
 		 * in this case, /etc/resolver/ will not be used, so we won't

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -11,6 +11,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/errors"
 	"github.com/crc-org/crc/pkg/crc/logging"
+	"github.com/crc-org/crc/pkg/crc/machine/bundle"
 	"github.com/crc-org/crc/pkg/crc/network"
 	"github.com/crc-org/crc/pkg/crc/services"
 	"github.com/crc-org/crc/pkg/crc/systemd"
@@ -145,7 +146,8 @@ func CheckCRCPublicDNSReachable(serviceConfig services.ServicePostStartConfig) (
 	return stdout, err
 }
 
-func CheckCRCLocalDNSReachableFromHost(apiHostname, appsHostname, appsDomain, expectedIP string) error {
+func CheckCRCLocalDNSReachableFromHost(bundle *bundle.CrcBundleInfo, expectedIP string) error {
+	apiHostname := bundle.GetAPIHostname()
 	ip, err := net.LookupIP(apiHostname)
 	if err != nil {
 		return err
@@ -161,6 +163,7 @@ func CheckCRCLocalDNSReachableFromHost(apiHostname, appsHostname, appsDomain, ex
 		 * in this case, /etc/resolver/ will not be used, so we won't
 		 * have wildcard DNS for our domains
 		 */
+		appsHostname := bundle.GetAppHostname("foo")
 		ip, err = net.LookupIP(appsHostname)
 		if err != nil {
 			// Right now admin helper fallback is not implemented on windows so
@@ -168,7 +171,7 @@ func CheckCRCLocalDNSReachableFromHost(apiHostname, appsHostname, appsDomain, ex
 			if runtime.GOOS == "windows" {
 				return err
 			}
-			logging.Warnf("Wildcard DNS resolution for %s does not appear to be working", appsDomain)
+			logging.Warnf("Wildcard DNS resolution for %s does not appear to be working", bundle.ClusterInfo.AppsDomain)
 			return nil
 		}
 		logging.Debugf("%s resolved to %s", appsHostname, ip)

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -3,11 +3,14 @@ package dns
 import (
 	"context"
 	"fmt"
+	"net"
+	"runtime"
 	"time"
 
 	"github.com/crc-org/crc/pkg/crc/adminhelper"
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/errors"
+	"github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/crc/network"
 	"github.com/crc-org/crc/pkg/crc/services"
 	"github.com/crc-org/crc/pkg/crc/systemd"
@@ -140,6 +143,51 @@ func CheckCRCPublicDNSReachable(serviceConfig services.ServicePostStartConfig) (
 	}
 	stdout, _, err := serviceConfig.SSHRunner.Run("curl", curlArgs...)
 	return stdout, err
+}
+
+func CheckCRCLocalDNSReachableFromHost(apiHostname, appsHostname, appsDomain, expectedIP string) error {
+	ip, err := net.LookupIP(apiHostname)
+	if err != nil {
+		return err
+	}
+	logging.Debugf("%s resolved to %s", apiHostname, ip)
+	if !matchIP(ip, expectedIP) {
+		logging.Warnf("%s resolved to %s but %s was expected", apiHostname, ip, expectedIP)
+		return fmt.Errorf("Invalid IP for %s", apiHostname)
+	}
+
+	if runtime.GOOS != "darwin" {
+		/* This check will fail with !CGO_ENABLED builds on darwin as
+		 * in this case, /etc/resolver/ will not be used, so we won't
+		 * have wildcard DNS for our domains
+		 */
+		ip, err = net.LookupIP(appsHostname)
+		if err != nil {
+			// Right now admin helper fallback is not implemented on windows so
+			// this check should still return an error.
+			if runtime.GOOS == "windows" {
+				return err
+			}
+			logging.Warnf("Wildcard DNS resolution for %s does not appear to be working", appsDomain)
+			return nil
+		}
+		logging.Debugf("%s resolved to %s", appsHostname, ip)
+		if !matchIP(ip, expectedIP) {
+			logging.Warnf("%s resolved to %s but %s was expected", appsHostname, ip, expectedIP)
+			return fmt.Errorf("Invalid IP for %s", appsHostname)
+		}
+	}
+	return nil
+}
+
+func matchIP(ips []net.IP, expectedIP string) bool {
+	for _, ip := range ips {
+		if ip.String() == expectedIP {
+			return true
+		}
+	}
+
+	return false
 }
 
 func addOpenShiftHosts(serviceConfig services.ServicePostStartConfig) error {


### PR DESCRIPTION
Most of this PR is about moving CheckCRCLocalDNSReachableFromHost to the `dns` package and slightly simplifying its code.
This removes the "Wildcard DNS check failed" warning from user mode networking since it is expected to fail in this scenario.
This also adds a "Downloading ..." info line before starting a lengthy bundle download.