### PR TITLE
Integration: Add testcase for login using crc-admin context

### DIFF
--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -1,6 +1,7 @@
 package test_test
 
 import (
+	"os/exec"
 	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,6 +27,25 @@ var _ = Describe("vary VM parameters: memory cpus, disk", Label("openshift-prese
 			} else {
 				Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "5", "--disk-size", "40", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
 			}
+		})
+
+		It("login to cluster using crc-admin context", func() {
+
+			err := AddOCToPath()
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd := exec.Command("oc", "config", "use-context", "crc-admin")
+			err = cmd.Run()
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("oc", "whoami")
+			out, err := cmd.Output()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(out)).To(ContainSubstring("kubeadmin"))
+
+			cmd = exec.Command("oc", "get", "co")
+			err = cmd.Run()
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("check VM's memory size", func() {
@@ -137,4 +157,5 @@ var _ = Describe("vary VM parameters: memory cpus, disk", Label("openshift-prese
 
 		})
 	})
+
 })

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -112,4 +114,22 @@ func SendCommandToVM(cmd string) (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+func AddOCToPath() error {
+	path := os.ExpandEnv("${HOME}/.crc/bin/oc:$PATH")
+	if runtime.GOOS == "windows" {
+		userHomeDir, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		unexpandedPath := filepath.Join(userHomeDir, ".crc/bin/oc;${PATH}")
+		path = os.ExpandEnv(unexpandedPath)
+	}
+	err := os.Setenv("PATH", path)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
#3456 and [this comment](https://github.com/crc-org/crc/issues/3456#issuecomment-1354482871) specifically.

Adding a testcase into existing test to login to the cluster using `crc-admin` context. No additional `crc start`. The issue above is still open so I assume this will fail for now, as it should until it's resolved. However, the way I added it here does not affect the rest of the tests - so the testcase will fail on its own. 