### PR TITLE
Adding OKD to the presets-related documentation

### DIFF
--- a/docs/source/meta/product-attributes.adoc
+++ b/docs/source/meta/product-attributes.adoc
@@ -20,6 +20,7 @@
 :ubuntu: Ubuntu
 :openshift: OpenShift
 :ocp: {openshift} Container Platform
+:okd: OKD
 
 // Product naming
 :prod: CRC

--- a/docs/source/topics/con_about-presets.adoc
+++ b/docs/source/topics/con_about-presets.adoc
@@ -3,7 +3,7 @@
 
 [role="_abstract"]
 {prod} presets represent a managed container runtime and the lower bounds of system resources required by the instance to run it.
-{prod} offers presets for {ocp} and the Podman container runtime.
+{prod} offers presets for {ocp}, {okd} and the Podman container runtime.
 
 On {msw} and {mac}, the {prod} guided installer prompts you for your desired preset.
 On Linux, the {ocp} preset is selected by default.

--- a/docs/source/topics/proc_changing-the-selected-preset.adoc
+++ b/docs/source/topics/proc_changing-the-selected-preset.adoc
@@ -23,7 +23,7 @@ To enable preset changes, you must delete the existing instance and start a new 
 $ {bin} config set preset __<name>__
 ----
 +
-Valid preset names are `openshift` for {ocp} and `podman` for the Podman container runtime.
+Valid preset names are `openshift` for {ocp}, `okd` for {okd} and `podman` for the Podman container runtime.
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
This PR adds `okd` as a possible preset in the documentation to make the users aware that they can choose it for their `crc` deployment.