### PR TITLE
Powershell Core Dectection

### DIFF
--- a/pkg/os/shell/shell_windows.go
+++ b/pkg/os/shell/shell_windows.go
@@ -64,6 +64,8 @@ func detect() (string, error) {
 		switch {
 		case strings.Contains(strings.ToLower(shell), "powershell"):
 			return "powershell", nil
+		case strings.Contains(strings.ToLower(shell), "pwsh"):
+			return "powershell", nil
 		case strings.Contains(strings.ToLower(shell), "cmd"):
 			return "cmd", nil
 		default:


### PR DESCRIPTION
This will allow Powershell Core to be detected on Windows as Powershell instead of falling back to default cmd which causes errors when running commands like crc oc-env.
