### PR TITLE
update windows preflight check for user in required groups

### DIFF
--- a/pkg/crc/preflight/preflight_checks_windows_test.go
+++ b/pkg/crc/preflight/preflight_checks_windows_test.go
@@ -1,0 +1,29 @@
+package preflight
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserInMemberList(t *testing.T) {
+	members := `DESKTOP-R05QDNL\someUser1
+DESKTOP-R05QDNL\someUser2
+NT AUTHORITY\INTERACTIVE
+DESKTOP-G7H96M0\crc`
+
+	tests := []struct {
+		username string
+		expected bool
+	}{
+		{`some`, false},
+		{`DESKTOP-G7H96M0\someUser1`, false},
+		{`DESK`, false},
+		{`someUser2`, true},
+		{`crc`, true},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, usernameInMembersList(tt.username, members))
+	}
+}


### PR DESCRIPTION
remove the username from `Get-LocalGroupMember` cmdlet and get the list of users
belonging to a group and perform string comparison to determine if current user
is part of the group

this should work around the need to supply the username with or without the domain
part depending on whether the machine was currently domain joined