### PR TITLE
fix choco github ci job

### DIFF
--- a/.github/workflows/choco-release.yml
+++ b/.github/workflows/choco-release.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Build the chocolatey package
+        shell: powershell
         run: make choco
       - name: Add api key for choco community feed
-        shell: pwsh
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
         run: choco apikey --key "$env:CHOCO_API_KEY" --source https://push.chocolatey.org/

--- a/.github/workflows/choco-release.yml
+++ b/.github/workflows/choco-release.yml
@@ -29,7 +29,11 @@ jobs:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
         run: choco apikey --key "$env:CHOCO_API_KEY" --source https://push.chocolatey.org/
       - name: Push the choco to community.chocolatey.org
-        run: choco push ./packaging/chocolatey/crc/*.nupkg --source https://push.chocolatey.org/
+        shell: bash
+        run: |
+          CRC_VERSION=${{ github.event.release.tag_name }}
+          CRC_VERSION=${CRC_VERSION:1}
+          choco push ./packaging/chocolatey/crc/crc.$CRC_VERSION.nupkg --source https://push.chocolatey.org/
       - name: Upload nupkg artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/windows-chocolatey.yml
+++ b/.github/workflows/windows-chocolatey.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Build the chocolatey package
+        shell: powershell
         run: make choco
       - name: Upload nupkg artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This fixes the issue seen in: https://github.com/crc-org/crc/actions/runs/5013245459/jobs/8986110758

```
  choco push ./packaging/chocolatey/crc/*.nupkg --source https://push.chocolatey.org/
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
Chocolatey v1.3.1
File specified is either not found or not a .nupkg file. './packaging/chocolatey/crc/*.nupkg'
Error: Process completed with exit code 1.
```