### PR TITLE
Status: Close ssh connection after requesting for service status

### DIFF
--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -157,6 +157,8 @@ func getMicroShiftStatus(vm *virtualMachine) types.OpenshiftStatus {
 		logging.Debugf("cannot get MicroShift status: %v", err)
 		return types.OpenshiftUnreachable
 	}
+	defer sshRunner.Close()
+
 	sd := systemd.NewInstanceSystemdCommander(sshRunner)
 	microShiftServiceState, err := sd.Status("microshift")
 	if err != nil {


### PR DESCRIPTION
Without this patch everytime when user execute `crc status` command there is a non terminated ssh connection stays. Same with when podman Desktop tray make API request and soon we have lot of sshd processes.

This PR make sure close the ssh connection after service status is received.
```
$  ps axu | grep sshd
root        2677  0.0  0.2  19920  9076 ?        Ss   01:17   0:00 sshd: core [priv]
core        2680  0.0  0.1  19920  5020 ?        S    01:17   0:00 sshd: core@pts/0
root        4372  0.0  0.2  19920  8416 ?        Ss   01:17   0:00 sshd: core [priv]
core        4375  0.0  0.1  19920  5028 ?        S    01:17   0:00 sshd: core@notty
root        4417  0.0  0.2  19920  9172 ?        Ss   01:17   0:00 sshd: core [priv]
core        4420  0.0  0.1  19920  4952 ?        S    01:17   0:00 sshd: core@notty
root        4449  0.0  0.2  19920  8424 ?        Ss   01:17   0:00 sshd: core [priv]
core        4452  0.0  0.1  19920  4952 ?        S    01:17   0:00 sshd: core@notty
root        4518  0.0  0.2  19920  8416 ?        Ss   01:17   0:00 sshd: core [priv]
core        4521  0.0  0.1  19920  4964 ?        S    01:17   0:00 sshd: core@notty
root        4543  0.0  0.2  19920  8276 ?        Ss   01:17   0:00 sshd: core [priv]
core        4546  0.0  0.1  19920  4960 ?        S    01:17   0:00 sshd: core@notty
root        4564  0.0  0.2  19920  8364 ?        Ss   01:17   0:00 sshd: core [priv]
core        4567  0.0  0.1  19920  5024 ?        S    01:17   0:00 sshd: core@notty
root        4589  0.0  0.2  19920  8364 ?        Ss   01:17   0:00 sshd: core [priv]
core        4592  0.0  0.1  19920  4896 ?        S    01:17   0:00 sshd: core@notty
root        4610  0.0  0.2  19920  8384 ?        Ss   01:18   0:00 sshd: core [priv]
core        4613  0.0  0.1  19920  4956 ?        S    01:18   0:00 sshd: core@notty
root        4678  0.0  0.2  19920  8364 ?        Ss   01:18   0:00 sshd: core [priv]
core        4686  0.0  0.1  19920  5060 ?        S    01:18   0:00 sshd: core@notty
root        4704  0.0  0.2  19920  8436 ?        Ss   01:18   0:00 sshd: core [priv]
core        4707  0.0  0.1  19920  5076 ?        S    01:18   0:00 sshd: core@notty
root        4729  0.0  0.2  19920  8364 ?        Ss   01:18   0:00 sshd: core [priv]
core        4732  0.0  0.1  19920  5056 ?        S    01:18   0:00 sshd: core@notty
root        4750  0.0  0.2  19920  8416 ?        Ss   01:18   0:00 sshd: core [priv]
core        4753  0.0  0.1  19920  4952 ?        S    01:18   0:00 sshd: core@notty
root        4775  0.0  0.2  19920  8376 ?        Ss   01:18   0:00 sshd: core [priv]
core        4778  0.0  0.1  19920  4896 ?        S    01:18   0:00 sshd: core@notty
root        4829  0.0  0.2  19920  9032 ?        Ss   01:18   0:00 sshd: core [priv]
```
