### PR TITLE
GrowLVForMicroshift: Change disk '/dev/vda' to '/dev/sda' for windows

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -134,10 +134,11 @@ func growRootFileSystem(sshRunner *crcssh.Runner, preset crcPreset.Preset) error
 	}
 
 	logging.Infof("Resizing %s filesystem", rootPart)
-	if _, _, err := sshRunner.RunPrivileged("Remounting /sysroot read/write", "mount -o remount,rw /sysroot"); err != nil {
+	rootFS := "/sysroot"
+	if _, _, err := sshRunner.RunPrivileged(fmt.Sprintf("Remounting %s read/write", rootFS), "mount -o remount,rw", rootFS); err != nil {
 		return err
 	}
-	if _, _, err = sshRunner.RunPrivileged(fmt.Sprintf("Growing %s filesystem", rootPart), "xfs_growfs", rootPart); err != nil {
+	if _, _, err = sshRunner.RunPrivileged(fmt.Sprintf("Growing %s filesystem", rootFS), "xfs_growfs", rootFS); err != nil {
 		return err
 	}
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -158,7 +158,7 @@ func getrootPartition(sshRunner *crcssh.Runner, label string) (string, error) {
 
 func runGrowpart(sshRunner *crcssh.Runner, rootPart string) error {
 	// with '/dev/[sv]da4' as input, run 'growpart /dev/[sv]da 4'
-	if _, _, err := sshRunner.RunPrivileged(fmt.Sprintf("Growing %s partition", rootPart), "/usr/bin/growpart", rootPart[:len("/dev/.da")], rootPart[len(rootPart)-1:]); err != nil {
+	if _, _, err := sshRunner.RunPrivileged(fmt.Sprintf("Growing %s partition", rootPart), "/usr/bin/growpart", rootPart[:len("/dev/.da")], rootPart[len("/dev/.da"):]); err != nil {
 		var exitErr *ssh.ExitError
 		if !errors.As(err, &exitErr) {
 			return err

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -176,12 +176,12 @@ func runGrowpart(sshRunner *crcssh.Runner, rootPart string) error {
 }
 
 func growLVForMicroshift(sshRunner *crcssh.Runner, lvFullName string, rootPart string) error {
-	if _, _, err := sshRunner.RunPrivileged("Resizing the physical volume(PV)", "/usr/sbin/pvresize", rootPart); err != nil {
+	if _, _, err := sshRunner.RunPrivileged("Resizing the physical volume(PV)", "/usr/sbin/pvresize", "--devices", rootPart, rootPart); err != nil {
 		return err
 	}
 
 	// Get the size of volume group
-	sizeVG, _, err := sshRunner.RunPrivileged("Get the volume group size", "/usr/sbin/vgs", "--noheadings", "--nosuffix", "--units", "b", "-o", "vg_size")
+	sizeVG, _, err := sshRunner.RunPrivileged("Get the volume group size", "/usr/sbin/vgs", "--noheadings", "--nosuffix", "--units", "b", "-o", "vg_size", "--devices", rootPart)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func growLVForMicroshift(sshRunner *crcssh.Runner, lvFullName string, rootPart s
 	}
 
 	// Get the size of root lv
-	sizeLV, _, err := sshRunner.RunPrivileged("Get the size of root logical volume", "/usr/sbin/lvs", "-S", fmt.Sprintf("lv_full_name=%s", lvFullName), "--noheadings", "--nosuffix", "--units", "b", "-o", "lv_size")
+	sizeLV, _, err := sshRunner.RunPrivileged("Get the size of root logical volume", "/usr/sbin/lvs", "-S", fmt.Sprintf("lv_full_name=%s", lvFullName), "--noheadings", "--nosuffix", "--units", "b", "-o", "lv_size", "--devices", rootPart)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func growLVForMicroshift(sshRunner *crcssh.Runner, lvFullName string, rootPart s
 	lvPath := fmt.Sprintf("/dev/%s", lvFullName)
 	if sizeToIncrease > 1 {
 		logging.Info("Extending and resizing '/dev/rhel/root' logical volume")
-		if _, _, err := sshRunner.RunPrivileged("Extending and resizing the logical volume(LV)", "/usr/sbin/lvextend", "-L", fmt.Sprintf("+%db", sizeToIncrease), lvPath); err != nil {
+		if _, _, err := sshRunner.RunPrivileged("Extending and resizing the logical volume(LV)", "/usr/sbin/lvextend", "-L", fmt.Sprintf("+%db", sizeToIncrease), lvPath, "--devices", rootPart); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
In windows the hyperV identified disk as SCSI and disk partitions are `/dev/sda*` instead `/dev/vda*` and this makes the pvs/lvs commands to fail since the `/etc/lvm/devices/system.devices` file contain `/dev/vda*`.

```
$ sudo pvdisplay
  Devices file PVID BAUW2KTKhF3RE03h4JEMd1EImwC3cWd0 last seen on
  /dev/vda3 not found.
```

In this PR we are changing the `/dev/vda*` to `/dev/sda*` so that disk resize works as expected in windows also.


**Fixes:** Issue #3718