### PR TITLE
config: Follow-ups to code resetting cpu/memory after preset change

### DIFF
--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -191,7 +191,6 @@ func (h *Handler) SetConfig(c *context) error {
 	if len(multiError.Errors) != 0 {
 		return multiError
 	}
-	crcConfig.UpdateDefaults(h.Config)
 	return c.JSON(http.StatusOK, client.SetOrUnsetConfigResult{
 		Properties: successProps,
 	})
@@ -220,7 +219,6 @@ func (h *Handler) UnsetConfig(c *context) error {
 	if len(multiError.Errors) != 0 {
 		return multiError
 	}
-	crcConfig.UpdateDefaults(h.Config)
 	return c.JSON(http.StatusOK, client.SetOrUnsetConfigResult{
 		Properties: successProps,
 	})

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -75,16 +75,6 @@ func (c *Config) validate(key string, value interface{}) error {
 	return nil
 }
 
-func (c *Config) revalidateSettingsValue(key string) error {
-	if err := c.validate(key, c.Get(key)); err != nil {
-		if _, err := c.Unset(key); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Set sets the value for a given config key
 func (c *Config) Set(key string, value interface{}) (string, error) {
 	setting, ok := c.settingsByName[key]
@@ -115,18 +105,6 @@ func (c *Config) Set(key string, value interface{}) (string, error) {
 		castValue = cast.ToString(value)
 	default:
 		return "", fmt.Errorf(invalidType, value, key)
-	}
-
-	// The `memory` and `cpus` values are preset-dependent.
-	// When they are lower than the preset requirements, this code
-	// automatically resets them to their default value.
-	if setting.Name == Preset {
-		if err := c.revalidateSettingsValue(Memory); err != nil {
-			return "", err
-		}
-		if err := c.revalidateSettingsValue(CPUs); err != nil {
-			return "", err
-		}
 	}
 
 	// Make sure if user try to set same value which

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -115,7 +115,7 @@ func (c *Config) Set(key string, value interface{}) (string, error) {
 		if _, err := c.Unset(key); err != nil {
 			return "", err
 		}
-		return "", nil
+		return c.settingsByName[key].callbackFn(key, castValue), nil
 	}
 
 	if setting.isSecret {

--- a/pkg/crc/config/secret_config_test.go
+++ b/pkg/crc/config/secret_config_test.go
@@ -15,8 +15,8 @@ const (
 func newTestConfigSecret() (*Config, error) {
 	cfg := New(NewEmptyInMemoryStorage(), NewEmptyInMemorySecretStorage())
 
-	cfg.AddSetting(password, Secret(""), ValidateString, SuccessfullyApplied, "")
-	cfg.AddSetting(secret, Secret("apples"), ValidateString, SuccessfullyApplied, "")
+	cfg.AddSetting(password, Secret(""), validateString, SuccessfullyApplied, "")
+	cfg.AddSetting(secret, Secret("apples"), validateString, SuccessfullyApplied, "")
 	return cfg, nil
 }
 

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -138,15 +138,7 @@ func RegisterSettings(cfg *Config) {
 }
 
 func presetChanged(cfg *Config, _ string, _ interface{}) {
-	// The `memory` and `cpus` values are preset-dependent.
-	// When they are lower than the preset requirements, this code
-	// automatically resets them to their default value.
-	if err := revalidateSettingsValue(cfg, Memory); err != nil {
-		logging.Debugf("error validating Memory config value: %v", err)
-	}
-	if err := revalidateSettingsValue(cfg, CPUs); err != nil {
-		logging.Debugf("error validating CPUs config value: %v", err)
-	}
+	UpdateDefaults(cfg)
 }
 
 func defaultCPUs(cfg Storage) int {
@@ -193,6 +185,16 @@ func revalidateSettingsValue(cfg *Config, key string) error {
 
 func UpdateDefaults(cfg *Config) {
 	RegisterSettings(cfg)
+
+	// The `memory` and `cpus` values are preset-dependent.
+	// When they are lower than the preset requirements, this code
+	// automatically resets them to their default value.
+	if err := revalidateSettingsValue(cfg, Memory); err != nil {
+		logging.Infof("failed to validate Memory setting: %v", err)
+	}
+	if err := revalidateSettingsValue(cfg, CPUs); err != nil {
+		logging.Infof("failed to validate CPUs setting: %v", err)
+	}
 }
 
 func BundleHelpMsg(cfg *Config) string {

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -70,7 +70,7 @@ func RegisterSettings(cfg *Config) {
 	}
 
 	// Preset setting should be on top because CPUs/Memory config depend on it.
-	cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteAndSetupMsg,
+	cfg.AddSetting(Preset, version.GetDefaultPreset().String(), validatePreset, RequiresDeleteAndSetupMsg,
 		fmt.Sprintf("Virtual machine preset (valid values are: %s)", preset.AllPresets()))
 	// Start command settings in config
 	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied, BundleHelpMsg(cfg))

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -46,16 +46,16 @@ func RegisterSettings(cfg *Config) {
 		return ValidateBool(value)
 	}
 
-	validateCPUs := func(value interface{}) (bool, string) {
-		return ValidateCPUs(value, GetPreset(cfg))
+	validCPUs := func(value interface{}) (bool, string) {
+		return validateCPUs(value, GetPreset(cfg))
 	}
 
-	validateMemory := func(value interface{}) (bool, string) {
-		return ValidateMemory(value, GetPreset(cfg))
+	validMemory := func(value interface{}) (bool, string) {
+		return validateMemory(value, GetPreset(cfg))
 	}
 
-	validateBundlePath := func(value interface{}) (bool, string) {
-		return ValidateBundlePath(value, GetPreset(cfg))
+	validBundlePath := func(value interface{}) (bool, string) {
+		return validateBundlePath(value, GetPreset(cfg))
 	}
 
 	validateSmbSharedDirs := func(value interface{}) (bool, string) {
@@ -73,16 +73,16 @@ func RegisterSettings(cfg *Config) {
 	cfg.AddSetting(Preset, version.GetDefaultPreset().String(), validatePreset, RequiresDeleteAndSetupMsg,
 		fmt.Sprintf("Virtual machine preset (valid values are: %s)", preset.AllPresets()))
 	// Start command settings in config
-	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied, BundleHelpMsg(cfg))
-	cfg.AddSetting(CPUs, defaultCPUs(cfg), validateCPUs, RequiresRestartMsg,
+	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validBundlePath, SuccessfullyApplied, BundleHelpMsg(cfg))
+	cfg.AddSetting(CPUs, defaultCPUs(cfg), validCPUs, RequiresRestartMsg,
 		fmt.Sprintf("Number of CPU cores (must be greater than or equal to '%d')", defaultCPUs(cfg)))
-	cfg.AddSetting(Memory, defaultMemory(cfg), validateMemory, RequiresRestartMsg,
+	cfg.AddSetting(Memory, defaultMemory(cfg), validMemory, RequiresRestartMsg,
 		fmt.Sprintf("Memory size in MiB (must be greater than or equal to '%d')", defaultMemory(cfg)))
-	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, ValidateDiskSize, RequiresRestartMsg,
+	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, validateDiskSize, RequiresRestartMsg,
 		fmt.Sprintf("Total size in GiB of the disk (must be greater than or equal to '%d')", constants.DefaultDiskSize))
-	cfg.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied,
+	cfg.AddSetting(NameServer, "", validateIPAddress, SuccessfullyApplied,
 		"IPv4 address of nameserver (string, like '1.1.1.1 or 8.8.8.8')")
-	cfg.AddSetting(PullSecretFile, "", ValidatePath, SuccessfullyApplied,
+	cfg.AddSetting(PullSecretFile, "", validatePath, SuccessfullyApplied,
 		fmt.Sprintf("Path of image pull secret (download from %s)", constants.CrcLandingPageURL))
 	cfg.AddSetting(DisableUpdateCheck, false, ValidateBool, SuccessfullyApplied,
 		"Disable update check (true/false, default: false)")
@@ -91,7 +91,7 @@ func RegisterSettings(cfg *Config) {
 
 	// Shared directories configs
 	if runtime.GOOS == "windows" {
-		cfg.AddSetting(SharedDirPassword, Secret(""), ValidateString, SuccessfullyApplied,
+		cfg.AddSetting(SharedDirPassword, Secret(""), validateString, SuccessfullyApplied,
 			"Password used while using CIFS/SMB file sharing (It is the password for the current logged in user)")
 
 		cfg.AddSetting(EnableSharedDirs, false, validateSmbSharedDirs, SuccessfullyApplied,
@@ -109,27 +109,27 @@ func RegisterSettings(cfg *Config) {
 	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, RequiresCleanupAndSetupMsg,
 		"Allow TCP/IP connections from the CRC VM to services running on the host (true/false, default: false)")
 	// Proxy Configuration
-	cfg.AddSetting(HTTPProxy, "", ValidateHTTPProxy, SuccessfullyApplied,
+	cfg.AddSetting(HTTPProxy, "", validateHTTPProxy, SuccessfullyApplied,
 		"HTTP proxy URL (string, like 'http://my-proxy.com:8443')")
-	cfg.AddSetting(HTTPSProxy, "", ValidateHTTPSProxy, SuccessfullyApplied,
+	cfg.AddSetting(HTTPSProxy, "", validateHTTPSProxy, SuccessfullyApplied,
 		"HTTPS proxy URL (string, like 'https://my-proxy.com:8443')")
-	cfg.AddSetting(NoProxy, "", ValidateNoProxy, SuccessfullyApplied,
+	cfg.AddSetting(NoProxy, "", validateNoProxy, SuccessfullyApplied,
 		"Hosts, ipv4 addresses or CIDR which do not use a proxy (string, comma-separated list such as '127.0.0.1,192.168.100.1/24')")
-	cfg.AddSetting(ProxyCAFile, "", ValidatePath, SuccessfullyApplied,
+	cfg.AddSetting(ProxyCAFile, "", validatePath, SuccessfullyApplied,
 		"Path to an HTTPS proxy certificate authority (CA)")
 
 	cfg.AddSetting(EnableClusterMonitoring, false, ValidateBool, SuccessfullyApplied,
 		"Enable cluster monitoring Operator (true/false, default: false)")
 
 	// Telemeter Configuration
-	cfg.AddSetting(ConsentTelemetry, "", ValidateYesNo, SuccessfullyApplied,
+	cfg.AddSetting(ConsentTelemetry, "", validateYesNo, SuccessfullyApplied,
 		"Consent to collection of anonymous usage data (yes/no)")
 
-	cfg.AddSetting(KubeAdminPassword, "", ValidateString, SuccessfullyApplied,
+	cfg.AddSetting(KubeAdminPassword, "", validateString, SuccessfullyApplied,
 		"User defined kubeadmin password")
-	cfg.AddSetting(IngressHTTPPort, constants.OpenShiftIngressHTTPPort, ValidatePort, RequiresHTTPPortChangeWarning,
+	cfg.AddSetting(IngressHTTPPort, constants.OpenShiftIngressHTTPPort, validatePort, RequiresHTTPPortChangeWarning,
 		fmt.Sprintf("HTTP port to use for OpenShift ingress/routes on the host (1024-65535, default: %d)", constants.OpenShiftIngressHTTPPort))
-	cfg.AddSetting(IngressHTTPSPort, constants.OpenShiftIngressHTTPSPort, ValidatePort, RequiresHTTPSPortChangeWarning,
+	cfg.AddSetting(IngressHTTPSPort, constants.OpenShiftIngressHTTPSPort, validatePort, RequiresHTTPSPortChangeWarning,
 		fmt.Sprintf("HTTPS port to use for OpenShift ingress/routes on the host (1024-65535, default: %d)", constants.OpenShiftIngressHTTPSPort))
 
 	if err := cfg.RegisterNotifier(Preset, presetChanged); err != nil {

--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -26,7 +26,7 @@ func validateMemoryNoPhysicalCheck(value interface{}, preset crcpreset.Preset) (
 }
 
 func newInMemoryConfig() (*Config, error) {
-	ValidateMemory = validateMemoryNoPhysicalCheck
+	validateMemory = validateMemoryNoPhysicalCheck
 	cfg := New(NewEmptyInMemoryStorage(), NewEmptyInMemorySecretStorage())
 
 	RegisterSettings(cfg)

--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/crc-org/crc/pkg/crc/constants"
+	crcpreset "github.com/crc-org/crc/pkg/crc/preset"
+	"github.com/crc-org/crc/pkg/crc/version"
+
+	"github.com/spf13/cast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// override for ValidateMemory in validations.go to disable the physical memory check
+func validateMemoryNoPhysicalCheck(value interface{}, preset crcpreset.Preset) (bool, string) {
+	v, err := cast.ToIntE(value)
+	if err != nil {
+		return false, fmt.Sprintf("requires integer value in MiB >= %d", constants.GetDefaultMemory(preset))
+	}
+	if v < constants.GetDefaultMemory(preset) {
+		return false, fmt.Sprintf("requires memory in MiB >= %d", constants.GetDefaultMemory(preset))
+	}
+	return true, ""
+}
+
+func newInMemoryConfig() (*Config, error) {
+	ValidateMemory = validateMemoryNoPhysicalCheck
+	cfg := New(NewEmptyInMemoryStorage(), NewEmptyInMemorySecretStorage())
+
+	RegisterSettings(cfg)
+
+	return cfg, nil
+}
+
+// Check that with the default preset, we cannot set less CPUs than the defaultCPUs
+// but that it is allowed with a different preset with less requirements (podman)
+func TestCPUsValidate(t *testing.T) {
+	cfg, err := newInMemoryConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     version.GetDefaultPreset().String(),
+		Invalid:   false,
+		IsDefault: true,
+		IsSecret:  false,
+	}, cfg.Get(Preset))
+
+	defaultCPUs := constants.GetDefaultCPUs(version.GetDefaultPreset())
+	_, err = cfg.Set(CPUs, defaultCPUs-1)
+	require.Error(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     defaultCPUs,
+		Invalid:   false,
+		IsDefault: true,
+		IsSecret:  false,
+	}, cfg.Get(CPUs))
+
+	_, err = cfg.Set(Preset, crcpreset.Podman)
+	require.NoError(t, err)
+	_, err = cfg.Set(CPUs, defaultCPUs-1)
+	require.NoError(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     defaultCPUs - 1,
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(CPUs))
+}
+
+// Check that when changing preset, invalid memory values are reset to their
+// default value
+func TestSetPreset(t *testing.T) {
+	cfg, err := newInMemoryConfig()
+	require.NoError(t, err)
+
+	_, err = cfg.Set(Preset, crcpreset.Podman)
+	require.NoError(t, err)
+	_, err = cfg.Set(Memory, 10000)
+	require.NoError(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     10000,
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(Memory))
+	_, err = cfg.Set(CPUs, 3)
+	require.NoError(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     3,
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(CPUs))
+
+	// Changing the preset to 'openshift' should reset the CPUs config value
+	_, err = cfg.Set(Preset, crcpreset.OpenShift)
+	require.NoError(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     10000,
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(Memory))
+	assert.Equal(t, SettingValue{
+		Value:     4,
+		Invalid:   false,
+		IsDefault: true,
+		IsSecret:  false,
+	}, cfg.Get(CPUs))
+}
+
+// Check that when unsetting preset, invalid memory values are reset to their
+// default value
+func TestUnsetPreset(t *testing.T) {
+	cfg, err := newInMemoryConfig()
+	require.NoError(t, err)
+
+	_, err = cfg.Set(Preset, crcpreset.Podman)
+	require.NoError(t, err)
+	_, err = cfg.Set(Memory, 10000)
+	require.NoError(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     10000,
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(Memory))
+	_, err = cfg.Set(CPUs, 3)
+	require.NoError(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     3,
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(CPUs))
+
+	// Unsetting the preset should reset the CPUs config value
+	_, err = cfg.Unset(Preset)
+	require.NoError(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     crcpreset.OpenShift.String(),
+		Invalid:   false,
+		IsDefault: true,
+		IsSecret:  false,
+	}, cfg.Get(Preset))
+	assert.Equal(t, SettingValue{
+		Value:     10000,
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(Memory))
+	assert.Equal(t, SettingValue{
+		Value:     4,
+		Invalid:   false,
+		IsDefault: true,
+		IsSecret:  false,
+	}, cfg.Get(CPUs))
+}

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -54,7 +54,8 @@ func ValidateCPUs(value interface{}, preset crcpreset.Preset) (bool, string) {
 }
 
 // ValidateMemory checks if provided memory is valid in the config
-func ValidateMemory(value interface{}, preset crcpreset.Preset) (bool, string) {
+// It's defined as a variable so that it can be overridden in tests to disable the physical memory check
+var ValidateMemory = func(value interface{}, preset crcpreset.Preset) (bool, string) {
 	v, err := cast.ToIntE(value)
 	if err != nil {
 		return false, fmt.Sprintf("requires integer value in MiB >= %d", constants.GetDefaultMemory(preset))

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -21,15 +21,15 @@ func ValidateBool(value interface{}) (bool, string) {
 	return true, ""
 }
 
-func ValidateString(value interface{}) (bool, string) {
+func validateString(value interface{}) (bool, string) {
 	if _, err := cast.ToStringE(value); err != nil {
 		return false, "must be a valid string"
 	}
 	return true, ""
 }
 
-// ValidateDiskSize checks if provided disk size is valid in the config
-func ValidateDiskSize(value interface{}) (bool, string) {
+// validateDiskSize checks if provided disk size is valid in the config
+func validateDiskSize(value interface{}) (bool, string) {
 	diskSize, err := cast.ToIntE(value)
 	if err != nil {
 		return false, fmt.Sprintf("could not convert '%s' to integer", value)
@@ -41,8 +41,8 @@ func ValidateDiskSize(value interface{}) (bool, string) {
 	return true, ""
 }
 
-// ValidateCPUs checks if provided cpus count is valid in the config
-func ValidateCPUs(value interface{}, preset crcpreset.Preset) (bool, string) {
+// validateCPUs checks if provided cpus count is valid in the config
+func validateCPUs(value interface{}, preset crcpreset.Preset) (bool, string) {
 	v, err := cast.ToIntE(value)
 	if err != nil {
 		return false, fmt.Sprintf("requires integer value >= %d", constants.GetDefaultCPUs(preset))
@@ -53,9 +53,9 @@ func ValidateCPUs(value interface{}, preset crcpreset.Preset) (bool, string) {
 	return true, ""
 }
 
-// ValidateMemory checks if provided memory is valid in the config
+// validateMemory checks if provided memory is valid in the config
 // It's defined as a variable so that it can be overridden in tests to disable the physical memory check
-var ValidateMemory = func(value interface{}, preset crcpreset.Preset) (bool, string) {
+var validateMemory = func(value interface{}, preset crcpreset.Preset) (bool, string) {
 	v, err := cast.ToIntE(value)
 	if err != nil {
 		return false, fmt.Sprintf("requires integer value in MiB >= %d", constants.GetDefaultMemory(preset))
@@ -66,55 +66,55 @@ var ValidateMemory = func(value interface{}, preset crcpreset.Preset) (bool, str
 	return true, ""
 }
 
-// ValidateBundlePath checks if the provided bundle path is valid
-func ValidateBundlePath(value interface{}, preset crcpreset.Preset) (bool, string) {
+// validateBundlePath checks if the provided bundle path is valid
+func validateBundlePath(value interface{}, preset crcpreset.Preset) (bool, string) {
 	if err := validation.ValidateBundlePath(cast.ToString(value), preset); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
 }
 
-// ValidateIP checks if provided IP is valid
-func ValidateIPAddress(value interface{}) (bool, string) {
+// validateIP checks if provided IP is valid
+func validateIPAddress(value interface{}) (bool, string) {
 	if err := validation.ValidateIPAddress(cast.ToString(value)); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
 }
 
-// ValidatePath checks if provided path is exist
-func ValidatePath(value interface{}) (bool, string) {
+// validatePath checks if provided path is exist
+func validatePath(value interface{}) (bool, string) {
 	if err := validation.ValidatePath(cast.ToString(value)); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
 }
 
-// ValidateHTTPProxy checks if given URI is valid for a HTTP proxy
-func ValidateHTTPProxy(value interface{}) (bool, string) {
+// validateHTTPProxy checks if given URI is valid for a HTTP proxy
+func validateHTTPProxy(value interface{}) (bool, string) {
 	if err := network.ValidateProxyURL(cast.ToString(value), false); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
 }
 
-// ValidateHTTPSProxy checks if given URI is valid for a HTTPS proxy
-func ValidateHTTPSProxy(value interface{}) (bool, string) {
+// validateHTTPSProxy checks if given URI is valid for a HTTPS proxy
+func validateHTTPSProxy(value interface{}) (bool, string) {
 	if err := network.ValidateProxyURL(cast.ToString(value), true); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
 }
 
-// ValidateNoProxy checks if the NoProxy string has the correct format
-func ValidateNoProxy(value interface{}) (bool, string) {
+// validateNoProxy checks if the NoProxy string has the correct format
+func validateNoProxy(value interface{}) (bool, string) {
 	if strings.Contains(cast.ToString(value), " ") {
 		return false, "NoProxy string can't contain spaces"
 	}
 	return true, ""
 }
 
-func ValidateYesNo(value interface{}) (bool, string) {
+func validateYesNo(value interface{}) (bool, string) {
 	if cast.ToString(value) == "yes" || cast.ToString(value) == "no" {
 		return true, ""
 	}
@@ -129,7 +129,7 @@ func validatePreset(value interface{}) (bool, string) {
 	return true, ""
 }
 
-func ValidatePort(value interface{}) (bool, string) {
+func validatePort(value interface{}) (bool, string) {
 	port, err := cast.ToUintE(value)
 	if err != nil {
 		return false, "Requires integer value in range of 1024-65535"

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -304,3 +304,26 @@ func TestTwoInstancesSetAndUnsetSameConfiguration(t *testing.T) {
 	assert.Equal(t, 4, config2.Get(cpus).Value)
 	assert.Equal(t, 4, config1.Get(cpus).Value)
 }
+
+func TestNotifier(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	var notified = false
+	err = config.RegisterNotifier(CPUs, func(config *Config, key string, value interface{}) {
+		notified = true
+		require.Equal(t, key, CPUs)
+		assert.Equal(t, SettingValue{
+			Value:     value,
+			IsDefault: false,
+		}, config.Get(cpus))
+
+	})
+	require.NoError(t, err)
+	_, err = config.Set(cpus, 5)
+	assert.NoError(t, err)
+	require.True(t, notified)
+}

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -327,3 +327,27 @@ func TestNotifier(t *testing.T) {
 	assert.NoError(t, err)
 	require.True(t, notified)
 }
+
+func TestCallbacks(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	callback, err := config.Set(cpus, 5)
+	require.NoError(t, err)
+	require.NotEmpty(t, callback)
+
+	callback, err = config.Unset(cpus)
+	require.NoError(t, err)
+	require.NotEmpty(t, callback)
+
+	callback, err = config.Set(cpus, 4)
+	require.NoError(t, err)
+	require.NotEmpty(t, callback)
+
+	callback, err = config.Unset(cpus)
+	require.NoError(t, err)
+	require.NotEmpty(t, callback)
+}

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -17,8 +17,8 @@ const (
 )
 
 func newTestConfig(configFile, envPrefix string) (*Config, error) {
-	validateCPUs := func(value interface{}) (bool, string) {
-		return ValidateCPUs(value, preset.OpenShift)
+	validCPUs := func(value interface{}) (bool, string) {
+		return validateCPUs(value, preset.OpenShift)
 	}
 	storage, err := NewViperStorage(configFile, envPrefix)
 	if err != nil {
@@ -27,8 +27,8 @@ func newTestConfig(configFile, envPrefix string) (*Config, error) {
 
 	secretStorage := NewEmptyInMemorySecretStorage()
 	config := New(storage, secretStorage)
-	config.AddSetting(cpus, 4, validateCPUs, RequiresRestartMsg, "")
-	config.AddSetting(nameServer, "", ValidateIPAddress, SuccessfullyApplied, "")
+	config.AddSetting(cpus, 4, validCPUs, RequiresRestartMsg, "")
+	config.AddSetting(nameServer, "", validateIPAddress, SuccessfullyApplied, "")
 	return config, nil
 }
 
@@ -142,14 +142,14 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "crc.json")
 
-	validateCPUs := func(value interface{}) (bool, string) {
-		return ValidateCPUs(value, preset.OpenShift)
+	validCPUs := func(value interface{}) (bool, string) {
+		return validateCPUs(value, preset.OpenShift)
 	}
 	storage, err := NewViperStorage(configFile, "CRC")
 	require.NoError(t, err)
 	config := New(storage, NewEmptyInMemorySecretStorage())
-	config.AddSetting(cpus, 4, validateCPUs, RequiresRestartMsg, "")
-	config.AddSetting(nameServer, "", ValidateIPAddress, SuccessfullyApplied, "")
+	config.AddSetting(cpus, 4, validCPUs, RequiresRestartMsg, "")
+	config.AddSetting(nameServer, "", validateIPAddress, SuccessfullyApplied, "")
 
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
 	flagSet.IntP(cpus, "c", 4, "")

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -35,6 +35,8 @@ var (
 	// will be true for releases on macos and windows
 	// will be false for git builds on macos and windows
 	installerBuild = "false"
+
+	defaultPreset = "openshift"
 )
 
 const (
@@ -139,4 +141,13 @@ func GetCRCLatestVersionFromMirror(transport http.RoundTripper) (*CrcReleaseInfo
 	}
 
 	return &releaseInfo, nil
+}
+
+func GetDefaultPreset() crcPreset.Preset {
+	preset, err := crcPreset.ParsePresetE(defaultPreset)
+	if err != nil {
+		// defaultPreset is set at compile-time, it should *never* be invalid
+		panic(fmt.Sprintf("Invalid compilet-time default preset '%s'", defaultPreset))
+	}
+	return preset
 }


### PR DESCRIPTION
The main goal of this patch series is to fix 2 bugs related to https://github.com/crc-org/crc/pull/3636 :
- cpu/memory are not checked when the preset is unset, only when they are set 
- the messages instructing the user to restart the VM are no longer printed if cpu/memory are set to their default value

This starts by refactoring the code a bit, and by adding a new RegisterNotifier API, and then this fixes the bugs.
This also adds unit tests for this new code/these bug fixes.

**Fixes:** Issue #3652, Issue #3663

**Relates to:** Issue #3637