### PR TITLE
CI: use dummy pull secret for microshift workflow

### DIFF
--- a/.github/workflows/macos-microshift.yml
+++ b/.github/workflows/macos-microshift.yml
@@ -35,21 +35,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      - name: check if OCP_PULL_SECRET exists
-        shell: bash
-        run: |
-          if [ ${PULL_SECRET} == "" ]; then
-            echo "The secret \"OCP_PULL_SECRET\" is not set; echo please go to \"settings > secrets > actions\" to create it"
-            exit 1
-          fi
-        env:
-          PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
-      - name: Write the pull secret to json file
-        shell: bash
-        run: |
-          echo $PULL_SECRET > temp-ps.json
-        env:
-          PULL_SECRET: ${{ secrets.OCP_PULL_SECRET }}
       - name: Build macOS installer
         run: make NO_CODESIGN=1 out/macos-universal/crc-macos-installer.pkg
       - name: Install crc pkg
@@ -61,4 +46,4 @@ jobs:
       - name: Wait 10 sec for the daemon to serve
         run: sleep 10
       - name: Run crc with microshift preset
-        run: crc start --pull-secret-file temp-ps.json
+        run: crc start

--- a/.github/workflows/macos-microshift.yml
+++ b/.github/workflows/macos-microshift.yml
@@ -41,9 +41,12 @@ jobs:
         run: sudo installer -pkg out/macos-universal/crc-macos-installer.pkg -target /
       - name: Set microshift preset as part of config
         run: crc config set preset microshift
+      - name: Create dummy pull secret
+        run: |
+          echo '{"auths":{"quay.io":{"auth":"b3BlbnN","email":"dummy@dummy.com"}}}' > dummy_pull.json
       - name: Run crc setup command
         run: crc setup
       - name: Wait 10 sec for the daemon to serve
         run: sleep 10
       - name: Run crc with microshift preset
-        run: crc start
+        run: crc start --pull-secret-file dummy_pull.json


### PR DESCRIPTION
Since all the images are already part of the bundle we can use
as dummy pull secret to start the microshift cluster and this will
also allow us to run that workflow from the fork.