### PR TITLE
[test] Issue #3458 Remove keyring accessible check from secret config store

### DIFF
--- a/pkg/crc/config/secret_config.go
+++ b/pkg/crc/config/secret_config.go
@@ -20,32 +20,25 @@ func (s Secret) String() string {
 }
 
 type SecretStorage struct {
-	secretService   string
-	storeAccessible bool
+	secretService string
 }
 
 func NewSecretStorage() *SecretStorage {
 	return &SecretStorage{
-		secretService:   secretServiceName,
-		storeAccessible: keyringAccessible(),
+		secretService: secretServiceName,
 	}
 }
 
 func (c *SecretStorage) Get(key string) interface{} {
-	if !c.storeAccessible {
-		return nil
-	}
 	secret, err := keyring.Get(c.secretService, key)
-	if errors.Is(err, keyring.ErrNotFound) {
+	if err != nil || errors.Is(err, keyring.ErrNotFound) {
+		logging.Debugf("error while getting config from secret store: %v", err)
 		return nil
 	}
 	return secret
 }
 
 func (c *SecretStorage) Set(key string, value interface{}) error {
-	if !c.storeAccessible {
-		return ErrSecretsNotAccessible
-	}
 	secret, err := cast.ToStringE(value)
 	if err != nil {
 		return fmt.Errorf("Failed to cast secret value to string: %w", err)
@@ -54,30 +47,17 @@ func (c *SecretStorage) Set(key string, value interface{}) error {
 }
 
 func (c *SecretStorage) Unset(key string) error {
-	if !c.storeAccessible {
-		return ErrSecretsNotAccessible
-	}
 	err := keyring.Delete(c.secretService, key)
-	if errors.Is(err, keyring.ErrNotFound) {
+	if err != nil || errors.Is(err, keyring.ErrNotFound) {
+		logging.Debugf("error while getting config from secret store: %v", err)
 		return nil
 	}
 	return err
 }
 
-func keyringAccessible() bool {
-	err := keyring.Set("crc-test", "foo", "bar")
-	if err == nil {
-		_ = keyring.Delete("crc-test", "foo")
-		return true
-	}
-	logging.Debugf("Keyring is not accessible: %v", err)
-	return false
-}
-
 func NewEmptyInMemorySecretStorage() *SecretStorage {
 	keyring.MockInit()
 	return &SecretStorage{
-		secretService:   secretServiceName,
-		storeAccessible: true,
+		secretService: secretServiceName,
 	}
 }

--- a/pkg/crc/config/secret_config.go
+++ b/pkg/crc/config/secret_config.go
@@ -56,7 +56,7 @@ func (c *SecretStorage) Unset(key string) error {
 }
 
 func NewEmptyInMemorySecretStorage() *SecretStorage {
-	keyring.MockInit()
+	// keyring.MockInit()
 	return &SecretStorage{
 		secretService: secretServiceName,
 	}


### PR DESCRIPTION
this check prevents the daemon from running on macOS when the Login keychain is locked the user gets a pop-up to unlock the keychain, if that is not done on time the launchd daemon service is not started by `crc setup` command
