### PR TITLE
preflight: add check to see if admin-helper namedpipe is accessible

### DIFF
--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/crc-org/crc/pkg/crc/logging"
 
+	"github.com/crc-org/crc/pkg/crc/adminhelper"
 	winnet "github.com/crc-org/crc/pkg/os/windows/network"
 	"github.com/crc-org/crc/pkg/os/windows/powershell"
 
@@ -223,6 +224,14 @@ func checkIfAdminHelperServiceRunning() error {
 	}
 	if strings.TrimSpace(stdout) != "Running" {
 		return fmt.Errorf("%s service is not running", constants.AdminHelperServiceName)
+	}
+	return checkAdminHelperNamedPipeAccessible()
+}
+
+func checkAdminHelperNamedPipeAccessible() error {
+	client := adminhelper.Client()
+	if _, err := client.Version(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -118,7 +118,7 @@ var adminHelperServiceCheks = []Check{
 		configKeySuffix:  "check-admin-helper-service-running",
 		checkDescription: "Checking admin helper service is running",
 		check:            checkIfAdminHelperServiceRunning,
-		fixDescription:   "Make sure you installed crc using the Windows installer",
+		fixDescription:   "Make sure you installed crc using the Windows installer and performed required reboot",
 		flags:            NoFix,
 
 		labels: labels{Os: Windows},


### PR DESCRIPTION
currently we only check if the admin-helper service is running, but it could happen that the service is running but current user is not in the 'crc-users' group, in this case directly trying to access the admin-helper api is better


will be helpful for https://github.com/crc-org/crc-extension/issues/93