### PR TITLE
[e2e] added repetitions to ensure the state of the cluster

### DIFF
--- a/test/extended/crc/cmd/cmd.go
+++ b/test/extended/crc/cmd/cmd.go
@@ -12,8 +12,10 @@ import (
 
 const (
 	// timeout to wait for cluster to change its state
-	clusterStateRetryCount    = 15
-	clusterStateTimeout       = 600
+	clusterStateRetryCount = 25
+	clusterStateTimeout    = 600
+	// defines the number of times the state should be matches in a row
+	clusterStateRepetition    = 3
 	CRCExecutableInstalled    = "installed"
 	CRCExecutableNotInstalled = "notInstalled"
 )
@@ -119,7 +121,7 @@ func UnsetConfigPropertySucceedsOrFails(property string, expected string) error 
 }
 
 func WaitForClusterInState(state string) error {
-	return util.MatchWithRetry(state, CheckCRCStatus,
+	return util.MatchRepetitionsWithRetry(state, CheckCRCStatus, clusterStateRepetition,
 		clusterStateRetryCount, clusterStateTimeout)
 }
 


### PR DESCRIPTION
During e2e executions eventually we see executions when the cluster state is showing running and then is degraded right away, if the subsequent steps on an scneario depends on that state we need to ensure the stability of the cluster. This PR introduces a new param `repetitions` to define the number of times that the state of the cluster should keep stable for a period of time 