### PR TITLE
[integration] added support for running integration tests on arm64 arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,10 @@ build_e2e: $(SOURCES)
 
 .PHONY: build_integration
 build_integration: $(SOURCES)
-	GOOS=linux   go test ./test/integration/ -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/linux-amd64/integration.test
-	GOOS=windows go test -tags "$(BUILDTAGS)" --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true $(VERSION_VARIABLES)" ./test/integration/ -c -o $(BUILD_DIR)/windows-amd64/integration.test.exe
-	GOOS=darwin  go test -tags "$(BUILDTAGS)" --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true $(VERSION_VARIABLES)" ./test/integration/ -c -o $(BUILD_DIR)/macos-amd64/integration.test
+	GOARCH=amd64 GOOS=linux   go test ./test/integration/ -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/linux-amd64/integration.test
+	GOARCH=amd64 GOOS=windows go test -tags "$(BUILDTAGS)" --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true $(VERSION_VARIABLES)" ./test/integration/ -c -o $(BUILD_DIR)/windows-amd64/integration.test.exe
+	GOARCH=amd64 GOOS=darwin  go test -tags "$(BUILDTAGS)" --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true $(VERSION_VARIABLES)" ./test/integration/ -c -o $(BUILD_DIR)/macos-amd64/integration.test
+	GOARCH=arm64 GOOS=darwin  go test -tags "$(BUILDTAGS)" --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true $(VERSION_VARIABLES)" ./test/integration/ -c -o $(BUILD_DIR)/macos-arm64/integration.test
 
 #  Build the container image for e2e
 .PHONY: containerized_e2e

--- a/images/build-integration/entrypoint.sh
+++ b/images/build-integration/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 
 # Vars
+ARCH="${ARCH:-"amd64"}"
 BINARY=integration.test
 if [[ ${PLATFORM} == 'windows' ]]; then
     BINARY=integration.test.exe
 fi
-BINARY_PATH="/opt/crc/bin/${PLATFORM}-amd64/${BINARY}"
+BINARY_PATH="/opt/crc/bin/${PLATFORM}-${ARCH}/${BINARY}"
 
 # Results
 RESULTS_PATH="${RESULTS_PATH:-/output}"

--- a/images/build-integration/entrypoint.sh
+++ b/images/build-integration/entrypoint.sh
@@ -82,14 +82,18 @@ if [[ ${PLATFORM} == 'windows' ]]; then
     if [[ ! -z "${BUNDLE_LOCATION+x}" ]] && [[ -n "${BUNDLE_LOCATION}" ]]; then
         BINARY_EXEC+="\$env:BUNDLE_PATH='${BUNDLE_LOCATION}'; "
     fi
+    BINARY_EXEC+="./${BINARY} > integration.results"
 else 
     BINARY_EXEC="cd ${EXECUTION_FOLDER}/bin && "
     BINARY_EXEC+="PULL_SECRET_PATH=${EXECUTION_FOLDER}/pull-secret "
     if [[ ! -z "${BUNDLE_LOCATION+x}" ]] && [[ -n "${BUNDLE_LOCATION}" ]]; then
         BINARY_EXEC+="BUNDLE_PATH=${BUNDLE_LOCATION} "
     fi
+    BINARY_EXEC+="./${BINARY} > integration.results"
+	if  ${PLATFORM} == 'macos' ; then
+		BINARY_EXEC="sudo su - ${TARGET_HOST_USERNAME} -c \"PATH=\$PATH:/usr/local/bin && ${BINARY_EXEC} \""
+	fi
 fi
-BINARY_EXEC+="./${BINARY} > integration.results"
 # Execute command remote
 $SSH "${REMOTE}" "${BINARY_EXEC}"
 


### PR DESCRIPTION
This PR is similar to #3347 but for integration tests. It will build a specific binary for integration tests on arm64 archs and allow the container to pick the right binary for that arch based on an ENV. 

Finally the ssh command to exec remotely the integration binary also requires to emulate a local session on macos platform, to emulate this ssh command now run `su` 