### PR TITLE
Start: use the router image as per openshift version for microshift preset

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -888,7 +888,7 @@ func ensureRoutesControllerIsRunning(sshRunner *crcssh.Runner, ocConfig oc.Confi
 }
 
 func getRouterControllerImage(preset crcPreset.Preset, bundleInfo *bundle.CrcBundleInfo) string {
-	if preset == crcPreset.OpenShift {
+	if preset == crcPreset.OpenShift || preset == crcPreset.Microshift {
 		return fmt.Sprintf("quay.io/crcont/routes-controller:%s", bundleInfo.GetOpenshiftVersion())
 	}
 	return "quay.io/crcont/routes-controller:latest"


### PR DESCRIPTION

router controller images are cached in bundle as openshift version if it available for that specific version so better to use it.

Also we need to remove that hack by putting this resource in bundle.
- https://github.com/crc-org/snc/issues/660


