### PR TITLE
Add spec and scripts for creating chocolatey package for crc

### DIFF
--- a/.github/workflows/windows-chocolatey.yml
+++ b/.github/workflows/windows-chocolatey.yml
@@ -1,0 +1,30 @@
+name: Build Windows chocolatey
+on:
+  push:
+    branches:
+      - "main"
+  pull_request: {}
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2022
+        go:
+          - 1.17
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Build the chocolatey package
+        run: make choco
+      - name: Upload nupkg artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: crc-chocolatey-nupkg
+          path: "./packaging/chocolatey/crc/*.nupkg"

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ test:
 
 GENERATED_RPM_FILES=packaging/rpm/crc.spec images/rpmbuild/Containerfile
 spec: $(GENERATED_RPM_FILES)
-	
+
 test-rpmbuild: spec
 	${CONTAINER_RUNTIME} build -t test-rpmbuild-img -f images/rpmbuild/Containerfile .
 	${CONTAINER_RUNTIME} create --name test-rpmbuild test-rpmbuild-img
@@ -142,7 +142,7 @@ build_docs:
 
 .PHONY: docs_serve
 docs_serve: build_docs
-	${CONTAINER_RUNTIME} run -it -v $(CURDIR)/docs:/docs:Z --rm -p 8088:8088/tcp $(DOCS_BUILD_CONTAINER) docs_serve 
+	${CONTAINER_RUNTIME} run -it -v $(CURDIR)/docs:/docs:Z --rm -p 8088:8088/tcp $(DOCS_BUILD_CONTAINER) docs_serve
 
 .PHONY: docs_check_links
 docs_check_links:
@@ -283,9 +283,9 @@ linux-release: clean lint linux-release-binary embed_crc_helpers gen_release_inf
 	@mkdir -p $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
 	@cp LICENSE $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
 	tar cJSf $(RELEASE_DIR)/crc-linux-amd64.tar.xz -C $(BUILD_DIR) crc-linux-$(CRC_VERSION)-amd64 --owner=0 --group=0
-	
+
 	@mv $(RELEASE_INFO) $(RELEASE_DIR)/$(RELEASE_INFO)
-	
+
 	cd $(RELEASE_DIR) && sha256sum * > sha256sum.txt
 
 .PHONY: embed_crc_helpers
@@ -383,3 +383,14 @@ $(BUILD_DIR)/windows-amd64/crc-windows-installer.zip: $(BUILD_DIR)/windows-amd64
 	rm -f $(HOST_BUILD_DIR)/split
 	pwsh -NoProfile -Command "cd $(HOST_BUILD_DIR); Compress-Archive -Path $(CABS_MSI) -DestinationPath crc-windows-installer.zip"
 	cd $(@D) && sha256sum $(@F)>$(@F).sha256sum
+
+.PHONY: choco choco-clean
+CHOCO_PKG_DIR = packaging/chocolatey/crc
+choco: clean choco-clean $(BUILD_DIR)/windows-amd64/crc.exe $(HOST_BUILD_DIR)/crc-embedder $(CHOCO_PKG_DIR)/crc.nuspec
+	$(HOST_BUILD_DIR)/crc-embedder download --goos=windows --components=admin-helper $(CHOCO_PKG_DIR)/tools
+	cp $(BUILD_DIR)/windows-amd64/crc.exe $(CHOCO_PKG_DIR)/tools/crc.exe
+	cp LICENSE $(CHOCO_PKG_DIR)/tools/LICENSE.txt
+	cd $(CHOCO_PKG_DIR) && choco pack
+choco-clean:
+	rm -f $(CHOCO_PKG_DIR)/*.nupkg
+	rm -f $(CHOCO_PKG_DIR)/tools/*.exe

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -9,3 +9,7 @@
 /darwin/*.pkg
 /windows/msi/
 /windows/product.wxs
+/chocolatey/crc/*.nupkg
+/chocolatey/crc/crc.nuspec
+/chocolatey/crc/tools/*.exe
+/chocolatey/crc/tools/LICENSE.txt

--- a/packaging/chocolatey/crc/README.md
+++ b/packaging/chocolatey/crc/README.md
@@ -1,0 +1,51 @@
+﻿# Chocolatey package for CRC (non GUI)
+
+## Pre-requisite
+
+The host machine needs to have [Chocolatey](https://chocolatey.org/) installed and should be able to build `crc`. Follow [chocolatey install guide](https://chocolatey.org/install) to install it.
+
+## Steps to build the package
+
+Build steps for the chocolatey package is incorporated in the `Makefile` under the `choco` target.
+
+1. Run `make choco`:
+```
+PS> make choco
+rm -rf /cygdrive/c/Users/anath/redhat/crc/docs/build
+rm -f packaging/darwin/Distribution
+rm -f packaging/darwin/Resources/welcome.html
+rm -f packaging/darwin/scripts/postinstall
+rm -rf packaging/darwin/root/
+rm -rf packaging/windows/msi
+rm -f out/windows-amd64/split
+rm -f packaging/rpm/crc.spec images/rpmbuild/Containerfile
+rm -rf out
+rm -f C:\Users\anath\go/bin/crc
+rm -rf release
+GOARCH=amd64 GOOS=windows go build -tags "containers_image_openpgp" -ldflags="-X github.com/crc-org/crc/pkg/crc/version.crcVersion=2.12.0 -X github.com/crc-org/crc/pkg/crc/version.ocpVersion=4.11.18 -X github.com/crc-org/crc/pkg/crc/version.okdVersion=4.11.0-0.okd-2022-11-05-030711 -X github.com/crc-org/crc/pkg/crc/version.podmanVersion=4.2.0 -X github.com/crc-org/crc/pkg/crc/version.commitSha=40b730ce " -o out/windows-amd64/crc.exe  ./cmd/crc
+go build --tags="build" -ldflags="-X github.com/crc-org/crc/pkg/crc/version.crcVersion=2.12.0 -X github.com/crc-org/crc/pkg/crc/version.ocpVersion=4.11.18 -X github.com/crc-org/crc/pkg/crc/version.okdVersion=4.11.0-0.okd-2022-11-05-030711 -X github.com/crc-org/crc/pkg/crc/version.podmanVersion=4.2.0 -X github.com/crc-org/crc/pkg/crc/version.commitSha=40b730ce " -o out/windows-amd64/crc-embedder  ./cmd/crc-embedder
+out/windows-amd64/crc-embedder download --goos=windows packaging/chocolatey/crc/tools
+0 B / 97.26 MiB [______________________________________________________________________________________________________________________________________________________________________________________] 0.00% ? p/s
+cp out/windows-amd64/crc.exe packaging/chocolatey/crc/tools/crc.exe
+cd packaging/chocolatey/crc && choco pack
+Chocolatey v1.2.0
+Attempting to build package from 'crc.nuspec'.
+Successfully created package 'C:\Users\anath\redhat\crc\packaging\chocolatey\crc\crc.2.12.0.nupkg'
+```
+
+2. Above command will generated `crc.nupkg` in the `packaging/chocolatey/crc` folder
+
+## Steps to push the package to chocolatey community repo
+
+1. Create [account](https://community.chocolatey.org/account/Register) in the chocolatey community feed.
+3. Copy the API Key from the [accounts page](https://community.chocolatey.org/account) (Click on the Show API Key button).
+4. Associate your API key with community feed:
+```
+PS> choco apikey --key <account_api_key> --source https://push.chocolatey.org/
+```
+5. Push the package using:
+```
+PS> choco push crc.2.11.0.nupkg --source https://push.chocolatey.org/
+```
+
+> Note: Chocolatey has a moderation process and there might be a need to answer queries from the moderators, keep an eye on the [package queue](https://community.chocolatey.org/packages).

--- a/packaging/chocolatey/crc/crc.nuspec.in
+++ b/packaging/chocolatey/crc/crc.nuspec.in
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>crc</id>
+    <version>__VERSION__</version>
+    <owners>https://github.com/crc-org</owners>
+    <title>CRC - Runs Containers</title>
+    <authors>anjannath</authors>
+    <projectUrl>https://crc.dev/blog/about</projectUrl>
+    <iconUrl>https://i.ibb.co/m0b6dsL/crc-upstream-logo.png</iconUrl>
+    <licenseUrl>https://github.com/crc-org/crc/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>crc ocp openshift openshiftlocal okd podman</tags>
+    <summary>CRC is a tool to run containers. It manages a local OpenShift 4.x cluster, OKD cluster or a Podman VM optimized for testing and development purposes.</summary>
+    <description>
+## CRC - Runs Containers
+
+CRC is a tool to run containers. It manages a local OpenShift 4.x cluster, OKD cluster or a Podman VM optimized for testing and development purposes.
+Learn more and contribute on [GitHub](https://github.com/crc-org/crc).
+    </description>
+    <releaseNotes>https://github.com/crc-org/crc/releases/tag/v__VERSION__</releaseNotes>
+    <copyright>2022 Red Hat, Inc</copyright>
+    <packageSourceUrl>https://github.com/crc-org/crc/tree/main/packaging/chocolatey</packageSourceUrl>
+    <projectSourceUrl>https://github.com/crc-org/crc</projectSourceUrl>
+    <docsUrl>https://crc.dev/crc</docsUrl>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/crc/tools/VERIFICATION.txt
+++ b/packaging/chocolatey/crc/tools/VERIFICATION.txt
@@ -1,0 +1,6 @@
+﻿VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+This package is published by the CRC project itself.

--- a/packaging/chocolatey/crc/tools/chocolateybeforemodify.ps1
+++ b/packaging/chocolatey/crc/tools/chocolateybeforemodify.ps1
@@ -1,0 +1,18 @@
+﻿# This runs in 0.9.10+ before upgrade and uninstall.
+# Use this file to do things like stop services prior to upgrade or uninstall.
+# NOTE: It is an anti-pattern to call chocolateyUninstall.ps1 from here. If you
+#  need to uninstall an MSI prior to upgrade, put the functionality in this
+#  file without calling the uninstall script. Make it idempotent in the
+#  uninstall script so that it doesn't fail when it is already uninstalled.
+# NOTE: For upgrades - like the uninstall script, this script always runs from
+#  the currently installed version, not from the new upgraded package version.
+
+$ErrorActionPreference = 'SilentlyContinue';
+
+# stop crc-admin-helper service and remove it
+Stop-Service -Name 'crcAdminHelper' -Force -Confirm:$false | Out-Null
+sc.exe delete "crcAdminHelper" | Out-Null
+
+# stop crc daemon scheduled task and remove it
+Stop-ScheduledTask -TaskName 'crcDaemon' | Out-Null
+Unregister-ScheduledTask -TaskName 'crcDaemon' -Confirm:$false | Out-Null

--- a/packaging/chocolatey/crc/tools/chocolateyinstall.ps1
+++ b/packaging/chocolatey/crc/tools/chocolateyinstall.ps1
@@ -1,0 +1,18 @@
+﻿$ErrorActionPreference = 'Stop'; # stop on all errors
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$setupScript = Join-Path "$toolsDir" "crcprerequisitesetup.ps1"
+
+Import-Module $setupScript
+
+# generate ignore file for crc-admin-helper-windows.exe to avoid shim generation and addintion to PATH
+New-Item "$toolsDir\crc-admin-helper-windows.exe.ignore" -ItemType File -Force | Out-Null
+
+if (Test-ProcessAdminRights) {
+    New-CrcGroup
+    Install-Hyperv
+    Install-AdminHelper -AdminHelperPath "$toolsDir\crc-admin-helper-windows.exe"
+    New-VsockGuestCommunicationRegistry
+} else {
+    Write-Host "CRC needs administrator privileges to enable Hyper-V, create new group and add current user to needed groups, please run the installation as administrator"
+    Exit 1
+}

--- a/packaging/chocolatey/crc/tools/chocolateyuninstall.ps1
+++ b/packaging/chocolatey/crc/tools/chocolateyuninstall.ps1
@@ -1,0 +1,8 @@
+﻿$ErrorActionPreference = 'SilentlyContinue';
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$setupScript = Join-Path "$toolsDir" "crcprerequisitesetup.ps1"
+
+Import-Module $setupScript
+
+# remove crc-users group
+Remove-LocalGroup -Name 'crc-users' -Confirm:$false | Out-Null

--- a/packaging/chocolatey/crc/tools/crcprerequisitesetup.ps1
+++ b/packaging/chocolatey/crc/tools/crcprerequisitesetup.ps1
@@ -1,0 +1,66 @@
+$CrcGroupName = 'crc-users'
+$CrcAdminHelperServiceName = 'crcAdminHelper'
+$VsockGuestCommunicationRegistryPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Virtualization\GuestCommunicationServices\00000400-FACB-11E6-BD58-64006A7986D3"
+
+function New-CrcGroup {
+    $crcgrp = Get-LocalGroup -Name $CrcGroupName -ErrorAction SilentlyContinue
+    if ($crcgrp) {
+        Write-Host "crc-users group already exists"
+    } else {
+        New-LocalGroup -Name $CrcGroupName -Description 'Group for Red Hat OpenShift Local users' | Out-Null
+    }
+}
+
+function Install-Hyperv {
+    $osProductType = Get-ComputerInfo | Select-Object -ExpandProperty OSProductType | Out-String -Stream | Where-Object { $_.Trim().Length -gt 0 }
+    switch ($osProductType)
+    {
+        "WorkStation" {
+            # check if hyperv is already enabled
+            $enabled = (Get-WindowsOptionalFeature -FeatureName "Microsoft-Hyper-V" -online | Select-Object -ExpandProperty State).ToString().Equals("Enabled")
+            if ($enabled) {
+                Write-Host "Hyper-V is already enabled"
+            } else {
+                Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart -ErrorAction SilentlyContinue | Out-Null
+            }
+        }
+        "Server" {
+            $enabled = (Get-WindowsFeature -Name "Hyper-V" | Select-Object -ExpandProperty InstallState).ToString().Equals("Installed")
+            if ($enabled) {
+                Write-Host "Hyper-V is already enabled"
+            } else {
+                Install-WindowsFeature -Name Hyper-V -IncludeManagementTools -ErrorAction SilentlyContinue | Out-Null
+            }
+        }
+    }
+}
+
+function Install-AdminHelper([string]$AdminHelperPath) {
+    $svc = Get-Service -Name "$CrcAdminHelperServiceName" -ErrorAction SilentlyContinue
+    if ($svc) {
+        Write-Host "Red Hat OpenShift Local Admin Helper service is already installed"
+    } else {
+        # New-Service cmdlet doesn't have a flag to set the arguments for admin-helper, it is passed using the -BinaryPathName itself
+        New-Service -Name 'crcAdminHelper' -DisplayName "Red Hat OpenShift Local Admin Helper" -Description "Perform administrative tasks for the user" -StartupType Automatic -BinaryPathName "$AdminHelperPath daemon" | Out-Null
+    }
+
+    Start-Service -Name 'crcAdminHelper' -Confirm:$false | Out-Null
+}
+
+function New-VsockGuestCommunicationRegistry {
+    # check if the registry path exists
+    $pathExists = Test-Path -Path $VsockGuestCommunicationRegistryPath -ErrorAction SilentlyContinue
+    # check if the property 'ElementName' exists at the path
+    $property = Get-ItemProperty -Path $VsockGuestCommunicationRegistryPath -Name 'ElementName' -ErrorAction SilentlyContinue
+    $propertyExists = $property.ElementName -eq "gvisor-tap-vsock"
+    if ($pathExists -and $propertyExists) {
+        Write-Host "Property ElementName in $VsockGuestCommunicationRegistryPath already exists"
+    } else {
+        # create the registry node
+        New-Item -Path $VsockGuestCommunicationRegistryPath -ErrorAction SilentlyContinue | Out-Null
+        # remove any pre-existing value
+        Remove-ItemProperty -Path $VsockGuestCommunicationRegistryPath -Name 'ElementName' -ErrorAction SilentlyContinue | Out-Null
+        # add the 'ElementName' property
+        New-ItemProperty -Path $VsockGuestCommunicationRegistryPath -Name 'ElementName' -Value 'gvisor-tap-vsock' -PropertyType string -Confirm:$false | Out-Null
+    }
+}

--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -119,14 +119,7 @@ func checkIfUserPartOfHyperVAdmins() error {
 }
 
 func fixUserPartOfHyperVAdmins() error {
-	outGroupName, _, err := powershell.Execute(`(New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-578")).Translate([System.Security.Principal.NTAccount]).Value`)
-	if err != nil {
-		logging.Debug(err.Error())
-		return fmt.Errorf("Unable to get group name")
-	}
-	groupName := strings.TrimSpace(strings.ReplaceAll(strings.TrimSpace(outGroupName), "BUILTIN\\", ""))
-
-	_, _, err = powershell.ExecuteAsAdmin("adding current user to Hyper-V administrator group", fmt.Sprintf("Add-LocalGroupMember -Group '%s' -Member '%s'", groupName, username()))
+	_, _, err := powershell.ExecuteAsAdmin("adding current user to Hyper-V administrator group", fmt.Sprintf("Add-LocalGroupMember -SID 'S-1-5-32-578' -Member '%s'", username()))
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -126,6 +126,19 @@ func fixUserPartOfHyperVAdmins() error {
 	return errReboot
 }
 
+func checkUserPartOfCrcUsers() error {
+	_, _, err := powershell.Execute(fmt.Sprintf("Get-LocalGroupMember -Group 'crc-users' -Member '%s'", username()))
+	return err
+}
+
+func fixUserPartOfCrcUsers() error {
+	_, _, err := powershell.ExecuteAsAdmin("adding current user to crc-users group", fmt.Sprintf("Add-LocalGroupMember -Group 'crc-users' -Member '%s'", username()))
+	if err != nil {
+		return err
+	}
+	return errReboot
+}
+
 func checkIfHyperVVirtualSwitchExists() error {
 	switchName := hyperv.AlternativeNetwork
 

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -147,6 +147,16 @@ var adminHelperServiceCheks = []Check{
 	},
 }
 
+var userPartOfCrcUsersGroupCheck = Check{
+	configKeySuffix:  "check-user-in-crc-users-group",
+	checkDescription: "Checking if current user is in crc-users group",
+	check:            checkUserPartOfCrcUsers,
+	fixDescription:   "Adding logon user to crc-users group",
+	fix:              fixUserPartOfCrcUsers,
+
+	labels: labels{Os: Windows},
+}
+
 var errReboot = errors.New("Please reboot your system and run 'crc setup' to complete the setup process")
 
 func username() string {
@@ -189,6 +199,7 @@ func getAllPreflightChecks() []Check {
 func getChecks(bundlePath string, preset crcpreset.Preset) []Check {
 	checks := []Check{}
 	checks = append(checks, hypervPreflightChecks...)
+	checks = append(checks, userPartOfCrcUsersGroupCheck)
 	checks = append(checks, vsockChecks...)
 	checks = append(checks, bundleCheck(bundlePath, preset))
 	checks = append(checks, genericCleanupChecks...)

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -13,13 +13,13 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage(), config.NewEmptyInMemorySecretStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 13)
+	assert.Len(t, cfg.AllConfigs(), 12)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 19)
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 19)
+	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 18)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 18)
 
-	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 18)
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 18)
+	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 17)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 17)
 }

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -13,13 +13,13 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage(), config.NewEmptyInMemorySecretStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 12)
+	assert.Len(t, cfg.AllConfigs(), 13)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 18)
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 18)
+	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 19)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 19)
 
-	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 17)
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 17)
+	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 18)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 18)
 }


### PR DESCRIPTION
the package currently performs the setup steps like installing hyper-v creation of 'crc-users' group, adding current user to this group and the hyper-v administrators group. It doesn't install or setup the tray

it is a portable choco package and embedds the crc and crc-admin-helper-windows binaries

## How to test

Look at the contained README file for instructions on how to create the choco package: https://github.com/crc-org/crc/pull/3444/files#diff-34a4d7b03e9cd0af82b8172946c44f002f78f40e35bda3843d819cdbc64a8167

### To only test the installation of the chocolatey package use the following commands:
```posh
# install CRC from the temporary test feed
PS> choco install crc --version 2.12.0 --source https://www.myget.org/F/anjan-choco-test/api/v2 
PS> crc setup
PS> shutdown -r -t 00
PS> crc setup
PS> crc start # should successfully start the cluster
```