### PR TITLE
Config: Make preset config aware of cpu/memory 

### DIFF
--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -191,6 +191,7 @@ func (h *Handler) SetConfig(c *context) error {
 	if len(multiError.Errors) != 0 {
 		return multiError
 	}
+	crcConfig.UpdateDefaults(h.Config)
 	return c.JSON(http.StatusOK, client.SetOrUnsetConfigResult{
 		Properties: successProps,
 	})
@@ -219,6 +220,7 @@ func (h *Handler) UnsetConfig(c *context) error {
 	if len(multiError.Errors) != 0 {
 		return multiError
 	}
+	crcConfig.UpdateDefaults(h.Config)
 	return c.JSON(http.StatusOK, client.SetOrUnsetConfigResult{
 		Properties: successProps,
 	})

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -95,6 +95,17 @@ func (c *Config) Set(key string, value interface{}) (string, error) {
 		return "", fmt.Errorf(invalidType, value, key)
 	}
 
+	// Make sure if user try to set same value which
+	// is default then just unset the value which
+	// anyway make it default and don't update it
+	// ~/.crc/crc.json (viper config) file.
+	if setting.defaultValue == castValue {
+		if _, err := c.Unset(key); err != nil {
+			return "", err
+		}
+		return "", nil
+	}
+
 	if setting.isSecret {
 		if err := c.secretStorage.Set(key, castValue); err != nil {
 			return "", err

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -115,13 +115,14 @@ func TestViperConfigLoadDefaultValue(t *testing.T) {
 		Value:     4,
 		IsDefault: true,
 	}, config.Get(cpus))
-
 	_, err = config.Set(cpus, 4)
 	assert.NoError(t, err)
 
 	bin, err := os.ReadFile(configFile)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"cpus":4}`, string(bin))
+	// Setting default value will not update
+	// write to the config so expected would be {}
+	assert.JSONEq(t, `{}`, string(bin))
 
 	assert.Equal(t, SettingValue{
 		Value:     4,


### PR DESCRIPTION
Preset property is bound with cpu/memory/bundle and have default
values for it but our `set` function doesn't have map around those
settings and a user can do following without any error message.
```
$ crc config set preset microshift
$ crc config set cpus 2
$ crc config set preset openshift
```
and when user try to perform `crc start` then error message shown.

With this PR we are making the set function bit self aware of the
preset and it's bound properties (cpu/memory) and make sure if those
property doesn't validated for the preset then unset those so default
values going to take over.

with this PR following now works as expected.
```
$ curl -X POST -d '{"properties":{"preset": "microshift"}}' --unix-socket ~/.crc/crc-http.sock http:/c/api/config
{"Properties":["preset"]}
$ curl -X POST -d '{"properties":{"cpus": "3"}}' --unix-socket ~/.crc/crc-http.sock http:/c/api/config
{"Properties":["cpus"]}
$ curl -X POST -d '{"properties":{"preset": "openshift"}}' --unix-socket ~/.crc/crc-http.sock http:/c/api/config
{"Properties":["preset"]}
$ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/config | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   894  100   894    0     0  56924      0 --:--:-- --:--:-- --:--:-- 59600
{
  "Configs": {
    "bundle": "/Users/prkumar/.crc/cache/crc_vfkit_4.12.13_arm64.crcbundle",
    "consent-telemetry": "no",
    "cpus": 4,
    "disable-update-check": true,
    "disk-size": 31,
    "enable-cluster-monitoring": false,
    "enable-experimental-features": false,
    "enable-shared-dirs": true,
    "host-network-access": false,
    "http-proxy": "",
    "https-proxy": "",
    "ingress-http-port": 80,
    "ingress-https-port": 443,
    "kubeadmin-password": "",
    "memory": 9216,

[...]
```