### PR TITLE
MicroShift: merge kubeconfig to user defined KUBECONFIG or ~/.kube/config

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -260,24 +260,13 @@ Use the 'podman' command line interface:
 This cluster was built from OKD - The Community Distribution of Kubernetes that powers Red Hat OpenShift.
 If you find an issue, please report it at https://github.com/openshift/okd
 `
-)
-
-func startTemplateForMicroshift() string {
-	tmpl := `Started the MicroShift cluster.
-
-%s
+	startTemplateForMicroShift = `Started the MicroShift cluster.
 
 Use the 'oc' command line interface:
   {{ .CommandLinePrefix }} {{ .EvalCommandLine }}
   {{ .CommandLinePrefix }} oc COMMAND
 `
-	userShell, err := shell.GetShell("")
-	if err != nil {
-		userShell = ""
-	}
-
-	return fmt.Sprintf(tmpl, shell.GetEnvString(userShell, "KUBECONFIG", "{{ .KubeConfigPath }}"))
-}
+)
 
 type templateVariables struct {
 	ClusterConfig       *clusterConfig
@@ -342,7 +331,7 @@ func writePodmanTemplatedMessage(writer io.Writer, s *startResult) error {
 }
 
 func writeMicroShiftTemplatedMessage(writer io.Writer, s *startResult) error {
-	parsed, err := template.New("template").Parse(startTemplateForMicroshift())
+	parsed, err := template.New("template").Parse(startTemplateForMicroShift)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -500,6 +500,10 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 				return nil, err
 			}
 		}
+		logging.Info("Adding microshift context to kubeconfig...")
+		if err := mergeKubeConfigFile(constants.KubeconfigFilePath); err != nil {
+			return nil, err
+		}
 
 		return &types.StartResult{
 			ClusterConfig: types.ClusterConfig{ClusterType: startConfig.Preset},


### PR DESCRIPTION
With this patch, the kubeconfig file which is part of microshift is
merged with kubeconfig file which user provided as part of `KUBECONFIG`
env or default path (~/.kube/config) and set the default context to
microshift. This will allow user to start microshift and consume
directly without export the kubconfig path.

```
$ oc config get-contexts
CURRENT   NAME                                                                CLUSTER                                 AUTHINFO                                             NAMESPACE
          default/api-192-168-130-11-nip-io:6443/kubeadmin                    api-192-168-130-11-nip-io:6443          kubeadmin/api-192-168-130-11-nip-io:6443             default
          default/api-35-199-20-126-nip-io:6443/kubeadmin                     api-35-199-20-126-nip-io:6443           kubeadmin/api-35-199-20-126-nip-io:6443              default
          demo/api-192-168-130-11-nip-io:6443/kubeadmin                       api-192-168-130-11-nip-io:6443          kubeadmin/api-192-168-130-11-nip-io:6443             demo
*         microshift                                                          microshift                              user                                                 default
          test/api-192-168-130-11-nip-io:6443/kubeadmin                       api-192-168-130-11-nip-io:6443          kubeadmin/api-192-168-130-11-nip-io:6443             test

$ oc config current-context
microshift
```