### PR TITLE
Set emergency login for core user with random password

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -79,6 +79,8 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		IngressHTTPPort:   config.Get(crcConfig.IngressHTTPPort).AsUInt(),
 		IngressHTTPSPort:  config.Get(crcConfig.IngressHTTPSPort).AsUInt(),
 		EnableSharedDirs:  config.Get(crcConfig.EnableSharedDirs).AsBool(),
+
+		EmergencyLogin: config.Get(crcConfig.EmergencyLogin).AsBool(),
 	}
 
 	client := newMachine()

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -130,6 +130,7 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 		IngressHTTPSPort:  cfg.Get(crcConfig.IngressHTTPSPort).AsUInt(),
 		Preset:            crcConfig.GetPreset(cfg),
 		EnableSharedDirs:  cfg.Get(crcConfig.EnableSharedDirs).AsBool(),
+		EmergencyLogin:    cfg.Get(crcConfig.EmergencyLogin).AsBool(),
 	}
 }
 

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -34,6 +34,7 @@ const (
 	SharedDirPassword       = "shared-dir-password" // #nosec G101
 	IngressHTTPPort         = "ingress-http-port"
 	IngressHTTPSPort        = "ingress-https-port"
+	EmergencyLogin          = "enable-emergency-login"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -88,6 +89,8 @@ func RegisterSettings(cfg *Config) {
 		"Disable update check (true/false, default: false)")
 	cfg.AddSetting(ExperimentalFeatures, false, ValidateBool, SuccessfullyApplied,
 		"Enable experimental features (true/false, default: false)")
+	cfg.AddSetting(EmergencyLogin, false, ValidateBool, SuccessfullyApplied,
+		"Enable emergency login for 'core' user. Password is randomly generated. (true/false, default: false)")
 
 	// Shared directories configs
 	if runtime.GOOS == "windows" {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -110,6 +110,7 @@ var (
 	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
 	DaemonSocketPath   = filepath.Join(CrcBaseDir, "crc.sock")
 	KubeconfigFilePath = filepath.Join(MachineInstanceDir, DefaultName, "kubeconfig")
+	PasswdFilePath     = filepath.Join(MachineInstanceDir, DefaultName, "passwd")
 )
 
 func GetDefaultBundlePath(preset crcpreset.Preset) string {

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -37,6 +37,9 @@ type StartConfig struct {
 	// Ports to access openshift routes
 	IngressHTTPPort  uint
 	IngressHTTPSPort uint
+
+	// Enable emergency login
+	EmergencyLogin bool
 }
 
 type ClusterConfig struct {


### PR DESCRIPTION
This PR allow user to set the emergency login for core user with a random generated password. It is helpful when user lost the ssh access and use VMM to debug the issue which require password for `core` user.

Generated password is printed on stdout if user use cli to start the VM and also part of `~/.crc/crc.log` in case want to access it later. In case of VM is started by api endpoint then password would be part of `~/.crc.crcd.log`.

```
$ crc config set enable-emergency-login true
$ crc config view
- enable-emergency-login                : true
[...]
$ crc start
[...]
INFO CRC VM is running
INFO Emergency login password for core user is: Yf9OwP7y
INFO Updating authorized keys...
[...]
```