### PR TITLE
macos: Make tray optional in the installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ packagedir: clean embed-download-darwin macos-universal-binary
 	# crc-tray.pkg
 	tar -C $(EMBED_DOWNLOAD_DIR) -xvzf $(EMBED_DOWNLOAD_DIR)/$(TRAY_TARBALL)
 	rm $(EMBED_DOWNLOAD_DIR)/$(TRAY_TARBALL)
-	mv $(EMBED_DOWNLOAD_DIR)/crc-tray-darwin-universal/crc-tray.app packaging/darwin/root-crc-tray/Applications/Red\ Hat\ OpenShift\ Local\ Tray.app
+	mv $(EMBED_DOWNLOAD_DIR)/crc-tray-darwin-universal/crc-tray.app packaging/darwin/root-crc-tray/Applications/Red\ Hat\ OpenShift\ Local.app
 	rm -fr $(EMBED_DOWNLOAD_DIR)/crc-tray-darwin-universal
 
 	# crc.pkg

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OKD_VERSION ?= 4.12.0-0.okd-2023-02-18-033438
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 2.15.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
-MACOS_INSTALL_PATH = /Applications/Red Hat OpenShift Local.app/Contents/Resources
+MACOS_INSTALL_PATH = /usr/local/crc
 CONTAINER_RUNTIME ?= podman
 
 TOOLS_DIR := tools

--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -5,7 +5,7 @@
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />
     <license file="LICENSE.txt"/>
-    <options customize="never" allow-external-scripts="no"/>
+    <options customize="allow" allow-external-scripts="no"/>
     <domains enable_localSystem="true" />
     <options rootVolumeOnly="true"/>
     <options hostArchitectures="x86_64,arm64" />
@@ -48,11 +48,11 @@ function installCheck() {
         <line choice="crc"/>
         <line choice="crc-tray"/>
     </choices-outline>
-    <choice id="crc" title="crc">
+    <choice id="crc" title="Red Hat OpenShift Local" enabled="false" selected="true" visible="true">
         <pkg-ref id="crc.pkg"/>
     </choice>
     <pkg-ref id="crc.pkg" auth="Root">crc.pkg</pkg-ref>
-    <choice id="crc-tray" title="crc-tray">
+    <choice id="crc-tray" title="System Tray for Red Hat OpenShift Local" enabled="true" selected="false" visible="true">
         <pkg-ref id="crc-tray.pkg"/>
     </choice>
     <pkg-ref id="crc-tray.pkg" auth="Root">crc-tray.pkg</pkg-ref>

--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -46,9 +46,14 @@ function installCheck() {
     </script>
     <choices-outline>
         <line choice="crc"/>
+        <line choice="crc-tray"/>
     </choices-outline>
     <choice id="crc" title="crc">
         <pkg-ref id="crc.pkg"/>
     </choice>
     <pkg-ref id="crc.pkg" auth="Root">crc.pkg</pkg-ref>
+    <choice id="crc-tray" title="crc-tray">
+        <pkg-ref id="crc-tray.pkg"/>
+    </choice>
+    <pkg-ref id="crc-tray.pkg" auth="Root">crc-tray.pkg</pkg-ref>
 </installer-script>

--- a/packaging/darwin/macos-pkg-build-and-sign.sh
+++ b/packaging/darwin/macos-pkg-build-and-sign.sh
@@ -42,7 +42,7 @@ function signAppBundle() {
 
 crcRootDir="${BASEDIR}/root-crc"
 trayRootDir="${BASEDIR}/root-crc-tray"
-crcBinDir="${crcRootDir}/Applications/Red Hat OpenShift Local.app/Contents/Resources"
+crcBinDir="${crcRootDir}/usr/local/crc"
 
 version=$(cat "${BASEDIR}/VERSION")
 

--- a/packaging/darwin/macos-pkg-build-and-sign.sh
+++ b/packaging/darwin/macos-pkg-build-and-sign.sh
@@ -40,24 +40,25 @@ function signAppBundle() {
   codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --timestamp --force --entitlements "${entitlements}" "$1"
 }
 
-binDir="${BASEDIR}/root/Applications/Red Hat OpenShift Local.app/Contents/Resources"
+rootDir="${BASEDIR}/root"
+binDir="${rootDir}/Applications/Red Hat OpenShift Local.app/Contents/Resources"
 
 version=$(cat "${BASEDIR}/VERSION")
 
-pkgbuild --analyze --root ${BASEDIR}/root ${BASEDIR}/components.plist
+pkgbuild --analyze --root "${rootDir}" ${BASEDIR}/components.plist
 plutil -replace BundleIsRelocatable -bool NO ${BASEDIR}/components.plist
 
 sign "${binDir}/crc"
 sign "${binDir}/crc-admin-helper-darwin"
 sign "${binDir}/vfkit"
 
-signAppBundle "${BASEDIR}/root/Applications/Red Hat OpenShift Local.app"
+signAppBundle "${rootDir}/Applications/Red Hat OpenShift Local.app"
 
 sudo chmod +sx "${binDir}/crc-admin-helper-darwin"
 
 pkgbuild --identifier com.redhat.crc --version ${version} \
   --scripts "${BASEDIR}/scripts" \
-  --root "${BASEDIR}/root" \
+  --root "${rootDir}" \
   --install-location / \
   --component-plist "${BASEDIR}/components.plist" \
   "${OUTPUT}/crc.pkg"

--- a/packaging/darwin/macos-pkg-build-and-sign.sh
+++ b/packaging/darwin/macos-pkg-build-and-sign.sh
@@ -55,7 +55,7 @@ sign "${crcBinDir}/crc"
 sign "${crcBinDir}/crc-admin-helper-darwin"
 sign "${crcBinDir}/vfkit"
 
-signAppBundle "${trayRootDir}/Applications/Red Hat OpenShift Local Tray.app"
+signAppBundle "${trayRootDir}/Applications/Red Hat OpenShift Local.app"
 
 sudo chmod +sx "${crcBinDir}/crc-admin-helper-darwin"
 


### PR DESCRIPTION
This PR makes the tray optional in the macOS installer.
Its installation is enabled by default, but this default can be changed easily in `packaging/darwin/Distribution.in`.
The way this works is that the crc binaries are split between a 'crc package' and a 'tray package' which will install in different paths.
These are generated with `pkgbuild`
Then these 2 packages are wrapped in a single installer using `productbuild`.
The `Distribution` file for this installer uses `choices-outline`/`choice` to allow to tweak what gets installed.