### PR TITLE
choco: ghci action to push choco package when a release is published

### DIFF
--- a/.github/workflows/choco-release.yml
+++ b/.github/workflows/choco-release.yml
@@ -1,0 +1,37 @@
+---
+name: Publish CRC choco to community feed
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    if: github.event.release.prerelease != true
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-2022
+        go:
+          - 1.19
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Build the chocolatey package
+        run: make choco
+      - name: Add api key for choco community feed
+        shell: pwsh
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+        run: choco apikey --key "$env:CHOCO_API_KEY" --source https://push.chocolatey.org/
+      - name: Push the choco to community.chocolatey.org
+        run: choco push ./packaging/chocolatey/crc/*.nupkg --source https://push.chocolatey.org/
+      - name: Upload nupkg artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: crc-chocolatey-nupkg-${{ github.event.release.tag_name }}
+          path: "./packaging/chocolatey/crc/*.nupkg"


### PR DESCRIPTION
this workflow will get triggered when a new release is published either newly created or from a draft release
