### PR TITLE
tools: add script to publish github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Publish release on github
+on:
+  workflow_dispatch:
+jobs:
+  publish_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Prepare empty notable changes
+        run: touch notable_changes.txt
+      - name: Run gh-release.sh
+        run: NONINTERACTIVE=1 ./gh-release.sh
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gh-release.sh
+++ b/gh-release.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+lastReleasedVersion="$(gh release view -R crc-org/crc --json tagName --jq .tagName)"
+currentRepoTag="$(git describe --tags --abbrev=0 --candidates=0 || echo "v0.0.0")"
+
+NONINTERACTIVE=${NONINTERACTIVE:-0}
+
+if ! grep -qP "^v\d\.\d+\.\d+$" <<< "$currentRepoTag"; then
+	echo "Tag $currentRepoTag doesn't follow the expected tag format of v0.0.0" >&2
+	exit 1
+fi
+
+if [[ "$currentRepoTag" = "v0.0.0" ]]; then
+	echo "Please tag before publishing release or fetch latest main from upstream" >&2
+	exit 1
+fi
+
+if [[ "$currentRepoTag" = "$lastReleasedVersion" ]]; then
+	echo "$currentRepoTag is already published on github" >&2
+	exit 1
+fi
+
+function prepare_release_notes() {
+	read -r -d '' rn_template << EOF
+Downloads are available at: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/%s
+To use these binaries follow the instructions at https://console.redhat.com/openshift/create/local to obtain the needed pull-secret.
+
+-------
+
+Notable Changes
+---
+
+- OpenShift %s
+- Podman %s
+- OKD %s
+%s
+
+
+git shortlog
+---
+
+%s
+EOF
+
+	changelog="$(git log --format="%h %s" "$lastReleasedVersion..$currentRepoTag")"
+	printf -v release_notes "$rn_template" "${currentRepoTag:1}" "$(ocp_version)" "$(podman_version)" "$(okd_version)" "$(notable_changes)" "$changelog"
+	echo "$release_notes"
+}
+
+function ocp_version() {
+	grep -oP "^OPENSHIFT_VERSION\s\?=\s\K\d\.\d+\.\d+$" Makefile
+}
+
+function podman_version() {
+	grep -oP "^PODMAN_VERSION\s\?=\s\K\d\.\d+\.\d+$" Makefile
+}
+
+function okd_version() {
+	grep -oP "^OKD_VERSION\s\?=\s\K\d\.\d+\..*$" Makefile
+}
+
+function notable_changes() {
+	if [[ -e notable-changes.txt ]]; then
+		cat notable-changes.txt
+	else
+		if @confirm "Notable changes file not found, would you still like to release?"; then
+			echo "Preparing release without notable changes.." >&2
+		else
+			exit 2
+		fi
+	fi
+}
+
+@confirm() {
+	# return true if NONINTERACTIVE is set
+	if [[ "${NONINTERACTIVE}" -eq 1 ]]; then
+		return 0
+	fi
+	local message="$*"
+	local result=3
+
+	echo -n "> $message (y/n) " >&2
+
+	while [[ $result -gt 1 ]] ; do
+	read -r -s -n 1 choice
+	case "$choice" in
+	  y|Y ) result=0 ;;
+	  n|N ) result=1 ;;
+	esac
+	done
+
+	return $result
+}
+
+release_txt=$(prepare_release_notes)
+
+printf "#####CRC Release notes#####\n\n%s\n\n#####CRC Release notes#####\n" "$release_txt"
+
+if @confirm "Push release to github?"; then
+	gh release create "$currentRepoTag" --verify-tag --draft --notes "$release_txt" --title "${currentRepoTag:1}-$(ocp_version)"
+else
+	echo "Release aborted!!"
+	exit 3
+fi
+


### PR DESCRIPTION
this adds a bash script named 'gh-release.sh' which can be used to publish the github releases of CRC

it needs to be ran from the commit which is tagged with the current desired release we want to publish

(need to also add a github actions job to run this)