### PR TITLE
Add user provided timeouts for slow systems

### DIFF
--- a/pkg/crc/cluster/status.go
+++ b/pkg/crc/cluster/status.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/crc/network"
+	crcos "github.com/crc-org/crc/pkg/os"
 )
 
 // WaitForClusterStable checks that the cluster is running a number of consecutive times
@@ -17,7 +18,7 @@ func WaitForClusterStable(ctx context.Context, ip string, kubeconfigFilePath str
 
 	startTime := time.Now()
 
-	retryDuration := 30 * time.Second
+	retryDuration := crcos.GetTimeOutEnvOrDefValue("CRC_CLUSTER_STABLE_DURATION", 30*time.Second)
 	retryCount := 20 // 10 minutes
 
 	if proxy.IsEnabled() {

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -2,6 +2,7 @@ package oc
 
 import (
 	"path/filepath"
+	"time"
 
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/ssh"
@@ -9,8 +10,8 @@ import (
 )
 
 const (
-	defaultTimeout = "30s"
-	fastTimeout    = "5s"
+	defaultTimeout = 30 * time.Second
+	fastTimeout    = 5 * time.Second
 )
 
 type Config struct {
@@ -19,7 +20,7 @@ type Config struct {
 	KubeconfigPath   string
 	Context          string
 	Cluster          string
-	Timeout          string
+	Timeout          time.Duration
 }
 
 // UseOcWithConfig return the oc executable along with valid kubeconfig
@@ -57,10 +58,10 @@ func (oc Config) runCommand(isPrivate bool, args ...string) (string, string, err
 	}
 
 	if isPrivate {
-		return oc.Runner.RunPrivate("timeout", append([]string{oc.Timeout, oc.OcExecutablePath}, args...)...)
+		return oc.Runner.RunPrivate("timeout", append([]string{oc.Timeout.String(), oc.OcExecutablePath}, args...)...)
 	}
 
-	return oc.Runner.Run("timeout", append([]string{oc.Timeout, oc.OcExecutablePath}, args...)...)
+	return oc.Runner.Run("timeout", append([]string{oc.Timeout.String(), oc.OcExecutablePath}, args...)...)
 }
 
 func (oc Config) RunOcCommand(args ...string) (string, string, error) {

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -31,7 +31,7 @@ func UseOCWithConfig(machineName string) Config {
 		KubeconfigPath:   filepath.Join(constants.MachineInstanceDir, machineName, "kubeconfig"),
 		Context:          constants.DefaultContext,
 		Cluster:          constants.DefaultName,
-		Timeout:          defaultTimeout,
+		Timeout:          crcos.GetTimeOutEnvOrDefValue("CRC_OC_TIMEOUT", defaultTimeout),
 	}
 }
 
@@ -42,7 +42,7 @@ func (oc Config) WithFailFast() Config {
 		KubeconfigPath:   oc.KubeconfigPath,
 		Context:          oc.Context,
 		Cluster:          oc.Cluster,
-		Timeout:          fastTimeout,
+		Timeout:          crcos.GetTimeOutEnvOrDefValue("CRC_OC_TIMEOUT", fastTimeout),
 	}
 }
 
@@ -83,6 +83,6 @@ func UseOCWithSSH(sshRunner *ssh.Runner) Config {
 		KubeconfigPath:   "/opt/kubeconfig",
 		Context:          constants.DefaultContext,
 		Cluster:          constants.DefaultName,
-		Timeout:          defaultTimeout,
+		Timeout:          crcos.GetTimeOutEnvOrDefValue("CRC_OC_TIMEOUT", defaultTimeout),
 	}
 }

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -11,6 +11,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/errors"
 	"github.com/crc-org/crc/pkg/crc/logging"
+	crcos "github.com/crc-org/crc/pkg/os"
 )
 
 type Runner struct {
@@ -108,6 +109,7 @@ err     : %w`+"\n", command, err)
 }
 
 func (runner *Runner) WaitForConnectivity(ctx context.Context, timeout time.Duration) error {
+	timeout = crcos.GetTimeOutEnvOrDefValue("CRC_SSH_TIMEOUT", timeout)
 	checkSSHConnectivity := func() error {
 		_, _, err := runner.Run("exit 0")
 		if err != nil {

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/crc-org/crc/pkg/crc/logging"
 
@@ -118,4 +119,15 @@ func RunningInTerminal() bool {
 
 func RunningUsingSSH() bool {
 	return os.Getenv("SSH_TTY") != ""
+}
+
+func GetTimeOutEnvOrDefValue(env string, defValue time.Duration) time.Duration {
+	usrDefinedValue, err := time.ParseDuration(os.Getenv(env))
+	if err != nil {
+		return defValue
+	}
+	if usrDefinedValue != 0 {
+		return usrDefinedValue
+	}
+	return defValue
 }

--- a/pkg/os/util_test.go
+++ b/pkg/os/util_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -93,4 +94,23 @@ func TestFileExists(t *testing.T) {
 
 	filename = filepath.Join(dirname, "nonexistent")
 	assert.False(t, FileExists(filename))
+}
+
+func TestGetTimeOutEnvOrDefValue(t *testing.T) {
+	// In case there is no env set
+	dummyTimeout := 10 * time.Second
+	gotTimeout := GetTimeOutEnvOrDefValue("CRC_DUMMY_TIME", dummyTimeout)
+	assert.Equal(t, dummyTimeout, gotTimeout)
+
+	// In case user provided the timeout value from env
+	os.Setenv("CRC_DUMMY_TIME", "40s")
+	defer os.Unsetenv("CRC_DUMMY_TIME")
+
+	gotTimeout = GetTimeOutEnvOrDefValue("CRC_DUMMY_TIME", dummyTimeout)
+	assert.Equal(t, 40*time.Second, gotTimeout)
+
+	// In case user provided wrong formatted timeout value from env
+	os.Setenv("CRC_DUMMY_TIME", "40")
+	gotTimeout = GetTimeOutEnvOrDefValue("CRC_DUMMY_TIME", dummyTimeout)
+	assert.NotEqual(t, 40*time.Second, gotTimeout)
 }


### PR DESCRIPTION
## Solution/Idea

Enable a way for user to provide different timeouts in case system is slow and crc takes more time than default.

## Proposed changes

Introduced following env variables
- CRC_OC_TIMEOUT
- CRC_SSH_TIMEOUT
- CRC_CLUSTER_STABLE_DURATION

## Testing

To increase `CRC_OC_TIMEOUT` use following 
```
$ CRC_OC_TIMEOUT=40s crc start
```