### PR TITLE
Update logging when podman or other preset in use

### DIFF
--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -24,7 +24,7 @@ var (
 
 func init() {
 	setupCmd.Flags().Bool(crcConfig.ExperimentalFeatures, false, "Allow the use of experimental features")
-	setupCmd.Flags().StringP(crcConfig.Bundle, "b", constants.GetDefaultBundlePath(crcConfig.GetPreset(config)), "Bundle to use for instance")
+	setupCmd.Flags().StringP(crcConfig.Bundle, "b", constants.GetDefaultBundlePath(crcConfig.GetPreset(config)), crcConfig.BundleHelpMsg(config))
 	setupCmd.Flags().BoolVar(&checkOnly, "check-only", false, "Only run the preflight checks, don't try to fix any misconfiguration")
 	setupCmd.Flags().BoolVar(&forceShowProgressbars, "show-progressbars", false, "Always show the progress bars for download and extraction")
 	addOutputFormatFlag(setupCmd)

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -34,7 +34,7 @@ func init() {
 	addOutputFormatFlag(startCmd)
 
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
-	flagSet.StringP(crcConfig.Bundle, "b", constants.GetDefaultBundlePath(crcConfig.GetPreset(config)), "The system bundle used to provision the instance")
+	flagSet.StringP(crcConfig.Bundle, "b", constants.GetDefaultBundlePath(crcConfig.GetPreset(config)), crcConfig.BundleHelpMsg(config))
 	flagSet.StringP(crcConfig.PullSecretFile, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
 	flagSet.IntP(crcConfig.CPUs, "c", constants.GetDefaultCPUs(crcConfig.GetPreset(config)), "Number of CPU cores to allocate to the instance")
 	flagSet.IntP(crcConfig.Memory, "m", constants.GetDefaultMemory(crcConfig.GetPreset(config)), "MiB of memory to allocate to the instance")

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -72,9 +72,7 @@ func RegisterSettings(cfg *Config) {
 	cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteAndSetupMsg,
 		fmt.Sprintf("Virtual machine preset (valid values are: %s, %s and %s)", preset.Podman, preset.OpenShift, preset.OKD))
 	// Start command settings in config
-	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied,
-		fmt.Sprintf("Bundle path/URI - absolute or local path, http, https or docker URI (string, like 'https://foo.com/%s', 'docker://quay.io/myorg/%s:%s' default '%s' )",
-			constants.GetDefaultBundle(GetPreset(cfg)), constants.GetDefaultBundle(GetPreset(cfg)), version.GetCRCVersion(), defaultBundlePath(cfg)))
+	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied, BundleHelpMsg(cfg))
 	cfg.AddSetting(CPUs, defaultCPUs(cfg), validateCPUs, RequiresRestartMsg,
 		fmt.Sprintf("Number of CPU cores (must be greater than or equal to '%d')", defaultCPUs(cfg)))
 	cfg.AddSetting(Memory, defaultMemory(cfg), validateMemory, RequiresRestartMsg,
@@ -166,4 +164,9 @@ func GetNetworkMode(config Storage) network.Mode {
 
 func UpdateDefaults(cfg *Config) {
 	RegisterSettings(cfg)
+}
+
+func BundleHelpMsg(cfg *Config) string {
+	return fmt.Sprintf("Bundle path/URI - absolute or local path, http, https or docker URI (string, like 'https://foo.com/%s', 'docker://quay.io/myorg/%s:%s' default '%s' )",
+		constants.GetDefaultBundle(GetPreset(cfg)), constants.GetDefaultBundle(GetPreset(cfg)), version.GetCRCVersion(), defaultBundlePath(cfg))
 }

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -172,6 +172,15 @@ func (bundle *CrcBundleInfo) GetPodmanVersion() string {
 	return bundle.Nodes[0].PodmanVersion
 }
 
+func (bundle *CrcBundleInfo) GetVersion() string {
+	switch bundle.GetBundleType() {
+	case crcPreset.Podman:
+		return bundle.GetPodmanVersion()
+	default:
+		return bundle.GetOpenshiftVersion()
+	}
+}
+
 func (bundle *CrcBundleInfo) GetBundleNameWithoutExtension() string {
 	return GetBundleNameWithoutExtension(bundle.GetBundleName())
 }

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -242,11 +242,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 			return nil, errors.Wrap(err, "Failed to ask for pull secret")
 		}
 
-		if crcBundleMetadata.IsOpenShift() {
-			logging.Infof("Creating CRC VM for %s %s...", startConfig.Preset, crcBundleMetadata.GetOpenshiftVersion())
-		} else {
-			logging.Infof("Creating CRC VM for Podman %s...", crcBundleMetadata.GetPodmanVersion())
-		}
+		logging.Infof("Creating CRC VM for %s %s...", startConfig.Preset.ForDisplay(), crcBundleMetadata.GetVersion())
 
 		sharedDirs := []string{}
 		if homeDir, err := os.UserHomeDir(); err == nil {

--- a/pkg/crc/preset/preset.go
+++ b/pkg/crc/preset/preset.go
@@ -29,6 +29,20 @@ func (preset Preset) String() string {
 	return "invalid"
 }
 
+func (preset Preset) ForDisplay() string {
+	switch preset {
+	case Podman:
+		return "Podman"
+	case OpenShift:
+		return "OpenShift"
+	case OKD:
+		return "OKD"
+	case Microshift:
+		return "MicroShift"
+	}
+	return "unknown"
+}
+
 func ParsePresetE(input string) (Preset, error) {
 	switch input {
 	case Podman.String():


### PR DESCRIPTION
With this patch you shouldn't get following logging message in case of microshift bundle.
```
INFO Loading bundle: crc_microshift_hyperv_4.12.6_amd64...
INFO Creating CRC VM for Podman ...
```


**Fixes:** Issue #3557 