### PR TITLE
Improvements to the .spec file

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-      - "old-main"
   pull_request: {}
   workflow_dispatch:
     inputs:

--- a/.github/workflows/make-check-win.yml
+++ b/.github/workflows/make-check-win.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-      - "old-main"
   pull_request: {}
 jobs:
   build:

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-      - "old-main"
   pull_request: {}
 jobs:
   build:

--- a/.github/workflows/make-rpm.yml
+++ b/.github/workflows/make-rpm.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-      - "old-main"
   pull_request: {}
 jobs:
   build:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-      - "old-main"
   pull_request: {}
 jobs:
   build:

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-      - "old-main"
   pull_request: {}
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OKD_VERSION ?= 4.12.0-0.okd-2023-02-18-033438
 MICROSHIFT_VERSION ?= 4.12.5
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 2.15.0
-COMMIT_SHA=$(shell git rev-parse --short HEAD)
+COMMIT_SHA?=$(shell git rev-parse --short HEAD)
 MACOS_INSTALL_PATH = /usr/local/crc
 CONTAINER_RUNTIME ?= podman
 
@@ -359,6 +359,7 @@ $(BUILD_DIR)/macos-universal/crc-macos-installer.tar: packagedir
 					   -e '/__BUNDLED_PROVIDES__/d' \
 					   -e 's/__VERSION__/'$(CRC_VERSION)'/g' \
 					   -e 's/__OPENSHIFT_VERSION__/'$(OPENSHIFT_VERSION)'/g' \
+					   -e 's/__COMMIT_SHA__/'$(COMMIT_SHA)'/g' \
 				       $< >$@
 
 %: %.in

--- a/developing.adoc
+++ b/developing.adoc
@@ -1,6 +1,6 @@
 
 
-= Developing CodeReady Containers
+= Developing CRC
 
 [[developing-overview]]
 == Overview
@@ -39,7 +39,7 @@ Do not keep the source code in your `$GOPATH`, as link:https://github.com/golang
 [[dependency-management]]
 == Dependency management
 
-CodeReady Containers uses link:https://github.com/golang/go/wiki/Modules[Go modules] for dependency management.
+CRC uses link:https://github.com/golang/go/wiki/Modules[Go modules] for dependency management.
 
 For more information, see the following:
 
@@ -96,11 +96,11 @@ $ make generate_mocks
 [[running-e2e-tests]]
 == Running e2e tests
 
-We have automated e2e tests which keep CodeReady Containers in shape.
+We have automated e2e tests which keep CRC in shape.
 
 [[intro-to-e2e-testing]]
 === Introduction
-End-to-end (e2e) tests borrow code from link:http://github.com/crc-org/clicumber[Clicumber] package to provide basic functionality for testing CLI binaries. This facilitates running commands in a persistent shell instance (`bash`, `tcsh`, `zsh`, Command Prompt, or PowerShell), assert its outputs (standard output, standard error, or exit code), check configuration files, and so on. The general functionality of Clicumber is then extended by CodeReady Containers specific test code to cover the whole functionality of CodeReady Containers.
+End-to-end (e2e) tests borrow code from link:http://github.com/crc-org/clicumber[Clicumber] package to provide basic functionality for testing CLI binaries. This facilitates running commands in a persistent shell instance (`bash`, `tcsh`, `zsh`, Command Prompt, or PowerShell), assert its outputs (standard output, standard error, or exit code), check configuration files, and so on. The general functionality of Clicumber is then extended by CRC specific test code to cover the whole functionality of CRC.
 
 [[how-to-run-e2e-tests]]
 === How to run

--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -60,7 +60,7 @@ export GOFLAGS="-mod=vendor"
 mkdir embed-files
 cp /usr/bin/crc-driver-libvirt embed-files
 cp /usr/bin/crc-admin-helper embed-files/crc-admin-helper-linux
-make GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ release
+make COMMIT_SHA=__COMMIT_SHA__ GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ release
 
 %install
 # with fedora macros: gopkginstall

--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -60,8 +60,7 @@ export GOFLAGS="-mod=vendor"
 mkdir embed-files
 cp /usr/bin/crc-driver-libvirt embed-files
 cp /usr/bin/crc-admin-helper embed-files/crc-admin-helper-linux
-make GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ linux-release
-make GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" macos-release-binary windows-release-binary
+make GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ release
 
 %install
 # with fedora macros: gopkginstall

--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -13,7 +13,7 @@ Version:                __VERSION__
 %global __os_install_post /usr/lib/rpm/brp-compress %{nil}
 
 %global common_description %{expand:
-CodeReady Container's executable}
+CRC's main executable}
 
 
 %global golicenses    LICENSE
@@ -22,7 +22,7 @@ CodeReady Container's executable}
 
 Name:           %{goname}
 Release:        1%{?dist}
-Summary:        CodeReady Container's executable
+Summary:        CRC's main executable
 License:        APL 2.0
 ExcludeArch:    armv7hl i686
 URL:            %{gourl}

--- a/usage-data.adoc
+++ b/usage-data.adoc
@@ -1,6 +1,6 @@
 = Usage data
 
-The following table describes the opt-in usage data collected by CodeReady Containers.
+The following table describes the opt-in usage data collected by CRC.
 
 .Data points
 |===
@@ -8,7 +8,7 @@ The following table describes the opt-in usage data collected by CodeReady Conta
 
 |*Install*         | Host OS                      |
 |                  | Host OS version              |
-|                  | CodeReady Containers version |
+|                  | CRC version                  |
 |                  | Installed using installers   | true/false
 
 |*Setup*           | Error message                |


### PR DESCRIPTION
The main goal of this series is to show a valid git hash in `crc version` after building from the spec file.
This also removes some leftover CodeReady Containers mention.