### PR TITLE
Bundle/Copy: Fix the kubeconfig copy for microshift bundle

### DIFF
--- a/pkg/crc/machine/bundle/copier.go
+++ b/pkg/crc/machine/bundle/copier.go
@@ -70,7 +70,7 @@ func (copier *Copier) CopyPrivateSSHKey(srcPath string) error {
 }
 
 func (copier *Copier) CopyKubeConfig() error {
-	if copier.srcBundle.IsOpenShift() {
+	if !copier.srcBundle.IsPodman() {
 		kubeConfigFileName := filepath.Base(copier.srcBundle.GetKubeConfigPath())
 		srcPath := copier.srcBundle.GetKubeConfigPath()
 		destPath := copier.resolvePath(kubeConfigFileName)


### PR DESCRIPTION
Only podman bundle doesn't have the kubeconfig so this PR switch the logic so that other preset make use of it.


