### PR TITLE
e2e: Add minimal user story

### DIFF
--- a/test/e2e/features/minimal.feature
+++ b/test/e2e/features/minimal.feature
@@ -1,0 +1,18 @@
+@minimal @darwin @linux @windows
+Feature: Minimal user story
+
+    User starts CRC cluster and checks status.
+
+    @cleanup
+    Scenario Outline: Start OpenShift cluster:
+        Given setting config property "preset" to value "<preset-value>" succeeds
+        And executing single crc setup command succeeds
+        And starting CRC with default bundle succeeds
+        Then checking that CRC is running
+
+        Examples:
+            | preset-value |
+            | podman       |
+            | microshift   |
+            | openshift    |
+


### PR DESCRIPTION
On environments with very limited resources (e.g. current arrangement for M1), standard e2e and integration don't run as expected. This provides a compact minimal scenario to use in those cases.

For each preset (`podman`, `microshift`, `openshift`), do a basic user cycle:
1. Setup
2. Start
3. Check status

**Note:**
This should probably not be included in CIs as it only does a strict subset of actions contained in other tests, but increases execution time.