### PR TITLE
Add registration trigger to daemon scheduled task

### DIFF
--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -40,6 +40,8 @@ var (
     <LogonTrigger>
       <UserId>%s</UserId>
     </LogonTrigger>
+    <RegistrationTrigger>
+    </RegistrationTrigger>
   </Triggers>
   <Actions Context="Author">
     <Exec>


### PR DESCRIPTION
Currently the daemon task is added with a trigger to start it on log-on but it's usefull to have the daemon task running upon task registration itself, otherwise user has to reboot

docs for the xml of registration trigger can be found at: https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-registrationtrigger-triggergroup-element

however the task not starting after `crc setup` has currently been seen only on windows 11 pro

this fixes #3715

