### PR TITLE
microshift: Use api.crc.testing kubeconfig to connect to cluster

### DIFF
--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -232,19 +232,6 @@ func contains(arr []string, str string) bool {
 	return false
 }
 
-func updateServerDetailsToKubeConfig(input, output string) error {
-	cfg, err := clientcmd.LoadFromFile(input)
-	if err != nil {
-		return err
-	}
-	for name, cluster := range cfg.Clusters {
-		if name == "microshift" && cluster.Server == "https://127.0.0.1:6443" {
-			cluster.Server = fmt.Sprintf("https://api%s:6443", constants.ClusterDomain)
-		}
-	}
-	return clientcmd.WriteToFile(*cfg, output)
-}
-
 func mergeKubeConfigFile(kubeConfigFile string) error {
 	globalConfigPath, kubeConf1, err := getGlobalKubeConfig()
 	if err != nil {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -1033,13 +1033,10 @@ func startMicroshift(ctx context.Context, sshRunner *crcssh.Runner, ocConfig oc.
 	if _, _, err := sshRunner.RunPrivileged("Starting microshift service", "systemctl", "start", "microshift"); err != nil {
 		return err
 	}
-	if err := sshRunner.CopyFileFromVM("/var/lib/microshift/resources/kubeadmin/kubeconfig", constants.KubeconfigFilePath, 0600); err != nil {
+	if err := sshRunner.CopyFileFromVM(fmt.Sprintf("/var/lib/microshift/resources/kubeadmin/api%s/kubeconfig", constants.ClusterDomain), constants.KubeconfigFilePath, 0600); err != nil {
 		return err
 	}
 	if err := sshRunner.CopyFile(constants.KubeconfigFilePath, "/opt/kubeconfig", 0644); err != nil {
-		return err
-	}
-	if err := updateServerDetailsToKubeConfig(constants.KubeconfigFilePath, constants.KubeconfigFilePath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
With 4.13, after starting the microshift service it create different kubeconfig according to different additional names/IP. we were using the localhost one which is mostly for localhost API access so in this PR we are going to make use of `api.crc.testing` kubecofig file instead localhost one.

- https://github.com/openshift/microshift/blob/main/docs/howto_kubeconfig.md
- https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.13/html/configuring/microshift-kubeconfig#remote-access-con_microshift-kubeconfig


**Fixes:** Issue #3725 