### PR TITLE
[WIP] Set emergency login for core user

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -78,6 +78,8 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		IngressHTTPPort:   config.Get(crcConfig.IngressHTTPPort).AsUInt(),
 		IngressHTTPSPort:  config.Get(crcConfig.IngressHTTPSPort).AsUInt(),
 		EnableSharedDirs:  config.Get(crcConfig.EnableSharedDirs).AsBool(),
+
+		EmergencyLogin: config.Get(crcConfig.EmergencyLogin).AsBool(),
 	}
 
 	client := newMachine()

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -34,6 +34,7 @@ const (
 	SharedDirPassword       = "shared-dir-password" // #nosec G101
 	IngressHTTPPort         = "ingress-http-port"
 	IngressHTTPSPort        = "ingress-https-port"
+	EmergencyLogin          = "enable-emergency-login"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -88,6 +89,8 @@ func RegisterSettings(cfg *Config) {
 		"Disable update check (true/false, default: false)")
 	cfg.AddSetting(ExperimentalFeatures, false, ValidateBool, SuccessfullyApplied,
 		"Enable experimental features (true/false, default: false)")
+	cfg.AddSetting(EmergencyLogin, false, ValidateBool, SuccessfullyApplied,
+		"Enable emergency login for 'core' user. Password set to 'rescue' (true/false, default: false)")
 
 	// Shared directories configs
 	if runtime.GOOS == "windows" {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -360,6 +360,13 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 	logging.Info("CRC VM is running")
 
+	// VM started and SSH available, so we can enable the emergency login
+	if startConfig.EmergencyLogin {
+		if err := enableEmergencyLogin(sshRunner); err != nil {
+			return nil, errors.Wrap(err, "Error enabling emergency login")
+		}
+	}
+
 	// Post VM start immediately update SSH key and copy kubeconfig to instance
 	// dir and VM
 	if err := updateSSHKeyPair(sshRunner); err != nil {
@@ -725,6 +732,12 @@ func addNameServerToInstance(sshRunner *crcssh.Runner, ns string) error {
 		return network.AddNameserversToInstance(sshRunner, nameservers)
 	}
 	return nil
+}
+
+func enableEmergencyLogin(sshRunner *crcssh.Runner) error {
+
+	_, _, err := sshRunner.Run("echo rescue | sudo passwd core --stdin")
+	return err
 }
 
 func updateSSHKeyPair(sshRunner *crcssh.Runner) error {

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -37,6 +37,9 @@ type StartConfig struct {
 	// Ports to access openshift routes
 	IngressHTTPPort  uint
 	IngressHTTPSPort uint
+
+	// Enable emergency login
+	EmergencyLogin bool
 }
 
 type ClusterConfig struct {


### PR DESCRIPTION
**Fixes:** #3677

## Solution/Idea
Performs a `passwd` for the `core` user as soon as the VM is reachable, comparable to running the command: 

```
PS> ssh -i c:\users\gbraad\.crc\machines\crc\id_ecdsa core@localhost -p 2222 -C "echo rescue | sudo passwd core --stdin"  
Changing password for user core.
```

The password is fixed to `rescue`.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. `crc config set enable-emergency-login true`
2. `crc start`
3. open the console and login using: core, rescue

![image](https://github.com/crc-org/crc/assets/1894/b4ef9765-e770-43eb-81a1-e6b0ec54eb7e)
