### PR TITLE
Add helper download.InMemory for downloading files without writing to disk

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -15,7 +15,7 @@ import (
 	crcErr "github.com/crc-org/crc/pkg/crc/errors"
 	"github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/crc/machine"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/preflight"
 	"github.com/crc-org/crc/pkg/crc/segment"
 	"github.com/crc-org/crc/pkg/crc/telemetry"
@@ -60,7 +60,7 @@ func init() {
 	}
 
 	// Initiate segment client
-	if segmentClient, err = segment.NewClient(config, network.HTTPTransport()); err != nil {
+	if segmentClient, err = segment.NewClient(config, httpproxy.HTTPTransport()); err != nil {
 		logging.Fatal(err.Error())
 	}
 
@@ -132,7 +132,7 @@ func setProxyDefaults() error {
 	noProxy := config.Get(crcConfig.NoProxy).AsString()
 	proxyCAFile := config.Get(crcConfig.ProxyCAFile).AsString()
 
-	proxyConfig, err := network.NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile)
+	proxyConfig, err := httpproxy.NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -19,6 +19,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/crc/machine/types"
 	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/preflight"
 	"github.com/crc-org/crc/pkg/crc/preset"
 	"github.com/crc-org/crc/pkg/crc/validation"
@@ -211,7 +212,7 @@ func checkIfNewVersionAvailable(noUpdateCheck bool) error {
 }
 
 func newVersionAvailable() (bool, string, string, error) {
-	release, err := crcversion.GetCRCLatestVersionFromMirror(network.HTTPTransport())
+	release, err := crcversion.GetCRCLatestVersionFromMirror(httpproxy.HTTPTransport())
 	if err != nil {
 		return false, "", "", err
 	}

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -16,7 +16,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/errors"
 	"github.com/crc-org/crc/pkg/crc/logging"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/oc"
 	"github.com/crc-org/crc/pkg/crc/ssh"
 	crctls "github.com/crc-org/crc/pkg/crc/tls"
@@ -322,7 +322,7 @@ func EnsureClusterIDIsNotEmpty(ctx context.Context, ocConfig oc.Config) error {
 	return nil
 }
 
-func AddProxyConfigToCluster(ctx context.Context, sshRunner *ssh.Runner, ocConfig oc.Config, proxy *network.ProxyConfig) error {
+func AddProxyConfigToCluster(ctx context.Context, sshRunner *ssh.Runner, ocConfig oc.Config, proxy *httpproxy.ProxyConfig) error {
 	type trustedCA struct {
 		Name string `json:"name"`
 	}
@@ -372,7 +372,7 @@ func AddProxyConfigToCluster(ctx context.Context, sshRunner *ssh.Runner, ocConfi
 	return nil
 }
 
-func addProxyCACertToCluster(sshRunner *ssh.Runner, ocConfig oc.Config, proxy *network.ProxyConfig, trustedCAName string) error {
+func addProxyCACertToCluster(sshRunner *ssh.Runner, ocConfig oc.Config, proxy *httpproxy.ProxyConfig, trustedCAName string) error {
 	proxyConfigMapFileName := fmt.Sprintf("/tmp/%s.json", trustedCAName)
 	proxyCABundleTemplate := `{
   "apiVersion": "v1",
@@ -476,7 +476,7 @@ func DeleteOpenshiftAPIServerPods(ctx context.Context, ocConfig oc.Config) error
 	return errors.Retry(ctx, 60*time.Second, deleteOpenshiftAPIServerPods, time.Second)
 }
 
-func CheckProxySettingsForOperator(ocConfig oc.Config, proxy *network.ProxyConfig, deployment, namespace string) (bool, error) {
+func CheckProxySettingsForOperator(ocConfig oc.Config, proxy *httpproxy.ProxyConfig, deployment, namespace string) (bool, error) {
 	if !proxy.IsEnabled() {
 		logging.Debugf("No proxy in use")
 		return true, nil

--- a/pkg/crc/cluster/status.go
+++ b/pkg/crc/cluster/status.go
@@ -6,11 +6,11 @@ import (
 	"time"
 
 	"github.com/crc-org/crc/pkg/crc/logging"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 )
 
 // WaitForClusterStable checks that the cluster is running a number of consecutive times
-func WaitForClusterStable(ctx context.Context, ip string, kubeconfigFilePath string, proxy *network.ProxyConfig) error {
+func WaitForClusterStable(ctx context.Context, ip string, kubeconfigFilePath string, proxy *httpproxy.ProxyConfig) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/crc-org/crc/pkg/crc/constants"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	crcpreset "github.com/crc-org/crc/pkg/crc/preset"
 	"github.com/crc-org/crc/pkg/crc/validation"
 	"github.com/spf13/cast"
@@ -92,7 +92,7 @@ func validatePath(value interface{}) (bool, string) {
 
 // validateHTTPProxy checks if given URI is valid for a HTTP proxy
 func validateHTTPProxy(value interface{}) (bool, string) {
-	if err := network.ValidateProxyURL(cast.ToString(value), false); err != nil {
+	if err := httpproxy.ValidateProxyURL(cast.ToString(value), false); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
@@ -100,7 +100,7 @@ func validateHTTPProxy(value interface{}) (bool, string) {
 
 // validateHTTPSProxy checks if given URI is valid for a HTTPS proxy
 func validateHTTPSProxy(value interface{}) (bool, string) {
-	if err := network.ValidateProxyURL(cast.ToString(value), true); err != nil {
+	if err := httpproxy.ValidateProxyURL(cast.ToString(value), true); err != nil {
 		return false, err.Error()
 	}
 	return true, ""

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -18,7 +18,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/gpg"
 	"github.com/crc-org/crc/pkg/crc/image"
 	"github.com/crc-org/crc/pkg/crc/logging"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	crcPreset "github.com/crc-org/crc/pkg/crc/preset"
 	"github.com/crc-org/crc/pkg/download"
 )
@@ -301,7 +301,7 @@ func getBundleDownloadInfo(preset crcPreset.Preset) (*download.RemoteFile, error
 func getDefaultBundleVerifiedHash(preset crcPreset.Preset) (string, error) {
 	client := &http.Client{
 		Timeout:   5 * time.Second,
-		Transport: network.HTTPTransport(),
+		Transport: httpproxy.HTTPTransport(),
 	}
 	res, err := client.Get(constants.GetDefaultBundleSignedHashURL(preset))
 	if err != nil {

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/crc-org/crc/pkg/crc/machine/state"
 	"github.com/crc-org/crc/pkg/crc/machine/types"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/preset"
 )
 
@@ -55,7 +55,7 @@ func (c *Client) GetConsoleURL() (*types.ConsoleResult, error) {
 	}, nil
 }
 
-func (c *Client) GetProxyConfig(machineName string) (*network.ProxyConfig, error) {
+func (c *Client) GetProxyConfig(machineName string) (*httpproxy.ProxyConfig, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -8,7 +8,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/machine/bundle"
 	"github.com/crc-org/crc/pkg/crc/machine/types"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/libmachine"
 	"github.com/crc-org/machine/libmachine/drivers"
 )
@@ -17,7 +17,7 @@ func getClusterConfig(bundleInfo *bundle.CrcBundleInfo) (*types.ClusterConfig, e
 	if !bundleInfo.IsOpenShift() {
 		return &types.ClusterConfig{
 			ClusterType: bundleInfo.GetBundleType(),
-			ProxyConfig: &network.ProxyConfig{},
+			ProxyConfig: &httpproxy.ProxyConfig{},
 		}, nil
 	}
 
@@ -65,8 +65,8 @@ func createLibMachineClient() (libmachine.API, func()) {
 	}
 }
 
-func getProxyConfig(bundleInfo *bundle.CrcBundleInfo) (*network.ProxyConfig, error) {
-	proxy, err := network.NewProxyConfig()
+func getProxyConfig(bundleInfo *bundle.CrcBundleInfo) (*httpproxy.ProxyConfig, error) {
+	proxy, err := httpproxy.NewProxyConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -21,6 +21,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/machine/state"
 	"github.com/crc-org/crc/pkg/crc/machine/types"
 	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/oc"
 	"github.com/crc-org/crc/pkg/crc/podman"
 	crcPreset "github.com/crc-org/crc/pkg/crc/preset"
@@ -761,7 +762,7 @@ func copyKubeconfigFileWithUpdatedUserClientCertAndKey(selfSignedCAKey *rsa.Priv
 	return updateClientCrtAndKeyToKubeconfig(clientKey, clientCert, srcKubeConfigPath, dstKubeConfigPath)
 }
 
-func configurePodmanProxy(ctx context.Context, sshRunner *crcssh.Runner, proxy *network.ProxyConfig) (err error) {
+func configurePodmanProxy(ctx context.Context, sshRunner *crcssh.Runner, proxy *httpproxy.ProxyConfig) (err error) {
 	if !proxy.IsEnabled() {
 		return nil
 	}
@@ -813,7 +814,7 @@ func configurePodmanProxy(ctx context.Context, sshRunner *crcssh.Runner, proxy *
 
 }
 
-func ensureProxyIsConfiguredInOpenShift(ctx context.Context, ocConfig oc.Config, sshRunner *crcssh.Runner, proxy *network.ProxyConfig) (err error) {
+func ensureProxyIsConfiguredInOpenShift(ctx context.Context, ocConfig oc.Config, sshRunner *crcssh.Runner, proxy *httpproxy.ProxyConfig) (err error) {
 	if !proxy.IsEnabled() {
 		return nil
 	}
@@ -821,7 +822,7 @@ func ensureProxyIsConfiguredInOpenShift(ctx context.Context, ocConfig oc.Config,
 	return cluster.AddProxyConfigToCluster(ctx, sshRunner, ocConfig, proxy)
 }
 
-func waitForProxyPropagation(ctx context.Context, ocConfig oc.Config, proxyConfig *network.ProxyConfig) {
+func waitForProxyPropagation(ctx context.Context, ocConfig oc.Config, proxyConfig *httpproxy.ProxyConfig) {
 	if !proxyConfig.IsEnabled() {
 		return
 	}

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -3,7 +3,7 @@ package types
 import (
 	"github.com/crc-org/crc/pkg/crc/cluster"
 	"github.com/crc-org/crc/pkg/crc/machine/state"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/preset"
 	crcpreset "github.com/crc-org/crc/pkg/crc/preset"
 )
@@ -46,7 +46,7 @@ type ClusterConfig struct {
 	KubeAdminPass string
 	ClusterAPI    string
 	WebConsoleURL string
-	ProxyConfig   *network.ProxyConfig
+	ProxyConfig   *httpproxy.ProxyConfig
 }
 
 type StartResult struct {

--- a/pkg/crc/network/httpproxy/proxy.go
+++ b/pkg/crc/network/httpproxy/proxy.go
@@ -1,4 +1,4 @@
-package network
+package httpproxy
 
 import (
 	"crypto/tls"

--- a/pkg/crc/network/httpproxy/proxy_test.go
+++ b/pkg/crc/network/httpproxy/proxy_test.go
@@ -1,4 +1,4 @@
-package network
+package httpproxy
 
 import (
 	"testing"

--- a/pkg/crc/network/httpproxy/utils.go
+++ b/pkg/crc/network/httpproxy/utils.go
@@ -1,4 +1,4 @@
-package network
+package httpproxy
 
 import (
 	"fmt"

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -18,7 +18,7 @@ import (
 	crcConfig "github.com/crc-org/crc/pkg/crc/config"
 	"github.com/crc-org/crc/pkg/crc/constants"
 	"github.com/crc-org/crc/pkg/crc/logging"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/telemetry"
 	"github.com/crc-org/crc/pkg/crc/version"
 	crcos "github.com/crc-org/crc/pkg/os"
@@ -216,7 +216,7 @@ func addConfigTraits(c *crcConfig.Config, in analytics.Traits) analytics.Traits 
 }
 
 func isProxyUsed() bool {
-	proxyConfig, err := network.NewProxyConfig()
+	proxyConfig, err := httpproxy.NewProxyConfig()
 	if err != nil {
 		return false
 	}

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/errors"
 	"github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/services"
 	"github.com/crc-org/crc/pkg/crc/systemd"
 	"github.com/crc-org/crc/pkg/crc/systemd/states"
@@ -114,10 +115,10 @@ func CheckCRCLocalDNSReachable(ctx context.Context, serviceConfig services.Servi
 func CheckCRCPublicDNSReachable(serviceConfig services.ServicePostStartConfig) (string, error) {
 	// This does not query DNS directly to account for corporate environment where external DNS resolution
 	// may only be done on the host running the http(s) proxies used for internet connectivity
-	proxyConfig, err := network.NewProxyConfig()
+	proxyConfig, err := httpproxy.NewProxyConfig()
 	if err != nil {
 		// try without using proxy
-		proxyConfig = &network.ProxyConfig{}
+		proxyConfig = &httpproxy.ProxyConfig{}
 	}
 	curlArgs := []string{"--head", publicDNSQueryURI}
 	if proxyConfig.IsEnabled() {

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/crc-org/crc/pkg/crc/logging"
-	"github.com/crc-org/crc/pkg/crc/network"
+	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/os/terminal"
 
 	"github.com/cavaliergopher/grab/v3"
@@ -61,7 +61,7 @@ func Download(uri, destination string, mode os.FileMode, sha256sum []byte) (stri
 	logging.Debugf("Downloading %s to %s", uri, destination)
 
 	client := grab.NewClient()
-	client.HTTPClient = &http.Client{Transport: network.HTTPTransport()}
+	client.HTTPClient = &http.Client{Transport: httpproxy.HTTPTransport()}
 	req, err := grab.NewRequest(destination, uri)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to get request from %s", uri)


### PR DESCRIPTION
this helper is put in a separate package pkg/download/inmemory to avoid import cycles which occurs due to the network package being imported in the pkg/download package, the cycle is network->ssh->constants->version as a result we'll not be able to import pkg/download in pkg/crc/version

currently the helper is used for downloading release-info.json file and the signed bundle hashes file sha256sum.txt.sig


