### PR TITLE
Update preflight_windows.go

### DIFF
--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -155,7 +155,7 @@ var userPartOfCrcUsersAndHypervAdminsGroupCheck = Check{
 var errReboot = errors.New("Please reboot your system and run 'crc setup' to complete the setup process")
 
 func username() string {
-	if ok, _ := win32.DomainJoined(); ok {
+	if ok := win32.DomainJoined(); ok {
 		return fmt.Sprintf(`%s\%s`, os.Getenv("USERDOMAIN"), os.Getenv("USERNAME"))
 	}
 	return os.Getenv("USERNAME")

--- a/pkg/os/windows/win32/domains_windows.go
+++ b/pkg/os/windows/win32/domains_windows.go
@@ -18,17 +18,28 @@ package win32
 
 import (
 	"errors"
+	"os"
 
 	"github.com/yusufpapurcu/wmi"
 )
 
-//nolint
+// nolint
 type Win32_ComputerSystem struct {
 	Partofdomain bool
 }
 
 // DomainJoined attempts to determine whether the machine is actively domain joined.
-func DomainJoined() (bool, error) {
+
+func DomainJoined() bool {
+	domainJoined, err := domainJoinedWmi()
+	if err != nil {
+		// simple additional domain check: a local User got the computername = domain
+		return os.Getenv("USERDOMAIN") != os.Getenv("COMPUTERNAME")
+	}
+	return domainJoined
+}
+
+func domainJoinedWmi() (bool, error) {
 	var c []Win32_ComputerSystem
 	q := wmi.CreateQuery(&c, "")
 


### PR DESCRIPTION
// simple additional domain check: a local User got the computername = domain


**Fixes:** Issue #3282

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Compare USERDOMAIN against COMPUTERNAME to detect a local usage

## Proposed changes

Add a second layer of test by checking content of USERDOMAIN and do not trust the win32 DomainJoin test only.

## Testing

See my comment in Issue #3282. I' m not totally sure, but i think it fails and in the error case it assumes it is a local user.
This might be a problem with permissions.