### PR TITLE
Improve 2 user-visible messages

### DIFF
--- a/pkg/crc/cluster/kubeadmin_password.go
+++ b/pkg/crc/cluster/kubeadmin_password.go
@@ -39,7 +39,7 @@ func UpdateKubeAdminUserPassword(ctx context.Context, ocConfig oc.Config, newPas
 
 	kubeAdminPassword, err := GetKubeadminPassword()
 	if err != nil {
-		return fmt.Errorf("Cannot generate the kubeadmin user password: %w", err)
+		return fmt.Errorf("Cannot read the kubeadmin user password from file: %w", err)
 	}
 	credentials := map[string]string{
 		"developer": "developer",

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -318,9 +318,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, err
 	}
 
-	if vm.bundle.IsOpenShift() {
-		logging.Infof("Starting CRC VM for %s %s...", startConfig.Preset, vm.bundle.GetOpenshiftVersion())
-	}
+	logging.Infof("Starting CRC VM for %s %s...", startConfig.Preset, vm.bundle.GetVersion())
 
 	if client.useVSock() {
 		if err := exposePorts(startConfig.Preset, startConfig.IngressHTTPPort, startConfig.IngressHTTPSPort); err != nil {


### PR DESCRIPTION
I noticed this while looking at okd-related issues. This improves one error message, and ensures we always print "Starting ... cluster".