### PR TITLE
cleanup: delete VM before deleting the machine's dir

### DIFF
--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -203,7 +203,7 @@ func removeCrcVM() (err error) {
 		// This means that there is no crc VM exist
 		return nil
 	}
-	stopVMCommand := fmt.Sprintf(`Stop-VM -Name "%s" -Force`, constants.DefaultName)
+	stopVMCommand := fmt.Sprintf(`Stop-VM -Name "%s" -TurnOff -Force`, constants.DefaultName)
 	if _, _, err := powershell.Execute(stopVMCommand); err != nil {
 		// ignore the error as this is useless (prefer not to use nolint here)
 		return err

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -70,13 +70,14 @@ var hypervPreflightChecks = []Check{
 
 		labels: labels{Os: Windows, NetworkMode: System},
 	},
-	{
-		cleanupDescription: "Removing crc's virtual machine",
-		cleanup:            removeCrcVM,
-		flags:              CleanUpOnly,
+}
 
-		labels: labels{Os: Windows},
-	},
+var cleanupCheckRemoveCrcVM = Check{
+	cleanupDescription: "Removing crc's virtual machine",
+	cleanup:            removeCrcVM,
+	flags:              CleanUpOnly,
+
+	labels: labels{Os: Windows},
 }
 
 var vsockChecks = []Check{
@@ -200,6 +201,7 @@ func getChecks(bundlePath string, preset crcpreset.Preset) []Check {
 	checks = append(checks, vsockChecks...)
 	checks = append(checks, bundleCheck(bundlePath, preset))
 	checks = append(checks, genericCleanupChecks...)
+	checks = append(checks, cleanupCheckRemoveCrcVM)
 	checks = append(checks, daemonTaskChecks...)
 	checks = append(checks, adminHelperServiceCheks...)
 	return checks


### PR DESCRIPTION
trying to delete the machine's dir without first deleting the hyper-v VM
causes error, since the existing VM will still be using the files inside
the machine's dir