### PR TITLE
[e2e] further small modifications to tests

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -57,8 +57,6 @@ Feature: Basic test
         And ensuring user is logged in succeeds
         And executing "oc get pods -n openshift-monitoring" succeeds
         Then stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*"
-        And unsetting config property "enable-cluster-monitoring" succeeds
-        And unsetting config property "memory" succeeds
         # stop
         When executing "crc stop"
         Then stdout should match "(.*)[Ss]topped the instance"

--- a/test/e2e/features/config.feature
+++ b/test/e2e/features/config.feature
@@ -96,9 +96,9 @@ Feature: Test configuration settings
 
         @windows
         Examples:
-            | property                        | value1 | value2 |
-            | skip-check-bundle-extracted     | true   | false  |
-            | skip-check-user-in-hyperv-group | true   | false  |
+            | property                                        | value1 | value2 |
+            | skip-check-bundle-extracted                     | true   | false  |
+            | check-user-in-crc-users-and-hyperv-admins-group | true   | false  |
 
     #| skip-check-hyperv-installed     | true   | false  |
     #| skip-check-hyperv-switch        | true   | false  |

--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -9,9 +9,6 @@ Feature: 4 Openshift stories
 
 	@darwin @linux @windows @startstop @testdata @story_health
 	Scenario: Overall cluster health
-		#Given ensuring CRC cluster is running succeeds
-		#And ensuring user is logged in succeeds
-		Given checking that CRC is running
 		Then executing "oc create namespace testproj" succeeds
 		And executing "oc project testproj" succeeds
 		And executing "oc apply -f httpd-example.yaml" succeeds

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -235,6 +235,18 @@ func InitializeScenario(s *godog.ScenarioContext) {
 					fmt.Println(err)
 					os.Exit(1)
 				}
+
+				err = crcCmd.UnsetConfigPropertySucceedsOrFails("enable-cluster-monitoring", "succeeds") // unsetting property that is not set gives 0 exitcode, so this works
+				if err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+
+				err = crcCmd.UnsetConfigPropertySucceedsOrFails("memory", "succeeds") // unsetting property that is not set gives 0 exitcode, so this works
+				if err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
 			}
 
 		}


### PR DESCRIPTION
Continued updates to e2e tests:

- move cleanup actions from end of Scenario to scenario's After hook (ensuring they are run even if there's a fail mid scenario)
- fix the logic when ensuring the cluster is running (`Background` section in `openshift_story` Feature)
- update Windows skip-check section in `config` Feature
- remove redundant (leftover) steps from `story_health` Scenario

Needs a test on Windows, I'll remove `Do Not Merge` label once it's done.