### PR TITLE
config: Return exit code 0 when getting default value

### DIFF
--- a/cmd/crc/cmd/config/get.go
+++ b/cmd/crc/cmd/config/get.go
@@ -28,10 +28,10 @@ func configGetCmd(config config.Storage) *cobra.Command {
 			telemetry.SetConfigurationKey(cmd.Context(), args[0])
 
 			if v.IsDefault {
-				return fmt.Errorf("Configuration property '%s' is not set. Default value is '%s'", key, v.AsString())
-
+				fmt.Printf("Configuration property '%s' is not set. Default value is '%s'\n", key, v.AsString())
+			} else {
+				fmt.Println(key, ":", v.AsString())
 			}
-			fmt.Println(key, ":", v.AsString())
 			return nil
 		},
 	}


### PR DESCRIPTION
`crc config get xxx` prints:
```
Configuration property 'xxx' is not set. Default value is 'yyy'
```
when its value is not set, but the command exit code is 1.

Since '1' is returned for errors (`crc config get invalid-prop`), this
is not the correct exit code. This commit changes it to 0, which is the
same as successful `crc config get` calls when the value is not the
default one.

This fixes https://github.com/crc-org/crc/issues/3678