### PR TITLE
bundle: Check that the bundle URLs match the OpenShift version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-out/
-docs/build/
-release/
+/out/
+/docs/build/
+/release/
 /release-info.json
 *.crcbundle
-tmp-embed/
-RPMS/
-crc
+/tmp-embed/
+/RPMS/
+/crc

--- a/pkg/crc/machine/bundle/constants_test.go
+++ b/pkg/crc/machine/bundle/constants_test.go
@@ -1,0 +1,27 @@
+package bundle
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/crc-org/crc/pkg/crc/preset"
+	"github.com/crc-org/crc/pkg/crc/version"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestURIOpenShiftVersion(t *testing.T) {
+	openshiftVersion := version.GetBundleVersion(preset.OpenShift)
+	require.NotEqual(t, openshiftVersion, "0.0.0-unset", fmt.Sprintf("OpenShift version is unset (%s), build flags are incorrect", openshiftVersion))
+
+	uriPrefix := fmt.Sprintf("https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/openshift/%s", openshiftVersion)
+	for _, osInfo := range bundleLocations {
+		for _, presetInfo := range osInfo {
+			for _, remoteFile := range presetInfo {
+				assert.True(t, strings.HasPrefix(remoteFile.URI, uriPrefix), fmt.Sprintf("URI %s does not match OpenShift version %s", remoteFile.URI, openshiftVersion))
+			}
+		}
+	}
+}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -75,13 +75,13 @@ func Download(uri, destination string, mode os.FileMode, sha256sum []byte) (stri
 }
 
 type RemoteFile struct {
-	uri       string
+	URI       string
 	sha256sum string
 }
 
 func NewRemoteFile(uri, sha256sum string) *RemoteFile {
 	return &RemoteFile{
-		uri:       uri,
+		URI:       uri,
 		sha256sum: sha256sum,
 	}
 
@@ -92,7 +92,7 @@ func (r *RemoteFile) Download(bundlePath string, mode os.FileMode) (string, erro
 	if err != nil {
 		return "", err
 	}
-	return Download(r.uri, bundlePath, mode, sha256)
+	return Download(r.URI, bundlePath, mode, sha256)
 }
 
 func (r *RemoteFile) GetSha256Sum() string {
@@ -100,7 +100,7 @@ func (r *RemoteFile) GetSha256Sum() string {
 }
 
 func (r *RemoteFile) GetSourceFilename() (string, error) {
-	u, err := url.Parse(r.uri)
+	u, err := url.Parse(r.URI)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Last release we updated the bundle URLs but forgot to change the OpenShift
version in Makefile. This new test ensures both are in sync.