### PR TITLE
msi: enclose username in quotes in the command adding user to hyper-v admins groups

### DIFF
--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -100,7 +100,7 @@
         <CustomAction Id="InstallHyperv" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
         <SetProperty Action="CAAddUserToHypervAdminGroup"
             Id="AddUserToHypervAdminGroup"
-            Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Add-LocalGroupMember -Member [LogonUser] -SID S-1-5-32-578&quot;"
+            Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Add-LocalGroupMember -Member '[LogonUser]' -SID S-1-5-32-578&quot;"
             Before="AddUserToHypervAdminGroup"
             Sequence="execute"/>
         <CustomAction Id="AddUserToHypervAdminGroup" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />


### PR DESCRIPTION

if the username contains space the powershell command was failing and user was not added to the group


fixes #3658 