### PR TITLE
Revert "Deploy router controller resource from bundle"

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -919,13 +919,6 @@ func logBundleDate(crcBundleMetadata *bundle.CrcBundleInfo) {
 }
 
 func ensureRoutesControllerIsRunning(sshRunner *crcssh.Runner, ocConfig oc.Config, preset crcPreset.Preset, bundleInfo *bundle.CrcBundleInfo) error {
-	// Check if the bundle have `/opt/crc/route_controller.yaml` file and if it has
-	// then use it to create the resource for router controller.
-	if _, _, err := sshRunner.Run("ls", "/opt/crc/route_controller.yaml"); err == nil {
-		_, _, err := ocConfig.RunOcCommand("apply", "-f", "/opt/crc/route_controller.yaml")
-		return err
-	}
-	// TODO: Remove this resource creation after crc 2.24 release
 	bin, err := json.Marshal(v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",


### PR DESCRIPTION
This reverts commit 7cf9765a88d5528d8c136de269a7cc75ede839bd. Looks like in the bundle, route controller resource does not have the vaild service account and because of that `/etc/hosts` file not updated as expected, which become blocker issue for current 2.22.0 release. This PR revert it and we will put it back after it is resolved on snc side.

- https://github.com/crc-org/snc/issues/747


