### PR TITLE
Replace yum with dnf for package installation

### DIFF
--- a/docs/source/topics/ref_required-software-packages.adoc
+++ b/docs/source/topics/ref_required-software-packages.adoc
@@ -8,7 +8,6 @@ Consult the following table to find the command used to install these packages f
 [options="header"]
 |====
 |Linux Distribution|Installation command
-|{fed}|`sudo dnf install NetworkManager`
-|{rhel}/{centos}|`su -c 'yum install NetworkManager'`
+|{fed}/{rhel}/{centos}|`sudo dnf install NetworkManager`
 |{debian}/{ubuntu}|`sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system network-manager`
 |====

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -159,15 +159,15 @@ func fixLibvirtInstalled(distro *linux.OsRelease) func() error {
 }
 
 func installLibvirtCommand(distro *linux.OsRelease) string {
-	yumCommand := "yum install -y libvirt libvirt-daemon-kvm qemu-kvm"
+	dnfCommand := "dnf install -y libvirt libvirt-daemon-kvm qemu-kvm"
 	switch {
 	case distroIsLike(distro, linux.Ubuntu):
 		return "apt-get update && apt-get install -y libvirt-daemon libvirt-daemon-system libvirt-clients"
 	case distroIsLike(distro, linux.Fedora):
-		return yumCommand
+		return dnfCommand
 	default:
-		logging.Warnf("unsupported distribution %s, trying to install libvirt with yum", distro)
-		return yumCommand
+		logging.Warnf("unsupported distribution %s, trying to install libvirt with dnf", distro)
+		return dnfCommand
 	}
 }
 


### PR DESCRIPTION
Since we now only support latest 2 releases of RHEL/Centos/Fedora and all distro now have dnf as default installed. We only needed yum for RHEL-7 which is now not supported as per our support matrics.


**Fixes:** Issue #3452 
