### PR TITLE
Add flag `--components` to `crc-embedder` tool

### DIFF
--- a/cmd/crc-embedder/cmd/download.go
+++ b/cmd/crc-embedder/cmd/download.go
@@ -1,13 +1,16 @@
 package cmd
 
 import (
+	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	downloadCmd.Flags().StringVar(&goos, "goos", runtime.GOOS, "Target platform (darwin, linux or windows)")
+	downloadCmd.Flags().StringSliceVar(&components, "components", []string{}, fmt.Sprintf("List of component(s) to download (%s)", strings.Join(getAllComponentNames(goos), ", ")))
 	rootCmd.AddCommand(downloadCmd)
 }
 
@@ -21,6 +24,6 @@ var downloadCmd = &cobra.Command{
 }
 
 func runDownload(args []string) error {
-	_, err := downloadDataFiles(goos, args[0])
+	_, err := downloadDataFiles(goos, components, args[0])
 	return err
 }


### PR DESCRIPTION
this is needed for the chocolatey package generation (#3444) where we want to select only the `admin-helper` to download current crc-embedder downloads all the data files needed for a platform

### demo run

```
❯ ./crc-embedder download --components=vfkit-driver . --log-level debug
DEBU Downloading https://github.com/crc-org/vfkit/releases/download/v0.0.4/vfkit to .
DEBU Download saved to vfkit

❯ ./crc-embedder download --goos=windows --components=vfkit-driver,tray --log-level debug /tmp
WARN 'vfkit-driver' is not available, ensure goos flag is used. Supported component names are: vfkit-driver, vfkit-entitlement, libvirt-driver, admin-helper, tray
DEBU Downloading https://github.com/crc-org/tray-electron/releases/download/1.2.9/crc-tray-windows.zip to /tmp
67.28 MiB / 97.26 MiB [--------------------------------------------------------------------------------------->_______________________________________] 69.18% 3.87 MiB p/s

❯ ./crc-embedder download -h
Download data files to embed in the crc executable

Usage:
  crc-embedder download [destination directory] [flags]

Flags:
      --components strings   Needed component(s) (vfkit-driver, vfkit-entitlement, libvirt-driver, admin-helper, tray)
      --goos string          Target platform (darwin, linux or windows) (default "darwin")
  -h, --help                 help for download

Global Flags:
      --log-level string   log level (e.g. "debug | info | warn | error") (default "info")

```