### PR TITLE
Revert "workflows: Downgrade mingw to workaround Windows failure"

### DIFF
--- a/.github/workflows/make-check-win.yml
+++ b/.github/workflows/make-check-win.yml
@@ -16,8 +16,6 @@ jobs:
         go:
           - 1.19
     steps:
-      - name: Downgrade mingw to workaround https://github.com/golang/go/issues/46099
-        run: choco install mingw --version 10.2.0 --allow-downgrade
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up Go


### PR DESCRIPTION
This reverts commit 1b6bf222090f04261ac15d32e223459449638499.

Previously we were downgrading mingw to work around an issue in the race
detector in Go on Windows when used with a newer version of GCC. The
issue was first reported here:

https://github.com/golang/go/issues/46099

The issue is reported to be fixed after go 1.19 was released

This fixes the CI failures on github actions windows machines, that
fails with the error:

Cannot find file at '..\\lib\mingw\tools\install\mingw64\bin\mingw32-make.exe' (C:\ProgramData\Chocolatey\lib\mingw\tools\install\mingw64\bin\mingw32-make.exe). This usually indicates a missing or moved file.
Error: Process completed with exit code 1.