### PR TITLE
Microshift: add disk resize functionality

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -15,7 +15,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/cluster"
 	"github.com/crc-org/crc/pkg/crc/constants"
 	crcerrors "github.com/crc-org/crc/pkg/crc/errors"
-	"github.com/crc-org/crc/pkg/crc/logging"
+	logging "github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/crc/machine/bundle"
 	"github.com/crc-org/crc/pkg/crc/machine/config"
 	"github.com/crc-org/crc/pkg/crc/machine/state"
@@ -117,26 +117,13 @@ func growRootFileSystem(sshRunner *crcssh.Runner, preset crcPreset.Preset) error
 	}
 	// With 4.7, this is quite a manual process until https://github.com/openshift/installer/pull/4746 gets fixed
 	// See https://github.com/crc-org/crc/issues/2104 for details
-	rootPart, _, err := sshRunner.Run("realpath", "/dev/disk/by-label/root")
+	rootPart, err := getrootPartition(sshRunner, "/dev/disk/by-label/root")
 	if err != nil {
 		return err
 	}
-	rootPart = strings.TrimSpace(rootPart)
-	if !strings.HasPrefix(rootPart, "/dev/vda") && !strings.HasPrefix(rootPart, "/dev/sda") {
-		return fmt.Errorf("Unexpected root device: %s", rootPart)
-	}
-	// with '/dev/[sv]da4' as input, run 'growpart /dev/[sv]da 4'
-	if _, _, err := sshRunner.RunPrivileged(fmt.Sprintf("Growing %s partition", rootPart), "/usr/bin/growpart", rootPart[:len("/dev/.da")], rootPart[len(rootPart)-1:]); err != nil {
-		var exitErr *ssh.ExitError
-		if !errors.As(err, &exitErr) {
-			return err
-		}
-		if exitErr.ExitStatus() != 1 {
-			return err
-		}
 
-		logging.Debugf("No free space after %s, nothing to do", rootPart)
-		return nil
+	if err := runGrowpart(sshRunner, rootPart); err != nil {
+		return err
 	}
 
 	logging.Infof("Resizing %s filesystem", rootPart)
@@ -147,6 +134,33 @@ func growRootFileSystem(sshRunner *crcssh.Runner, preset crcPreset.Preset) error
 		return err
 	}
 
+	return nil
+}
+
+func getrootPartition(sshRunner *crcssh.Runner, label string) (string, error) {
+	rootPart, _, err := sshRunner.Run("realpath", label)
+	if err != nil {
+		return "", err
+	}
+	rootPart = strings.TrimSpace(rootPart)
+	if !strings.HasPrefix(rootPart, "/dev/vda") && !strings.HasPrefix(rootPart, "/dev/sda") {
+		return "", fmt.Errorf("Unexpected root device: %s", rootPart)
+	}
+	return rootPart, nil
+}
+
+func runGrowpart(sshRunner *crcssh.Runner, rootPart string) error {
+	// with '/dev/[sv]da4' as input, run 'growpart /dev/[sv]da 4'
+	if _, _, err := sshRunner.RunPrivileged(fmt.Sprintf("Growing %s partition", rootPart), "/usr/bin/growpart", rootPart[:len("/dev/.da")], rootPart[len(rootPart)-1:]); err != nil {
+		var exitErr *ssh.ExitError
+		if !errors.As(err, &exitErr) {
+			return err
+		}
+		if exitErr.ExitStatus() != 1 {
+			return err
+		}
+		logging.Debugf("No free space after %s, nothing to do", rootPart)
+	}
 	return nil
 }
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -112,8 +112,7 @@ func (client *client) updateVMConfig(startConfig types.StartConfig, vm *virtualM
 
 func growRootFileSystem(sshRunner *crcssh.Runner, preset crcPreset.Preset) error {
 	if preset == crcPreset.Microshift {
-		logging.Debugf("growRootFileSystem does not support LVM which is used by %s images", preset)
-		return nil
+		return growLVForMicroshift(sshRunner)
 	}
 	// With 4.7, this is quite a manual process until https://github.com/openshift/installer/pull/4746 gets fixed
 	// See https://github.com/crc-org/crc/issues/2104 for details
@@ -160,6 +159,53 @@ func runGrowpart(sshRunner *crcssh.Runner, rootPart string) error {
 			return err
 		}
 		logging.Debugf("No free space after %s, nothing to do", rootPart)
+	}
+	return nil
+}
+
+func growLVForMicroshift(sshRunner *crcssh.Runner) error {
+	rootPart, _, err := sshRunner.RunPrivileged("Get PV disk path", "/usr/sbin/pvs", "-S", "lv_name=root", "-o", "pv_name", "--noheadings")
+	if err != nil {
+		return err
+	}
+	rootPart = strings.TrimSpace(rootPart)
+	if err := runGrowpart(sshRunner, rootPart); err != nil {
+		return err
+	}
+
+	if _, _, err := sshRunner.RunPrivileged("Resizing the physical volume(PV)", "/usr/sbin/pvresize", rootPart); err != nil {
+		return err
+	}
+
+	// Get the size of volume group
+	sizeVG, _, err := sshRunner.RunPrivileged("Get the volume group size", "/usr/sbin/vgs", "--noheadings", "--nosuffix", "--units", "b", "-o", "vg_size")
+	if err != nil {
+		return err
+	}
+	vgSize, err := strconv.Atoi(strings.TrimSpace(sizeVG))
+	if err != nil {
+		return err
+	}
+
+	// Get the size of root lv
+	sizeLV, _, err := sshRunner.RunPrivileged("Get the size of root logical volume", "/usr/sbin/lvs", "-S", "lv_name=root", "--noheadings", "--nosuffix", "--units", "b", "-o", "lv_size")
+	if err != nil {
+		return err
+	}
+	lvSize, err := strconv.Atoi(strings.TrimSpace(sizeLV))
+	if err != nil {
+		return err
+	}
+
+	// vgFree space as part of the bundle is default to ~15.02G (16127098880 byte)
+	vgFree := 16127098880
+	expectedLVSize := vgSize - vgFree
+	sizeToIncrease := expectedLVSize - lvSize
+	if sizeToIncrease > 1 {
+		logging.Info("Extending and resizing '/dev/rhel/root' logical volume")
+		if _, _, err := sshRunner.RunPrivileged("Extending and resizing the logical volume(LV)", "/usr/sbin/lvextend", "-r", "-L", fmt.Sprintf("+%db", sizeToIncrease), "/dev/rhel/root"); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The way this PR works is in following steps
- It grows the disk size usign growpart command
- Resize the physical volume
- Make sure that volume group where `/sysroot` mounted and free space which is going to used by LVMS for persistant volume (pv) creation use equal disk size during the resizing because after `pvresize` all the space goes as free space.


