### PR TITLE
Remove lease resource from openshift-machine-config-operator namespace

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -483,6 +483,13 @@ func DeleteMCOLeaderLease(ctx context.Context, ocConfig oc.Config) error {
 	if err := WaitForOpenshiftResource(ctx, ocConfig, "cm"); err != nil {
 		return err
 	}
-	_, _, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "cm", "machine-config-controller")
+	if _, _, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "cm", "machine-config-controller"); err != nil {
+		return err
+	}
+	// https://issues.redhat.com/browse/OCPBUGS-7583 as workaround
+	if err := WaitForOpenshiftResource(ctx, ocConfig, "lease"); err != nil {
+		return err
+	}
+	_, _, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "lease", "--all")
 	return err
 }

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -483,7 +483,7 @@ func DeleteMCOLeaderLease(ctx context.Context, ocConfig oc.Config) error {
 	if err := WaitForOpenshiftResource(ctx, ocConfig, "cm"); err != nil {
 		return err
 	}
-	if _, _, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "cm", "machine-config-controller"); err != nil {
+	if _, _, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "configmap", "machine-config-controller"); err != nil {
 		return err
 	}
 	// https://issues.redhat.com/browse/OCPBUGS-7583 as workaround


### PR DESCRIPTION
With 4.12.3 we found out that MCO is block till
machine-config-controller and machine-config lease is not acquired
and that takes around 5 mins. In this patch we are removing all the
lease (as of now these 2 are present) from this namespace so that MCO
is not block for that long time.

We still don't know the root cause so a Jira issue is created against
MCO to track it: https://issues.redhat.com/browse/OCPBUGS-7583