### PR TITLE
Ignore test out dirs from commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /out/
+/test/e2e/out/
+/test/integration/out/
 /docs/build/
 /release/
 /release-info.json


### PR DESCRIPTION
Git currently thinks that all `diagnose-...` and `*.log` files from tests should go into commits. 

I added explicit paths to test out dirs `/test/e2e/out/` and `/test/integration/out/`.

```
jsliacan ~/Github/crc (ocp-proxy-story)$ git status
On branch ocp-proxy-story
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   test/e2e/features/story_openshift_proxy.feature
	modified:   test/e2e/testsuite/testsuite.go

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	test/e2e/out/test-results/diagnose-1675420839.zip
	test/e2e/out/test-results/diagnose-1675422816.zip
	test/e2e/out/test-results/diagnose-1675424650.zip
	test/e2e/out/test-results/e2e_2023-2-3_10-22-49.log
	test/e2e/out/test-results/e2e_2023-2-3_10-25-11.log
	test/e2e/out/test-results/e2e_2023-2-3_11-00-55.log

no changes added to commit (use "git add" and/or "git commit -a")
```
