### PR TITLE
CrcBundleInfo's IsOpenShift() now considers OKD to also be OpenShift

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -199,7 +199,8 @@ func (bundle *CrcBundleInfo) GetBundleType() crcPreset.Preset {
 }
 
 func (bundle *CrcBundleInfo) IsOpenShift() bool {
-	return bundle.GetBundleType() == crcPreset.OpenShift
+	preset := bundle.GetBundleType()
+	return preset == crcPreset.OpenShift || preset == crcPreset.OKD
 }
 
 func (bundle *CrcBundleInfo) IsMicroshift() bool {


### PR DESCRIPTION
There are numerous places in the CRC code base that calls IsOpenShift() to run logic that is not intended for Podman setups or other more limited setups. Using the "okd" preset gives you something that is very close to the "openshift" preset.

CrcBundleInfo's IsOpenShift() now treats the "okd" preset as if it was OpenShift. This means we can avoid littering the code with checks for both OpenShift and OKD in a bunch of places, which also reduces the risk of forgetting to check for OKD.

**Fixes:** Issue #3635 

## Solution/Idea

Treat the "okd" preset as equivalent to "openshift" in CrcBundleInfo. This means the various bundle.IsOpenShift() checks throughout the CRC code base will also apply to OKD.

## Testing

Before the fix `crc start` fails with errors described in #3635. Run `stop` and `delete` on previous CRC installation, then `setup` and `start` using the newly compiled CRC.

1. `crc stop`
2. `crc delete`
3.  `~/go/bin/crc setup`
4. `~/go/bin/crc start --log-level debug`
5. Takes quite a while to start but does so eventually
6. `~/go/bin/crc status` shows both CRC VM and OpenShift as "Running"
7. `~/go/bin/crc console --url` and `~/go/bin/crc console --credentials` show expected information
