### PR TITLE
Segment: Add preset value for each event before sending to segment

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -275,7 +275,6 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	telemetry.SetCPUs(ctx, startConfig.CPUs)
 	telemetry.SetMemory(ctx, uint64(startConfig.Memory)*1024*1024)
 	telemetry.SetDiskSize(ctx, uint64(startConfig.DiskSize)*1024*1024*1024)
-	telemetry.SetPreset(ctx, startConfig.Preset)
 
 	if err := client.validateStartConfig(startConfig); err != nil {
 		return nil, err

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -168,6 +168,9 @@ func (c *Client) upload(action string, a analytics.Properties) error {
 	if c.config.Get(crcConfig.ConsentTelemetry).AsString() != "yes" {
 		return nil
 	}
+	// Add preset value as property for each event before uploading to segment
+	preset := crcConfig.GetPreset(c.config)
+	a = a.Set("preset", preset)
 
 	identify := c.identifyNew()
 	hash, err := identifyHash(identify)

--- a/pkg/crc/telemetry/telemetry.go
+++ b/pkg/crc/telemetry/telemetry.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/crc-org/crc/pkg/crc/constants"
-	crcpreset "github.com/crc-org/crc/pkg/crc/preset"
 )
 
 type contextKey struct{}
@@ -76,10 +75,6 @@ func SetDiskSize(ctx context.Context, value uint64) {
 
 func SetConfigurationKey(ctx context.Context, value string) {
 	setContextProperty(ctx, "key", value)
-}
-
-func SetPreset(ctx context.Context, value crcpreset.Preset) {
-	setContextProperty(ctx, "preset", value)
 }
 
 func SetStartType(ctx context.Context, value StartType) {


### PR DESCRIPTION
Preset value is only capured in the start command and if start command
fails as part of preflight test or even daemon not available phase then
this value is not available. We tried to map the preset data from amplitude
side and there is lot of `none` because some segment data (captured by
start action) doesn't have preset info. This PR make sure that each
events have preset value before sending it to segment.

Issue #3735 