### PR TITLE
e2e: Check that we are testing the correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OKD_VERSION ?= 4.12.0-0.okd-2023-02-18-033438
 MICROSHIFT_VERSION ?= 4.12.9
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 2.17.0
-COMMIT_SHA?=$(shell git rev-parse --short HEAD)
+COMMIT_SHA?=$(shell git rev-parse --short=6 HEAD)
 MACOS_INSTALL_PATH = /usr/local/crc
 CONTAINER_RUNTIME ?= podman
 

--- a/Makefile
+++ b/Makefile
@@ -233,8 +233,11 @@ endif
 ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
+ifndef VERSION_TO_TEST
+	VERSION_TO_TEST = --crc-version=$(CRC_VERSION)+$(COMMIT_SHA)
+endif
 e2e:
-	@go test --timeout=180m $(REPOPATH)/test/e2e -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) $(GODOG_OPTS) $(CLEANUP_HOME) $(INSTALLER_PATH) $(USER_PASSWORD)
+	@go test --timeout=180m $(REPOPATH)/test/e2e -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) $(GODOG_OPTS) $(CLEANUP_HOME) $(VERSION_TO_TEST) $(INSTALLER_PATH) $(USER_PASSWORD)
 
 .PHONY: e2e-stories e2e-story-health e2e-story-marketplace e2e-story-registry
 # cluster must already be running, crc must be in the path

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -7,7 +7,7 @@ Feature: Basic test
     @darwin @linux @windows
     Scenario: CRC version
         When executing crc version command
-        Then stdout should contain "version:"
+        Then stdout should contain correct version
 
     @darwin @linux @windows
     Scenario: CRC help

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -29,6 +29,7 @@ var (
 	pullSecretFile     string
 	cleanupHome        bool
 	testWithShell      string
+	CRCVersion         string
 
 	GodogFormat              string
 	GodogTags                string
@@ -47,6 +48,7 @@ func ParseFlags() {
 	pflag.StringVar(&pullSecretFile, "pull-secret-file", "/path/to/pull-secret", "Path to the file containing pull secret")
 	pflag.StringVar(&CRCExecutable, "crc-binary", "/path/to/binary/crc", "Path to the CRC executable to be tested")
 	pflag.BoolVar(&cleanupHome, "cleanup-home", false, "Try to remove crc home folder before starting the suite") // TODO: default=true
+	pflag.StringVar(&CRCVersion, "crc-version", "", "Version of CRC to be tested")
 }
 
 func InitializeTestSuite(tctx *godog.TestSuiteContext) {
@@ -366,6 +368,8 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		util.CommandReturnShouldNotContain)
 	s.Step(`^(stdout|stderr|exitcode) (?:should|does not) contain$`,
 		util.CommandReturnShouldNotContainContent)
+	s.Step(`^(stdout|stderr|exitcode) (?:should contain|contains) correct version$`,
+		CommandReturnShouldContainCorrectVersion)
 
 	s.Step(`^(stdout|stderr|exitcode) (?:should equal|equals) "(.*)"$`,
 		util.CommandReturnShouldEqual)
@@ -591,6 +595,15 @@ func CheckOutputMatchWithRetry(retryCount int, retryTime string, command string,
 	}
 
 	return matchErr
+}
+
+func CommandReturnShouldContainCorrectVersion() error {
+
+	if CRCVersion == "" {
+		return util.CommandReturnShouldContain("stdout", "version:")
+	}
+
+	return util.CommandReturnShouldContain("stdout", CRCVersion)
 }
 
 func CheckCRCStatus(state string) error {


### PR DESCRIPTION
Make use of `crc version` output to cross check that we are indeed testing the expected CRC version. Because version is so unique, it is enough to check for containment. If we start releasing `*-ec` and similar variations, this might need to be changed to matching instead of containing.  

In the case of this CI, this PR has no effect -- if `VERSION_TO_TEST` is set to `--crc-version=""` (default), then version is **not** checked. I manually checked the first Scenario in `basic.feature` which is affected if version is passed:

```
Log successfully started, logging into: /home/jsliacan/Github/crc/test/e2e/out/test-results/e2e_2023-3-8_15-21-12.log
Running e2e test in: /home/jsliacan/Github/crc/test/e2e/out/test-run
Working directory set to: /home/jsliacan/Github/crc/test/e2e/out/test-run
Using existing bundle: /home/jsliacan/Downloads/crc_libvirt_4.12.5_amd64.crcbundle
Feature: Basic test
  User explores some of the top-level CRC commands while going
  through the lifecycle of CRC.

  Scenario: CRC version                        # features/test.feature:8
    When executing crc version command         # testsuite.go:868 -> github.com/crc-org/crc/test/e2e/testsuite.ExecuteCRCCommand
    Then stdout should contain correct version # testsuite.go:600 -> github.com/crc-org/crc/test/e2e/testsuite.CommandREturnShouldContainCorrectVersion
Deleted CRC instance (if one existed).

1 scenarios (1 passed)
2 steps (2 passed)
58.890846ms
ok  	github.com/crc-org/crc/test/e2e	0.085s
```