### PR TITLE
Status: Add microshift as part of status

### DIFF
--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -180,10 +180,10 @@ func (s *status) prettyPrintTo(writer io.Writer) error {
 		{"CRC VM", s.CrcStatus},
 	}
 
-	if s.OpenShiftVersion != "" {
+	if s.Preset == preset.OpenShift {
 		lines = append(lines, line{"OpenShift", openshiftStatus(s)})
 	}
-	if s.PodmanVersion != "" {
+	if s.Preset == preset.Podman {
 		lines = append(lines, line{"Podman", s.PodmanVersion})
 	}
 	if s.Preset == preset.Microshift {

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -186,6 +186,9 @@ func (s *status) prettyPrintTo(writer io.Writer) error {
 	if s.PodmanVersion != "" {
 		lines = append(lines, line{"Podman", s.PodmanVersion})
 	}
+	if s.Preset == preset.Microshift {
+		lines = append(lines, line{"MicroShift", openshiftStatus(s)})
+	}
 
 	if s.RAMSize != -1 && s.RAMUsage != -1 {
 		lines = append(lines, line{"RAM Usage", fmt.Sprintf(

--- a/cmd/crc/cmd/status_test.go
+++ b/cmd/crc/cmd/status_test.go
@@ -60,7 +60,6 @@ func TestPlainStatus(t *testing.T) {
 
 	expected := `CRC VM:          Running
 OpenShift:       Running (v4.5.1)
-Podman:          3.3.1
 RAM Usage:       0B of 0B
 Disk Usage:      10GB of 20GB (Inside the CRC VM)
 Cache Usage:     10kB

--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -80,7 +80,7 @@ func (status *Status) IsReady() bool {
 }
 
 func GetClusterOperatorsStatus(ctx context.Context, ip string, kubeconfigFilePath string) (*Status, error) {
-	lister, err := kubernetesClient(ip, kubeconfigFilePath)
+	lister, err := openshiftClient(ip, kubeconfigFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ type operatorLister interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*openshiftapi.ClusterOperatorList, error)
 }
 
-func kubernetesClient(ip string, kubeconfigFilePath string) (*clientset.Clientset, error) {
+func openshiftClient(ip string, kubeconfigFilePath string) (*clientset.Clientset, error) {
 	config, err := kubernetesClientConfiguration(ip, kubeconfigFilePath)
 	if err != nil {
 		return nil, err

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -53,7 +53,7 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 		return nil, err
 	}
 
-	if bundleInfo.IsOpenShift() {
+	if !bundleInfo.IsPodman() {
 		if fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain) != constants.AppsDomain {
 			return nil, fmt.Errorf("unexpected bundle, it must have %s apps domain", constants.AppsDomain)
 		}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -295,13 +295,12 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Error getting the machine state")
 	}
 	if vmState == state.Running {
-		if !vm.bundle.IsOpenShift() {
-			logging.Infof("A CRC VM for Podman %s is already running", vm.bundle.GetPodmanVersion())
+		logging.Infof("A CRC VM for %s %s is already running", startConfig.Preset.ForDisplay(), vm.bundle.GetVersion())
+		if vm.bundle.IsPodman() {
 			return &types.StartResult{
 				Status: vmState,
 			}, nil
 		}
-		logging.Infof("A CRC VM for OpenShift %s is already running", vm.bundle.GetOpenshiftVersion())
 		clusterConfig, err := getClusterConfig(vm.bundle)
 		if err != nil {
 			return nil, errors.Wrap(err, "Cannot create cluster configuration")


### PR DESCRIPTION
With this patch now for microshift preset user will get following
output.
```
$ ./crc status
CRC VM:          Running
MicroShift:      Running (v4.12.9)
RAM Usage:       1.144GB of 3.913GB
Disk Usage:      4.647GB of 16.1GB (Inside the CRC VM)
Cache Usage:     208.9GB
Cache Directory: /home/prkumar/.crc/cache

$ ./crc status -ojson
{
  "success": true,
  "crcStatus": "Running",
  "microshiftStatus": "Running",
  "microshiftVersion": "4.12.9",
  "diskUsage": 4646580224,
  "diskSize": 16095641600,
  "cacheUsage": 208867411129,
  "cacheDir": "/home/prkumar/.crc/cache",
  "ramSize": 3912945664,
  "ramUsage": 1144094720,
  "preset": "microshift"
}
```

Fixes: #3592 