### PR TITLE
Revert "Revert "Deploy router controller resource from bundle""

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -912,6 +912,13 @@ func logBundleDate(crcBundleMetadata *bundle.CrcBundleInfo) {
 }
 
 func ensureRoutesControllerIsRunning(sshRunner *crcssh.Runner, ocConfig oc.Config, preset crcPreset.Preset, bundleInfo *bundle.CrcBundleInfo) error {
+	// Check if the bundle have `/opt/crc/routes-controller.yaml` file and if it has
+	// then use it to create the resource for the routes controller.
+	if _, _, err := sshRunner.Run("ls", "/opt/crc/routes-controller.yaml"); err == nil {
+		_, _, err := ocConfig.RunOcCommand("apply", "-f", "/opt/crc/routes-controller.yaml")
+		return err
+	}
+	// TODO: Remove this resource creation after crc 2.24 release
 	bin, err := json.Marshal(v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",


### PR DESCRIPTION
This reverts commit 567ca08207891650e2cf9e8b2aeffc40d44c2850.

Since now we updated the routes-controller resource with correct service account so it is now good to bring that feature back.

Also file is changed `routes-controller.yaml` as we have in the bundle.


