### PR TITLE
e2e: Monitoring operator has one pod since OCP 4.13

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -56,7 +56,7 @@ Feature: Basic test
         When checking that CRC is running
         And ensuring user is logged in succeeds
         And executing "oc get pods -n openshift-monitoring" succeeds
-        Then stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*"
+        Then stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *1/1\ *Running.*"
         # stop
         When executing "crc stop"
         Then stdout should match "(.*)[Ss]topped the instance"


### PR DESCRIPTION
Starting with OpenShift 4.13, monitoring operator will have 1 pod. We used to check for `2/2`. 

 ```xml 
<failure message="Step stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*": output did not match. Expected: '.*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*', Actual: 'NAME READY STATUS RESTARTS AGE alertmanager-main-0 6/6 Running 1 (3m58s ago) 4m5s cluster-monitoring-operator-78b755f457-6k4df 1/1 Running 0 4m37s kube-state-metrics-58957c56bc-v268k 3/3 Running 0 4m11s node-exporter-4rx4t 2/2 Running 0 4m10s openshift-state-metrics-5449996978-p585x 3/3 Running 0 4m11s prometheus-adapter-7f65dfd454-jrmqt 1/1 Running 0 4m8s prometheus-k8s-0 6/6 Running 0 4m1s prometheus-operator-6c5b488ff4-vgq9w 2/2 Running 0 4m20s prometheus-operator-admission-webhook-c8c577b57-bzww2 1/1 Running 0 4m28s telemeter-client-dcdcf886d-2hb9b 3/3 Running 0 4m5s thanos-querier-57c756949c-pz82d 6/6 Running 0 4m3s'"/>
```
Should only be merged when we start using `4.13.x` bundles.