### PR TITLE
OKD preset added to GetBundleType

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -186,16 +186,11 @@ func (bundle *CrcBundleInfo) GetBundleNameWithoutExtension() string {
 }
 
 func (bundle *CrcBundleInfo) GetBundleType() crcPreset.Preset {
-	switch bundle.Type {
-	case "snc", "snc_custom":
-		return crcPreset.OpenShift
-	case "podman", "podman_custom":
-		return crcPreset.Podman
-	case "microshift", "microshift_custom":
-		return crcPreset.Microshift
-	default:
-		return crcPreset.OpenShift
+	bundleType := strings.TrimSuffix(bundle.Type, "_custom")
+	if bundleType == "snc" {
+		bundleType = "openshift"
 	}
+	return crcPreset.ParsePreset(bundleType)
 }
 
 func (bundle *CrcBundleInfo) IsOpenShift() bool {

--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -164,3 +164,25 @@ func TestCustomBundleName(t *testing.T) {
 	customBundleName = GetCustomBundleName(customBundleName)
 	checkBundleName(t, customBundleName)
 }
+
+func TestGetBundleType(t *testing.T) {
+	var bundle CrcBundleInfo
+	bundle.Type = "okd"
+	require.Equal(t, preset.OKD, bundle.GetBundleType())
+	bundle.Type = "okd_custom"
+	require.Equal(t, preset.OKD, bundle.GetBundleType())
+	bundle.Type = "microshift"
+	require.Equal(t, preset.Microshift, bundle.GetBundleType())
+	bundle.Type = "microshift_custom"
+	require.Equal(t, preset.Microshift, bundle.GetBundleType())
+	bundle.Type = "openshift"
+	require.Equal(t, preset.OpenShift, bundle.GetBundleType())
+	bundle.Type = "openshift_custom"
+	require.Equal(t, preset.OpenShift, bundle.GetBundleType())
+	bundle.Type = "snc"
+	require.Equal(t, preset.OpenShift, bundle.GetBundleType())
+	bundle.Type = "snc_custom"
+	require.Equal(t, preset.OpenShift, bundle.GetBundleType())
+	bundle.Type = ""
+	require.Equal(t, preset.OpenShift, bundle.GetBundleType())
+}


### PR DESCRIPTION
**Fixes:** Issue #3595 [BUG] Bundle logic not working as expected for the OKD preset

## Solution/Idea

Fix based on: https://github.com/crc-org/crc/issues/3595#issuecomment-1505078190.  
After testing locally on Windows 10 there are no needs to change function bundleMismatchWithPreset().

## Proposed changes

List main as well as consequential changes you introduced or had to introduce. 

1. Added posibility to get crcPreset OKD


## Testing
Was only tested by 'hand'.

