### PR TITLE
Status: Remove local variable for cluster status result

### DIFF
--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -51,9 +51,6 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	}
 
 	if vmStatus != state.Running {
-		clusterStatusResult := &types.ClusterStatusResult{
-			CrcStatus: vmStatus,
-		}
 		return clusterStatusResult, nil
 	}
 


### PR DESCRIPTION
As part of 22addb71697a79f1368dec26ecdd810731087882 , we missed to remove the local variable which return only the vmstatus but not the preset info or state.

without this PR
```
 $ ./crc status -ojson
{
  "success": true,
  "crcStatus": "Stopped",
  "cacheUsage": 228490767105,
  "cacheDir": "/home/prkumar/.crc/cache",
  "preset": ""
}
13:41 $ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/status | jq .
{
  "CrcStatus": "Stopped",
  "OpenshiftStatus": "",
  "DiskUse": 0,
  "DiskSize": 0,
  "RAMUse": 0,
  "RAMSize": 0,
  "Preset": ""
}

```

