### PR TITLE
podman-env: Add missing '--root'

### DIFF
--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -57,7 +57,12 @@ func runPodmanEnv() error {
 	} else {
 		fmt.Println(shell.GetEnvString(userShell, "DOCKER_HOST", "npipe:////./pipe/crc-podman"))
 	}
-	fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env"))
+	if root {
+		fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env --root"))
+	} else {
+		fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env"))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When using `crc podman-env --root`, the printed instructions are missing
`--root`.

This fixes https://github.com/crc-org/crc/issues/3492