### PR TITLE
Remove Read and Write timeout from the daemon API server

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -147,9 +147,8 @@ func run(configuration *types.Configuration) error {
 		mux.Handle("/api/", http.StripPrefix("/api", api.NewMux(config, machineClient, logging.Memory, segmentClient)))
 		mux.Handle("/socket/", http.StripPrefix("/socket", websocket.NewWebsocketServer(machineClient)))
 		s := &http.Server{
-			Handler:      handlers.LoggingHandler(os.Stderr, mux),
-			ReadTimeout:  10 * time.Second,
-			WriteTimeout: 10 * time.Second,
+			Handler:           handlers.LoggingHandler(os.Stderr, mux),
+			ReadHeaderTimeout: 10 * time.Second,
 		}
 		if err := s.Serve(listener); err != nil {
 			errCh <- errors.Wrap(err, "api http.Serve failed")


### PR DESCRIPTION
Fixes #3600

the timeouts were added in b38b9ef2f020ee92370bf896e455a067087ff121 to fix golangci_lint errors, however since we have some long running operations such as '/start', '/stop' and '/delete' which takes more then 10 seconds to finish, it ends up with io error

this commit removes the ReadTimeout and WriteTimeout and instead set
the ReadHeaderTimeout for the server

setting ReadHeaderTimeout should prevent slowloris attacks as reported by golangci_lint
