### PR TITLE
Integration: disable output string truncation in gomega

### DIFF
--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gomegaformat "github.com/onsi/gomega/format"
 	"github.com/sirupsen/logrus"
 )
 
@@ -29,6 +30,9 @@ var pullSecretPath string
 func TestTest(t *testing.T) {
 
 	RegisterFailHandler(Fail)
+
+	// disable error/output strings truncation
+	gomegaformat.MaxLength = 0
 
 	// fetch the current (reporter) config
 	suiteConfig, reporterConfig := GinkgoConfiguration()


### PR DESCRIPTION
It often happens in the CI that the messages are truncated and it's hard to tell what happened. See example below.

This change (hopefully) disables the `format.MaxLength` setting.

```
   [FAILED] Unexpected error:
      <cmd.CodeExitError>: {
          Err: <*errors.errorString | 0xc00036a5e0>{
              s: "error running /usr/bin/crc start -b /home/packer/crc_libvirt_4.13.0_amd64.crcbundle -p /home/packer/pull-secret:\nCommand stdout:\n\nstderr:\nlevel=debug msg=\"CRC version: 2.20.0+ab31cb\\n\"\nlevel=debug msg=\"OpenShift version: 4.13.0\\n\"\nlevel=debug msg=\"Podman version: 4.4.4\\n\"\nlevel=debug msg=\"Running 'crc start'\"\nlevel=debug msg=\"Total memory of system is 67161911296 bytes\"\nlevel=debug msg=\"No new version available. The latest version is 2.20.0\"\nlevel=debug msg=\"Checking file: /home/packer/.crc/machines/crc/.crc-exist\"\nlevel=debug msg=\"Checking if systemd-resolved.service is running\"\nlevel=debug msg=\"Running 'systemctl status systemd-resolved.service'\"\nlevel=debug msg=\"Command failed: exit status 3\"\nlevel=debug msg=\"stdout: * systemd-resolved.service - Network Name Resolution\\n   Loaded: loaded (/usr/lib/systemd/system/systemd-resolved.service; disabled; vendor preset: disabled)\\n   Active: inactive (dead)\\n     Docs: man:systemd-resolved.service(8)\\n           https://www.freedesktop.org/wiki/Software/systemd/resolved\\n           https://www.freedesktop.org/wiki/Software/systemd/writing-network-configuration-managers\\n           https://www.freedesktop.org/wiki/Software/systemd/writing-resolver-clients\\n\"\nlevel=debug msg=\"stderr: \"\nlevel=info msg=\"Checking if running as non-root\"\nlevel=info msg=\"Checking if running inside WSL2\"\nlevel=info msg=\"Checking if crc-admin-helper executable is cached\"\nlevel=debug msg=\"Running '/home/packer/.crc/bin/crc-admin-helper-linux --version'\"\nlevel=debug msg=\"Found crc-admin-helper-linux version 0.0.12\"\nlevel=debug msg=\"crc-admin-helper executable already cached\"\nlevel=info msg=\"Checking if running on a supported CPU architecture\"\nlevel=debug msg=\"GOARCH is amd64 GOOS is linux\"\nlevel=info msg=\"Checking if crc executable symlink exists\"\nlevel=info msg=\"Checking minimum RAM requirements\"\nlevel=debug msg=\"Total memory of system is 67161911296 bytes\"\nlevel=info msg=\"Checking if Virtualization is enabled\"\nlevel=debug msg=\"Checking if the vmx/svm flags are present in /proc/cpuinfo\"\nlevel=debug msg=\"CPU virtualization flags are good\"\nlevel=info msg=\"Checking if KVM is enabled\"\nlevel=debug msg=\"Checking if /dev/kvm exists\"\nlevel=debug msg=\"/dev/kvm was found\"\nlevel=info msg=\"Checking if libvirt is installed\"\nlevel=debug msg=\"Checking if 'virsh' is available\"\nlevel=debug msg=\"'virsh' was found in /usr/bin/virsh\"\nlevel=debug msg=\"Checking 'virsh capabilities' for libvirtd/qemu availability\"\nlevel=debug msg=\"Running 'virsh --readonly --connect qemu:///system capabilities'\"\nlevel=debug msg=\"Found x86_64 hypervisor with 'hvm' capabilities\"\nlevel=info msg=\"Checking if user is part of libvirt group\"\nlevel=debug msg=\"Checking if current user is part of the libvirt group\"\nlevel=debug msg=\"Current user is already in the libvirt group\"\nlevel=info msg=\"Checking if active user/process is currently part of the libvirt group\"\nlevel=info msg=\"Checking if libvirt daemon is running\"\nlevel=debug msg=\"Checking if libvirtd service is running\"\nlevel=debug msg=\"Running 'systemctl status virtqemud.socket'\"\nlevel=debug msg=\"Command failed: exit status 3\"\nlevel=debug msg=\"stdout: * virtqemud.socket - Libvirt qemu local socket\\n   Loaded: loaded (/usr/lib/systemd/system/virtqemud.socket; disabled; vendor preset: disabled)\\n   Active: inactive (dead)\\n   Listen: /run/libvirt/virtqemud-sock (Stream)\\n\"\nlevel=debug msg=\"stderr: \"\nlevel=debug msg=\"virtqemud.socket is neither running nor listening\"\nlevel=debug msg=\"Running 'systemctl status libvirtd.socket'\"\nlevel=debug msg=\"libvirtd.socket is running\"\nlevel=info msg=\"Checking if a supported libvirt version is installed\"\nlevel=debug msg=\"Checking if libvirt version is >=3.4.0\"\nlevel=debug msg=\"Running 'virsh -v'\"\nlevel=info msg=\"Checking if crc-drive...
  Gomega truncated this representation as it exceeds 'format.MaxLength'. 
```