### PR TITLE
bug-3635 fix generating kubeadmin-password for OKD preset

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -681,7 +681,7 @@ func createHost(machineConfig config.MachineConfig, preset crcPreset.Preset) err
 	if err := crcssh.GenerateSSHKey(constants.GetPrivateKeyPath()); err != nil {
 		return fmt.Errorf("Error generating ssh key pair: %v", err)
 	}
-	if preset == crcPreset.OpenShift {
+	if preset == crcPreset.OpenShift || preset == crcPreset.OKD {
 		if err := cluster.GenerateKubeAdminUserPassword(); err != nil {
 			return errors.Wrap(err, "Error generating new kubeadmin password")
 		}


### PR DESCRIPTION
**Fixes:** Issue #3635 

## Solution/Idea

To generate the kubeadmin-password file because it is missing which is causing the bug

## Proposed changes

After investigating I noticed there is a function that created the file but only for the OpenShift prefix.
Adding the OKD to it solved the issue.
This may be further improved if in the future that distinction will go away, for now this seems like a straight forward fix.

## Testing

We need to test if the OKD 4.12 cluster start attempt does not fail on the missing kubeadmin_password file.

Clean:
1. crc delete -f
2. crc cleanup
Set prefix:
3. crc config set preset okd

3. crc setup
4. crc start --log-level debug

Note : I have an issue that I had before that does seem unrelated to my PR, this issue was already present in the branch, but is not present in the 2.19 binary that is in public release.
It might be a bug that is introduced in the current branch, I get : 

```
Temporary error: ssh command error:
command : timeout 5s oc get nodes --context admin --cluster crc --kubeconfig /opt/kubeconfig
err     : Process exited with status 1
```

Again, this change did not affect that behaviour but needs to be verified.
