### PR TITLE
Fixes #3628 Remove memory check

### DIFF
--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -12,13 +12,6 @@
     <installation-check script="installCheck();"/>
     <script>
 function installCheck() {
-    if (9216000000 > system.sysctl('hw.memsize')) {
-        my.result.title = 'Too few memory installed';
-        my.result.message = 'Red Hat OpenShift Local requires at least 9GB of memory to run';
-        my.result.type = 'Fatal';
-        return false;
-    }
-
 	var apps = system.applications.fromIdentifier('com.redhat.codeready.containers');
 	if(apps) {
         my.result.title = 'Update failed';

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -16,9 +16,6 @@
         <Condition Message="Red Hat OpenShift Local requires the Windows 10 Fall Creators Update (version 1709) or newer.">
             <![CDATA[Installed OR (CURRENTBUILD > MINIMUMBUILD)]]>
         </Condition>
-        <Condition Message="Red Hat OpenShift Local requires at least 9GB of RAM to run. Aborting installation.">
-            <![CDATA[Installed OR (PhysicalMemory >= 9126)]]>
-        </Condition>
         <Property Id="WINDOWSEDITION" Secure="yes">
             <RegistrySearch Id="WindowsEditionReg" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="EditionID" Type="raw" />
         </Property>


### PR DESCRIPTION
**Fixes:** Issue #3628

## Solution/Idea

Removes the memory check, as this is incorrect for a 8GB macbook that is capable of running MicroShift (and podman).

## Proposed changes

Lowering the check makes this less relevant/meaningless; it says nothing about the ability in that case to run any of the supported presets. Any check needs to happen from the preset specific default values on startup, not installation.

1. Grab an 8GB macbook M1
2. Start the installer
3. ...

