### PR TITLE
hyperv: Replace parseLines/SplitLines with getFirstLine

### DIFF
--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/crc-org/crc/pkg/crc/logging"
+	crcstrings "github.com/crc-org/crc/pkg/strings"
 	openshiftapi "github.com/openshift/api/config/v1"
 	k8sapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,7 +102,7 @@ func getStatus(ctx context.Context, lister operatorLister, selector []string) (*
 
 	found := false
 	for _, c := range co.Items {
-		if len(selector) > 0 && !contains(c.ObjectMeta.Name, selector) {
+		if len(selector) > 0 && !crcstrings.Contains(selector, c.ObjectMeta.Name) {
 			continue
 		}
 		found = true
@@ -176,15 +177,6 @@ func GetClusterNodeStatus(ctx context.Context, ip string, kubeconfigFilePath str
 		logging.Debugf("Unexpected node status for %s", ns)
 	}
 	return status, nil
-}
-
-func contains(value string, list []string) bool {
-	for _, v := range list {
-		if v == value {
-			return true
-		}
-	}
-	return false
 }
 
 type operatorLister interface {

--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -11,6 +11,7 @@ import (
 	winnet "github.com/crc-org/crc/pkg/os/windows/network"
 	"github.com/crc-org/crc/pkg/os/windows/powershell"
 	"github.com/crc-org/crc/pkg/os/windows/win32"
+	crcstrings "github.com/crc-org/crc/pkg/strings"
 )
 
 const (
@@ -30,7 +31,7 @@ func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
 
 	time.Sleep(2 * time.Second)
 
-	if !contains(getInterfaceNameserverValues(networkInterface), serviceConfig.IP) {
+	if !crcstrings.Contains(getInterfaceNameserverValues(networkInterface), serviceConfig.IP) {
 		return fmt.Errorf("Nameserver %s not successfully set on interface %s. Perhaps you can try this new network mode: https://github.com/crc-org/crc/wiki/VPN-support--with-an--userland-network-stack", serviceConfig.IP, networkInterface)
 	}
 	return nil
@@ -41,15 +42,6 @@ func getInterfaceNameserverValues(iface string) []string {
 	stdOut, _, _ := powershell.Execute(getDNSServerCommand)
 
 	return parseLines(stdOut)
-}
-
-func contains(s []string, e string) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
 }
 
 func setInterfaceNameserverValue(iface string, address string) {

--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -1,9 +1,7 @@
 package dns
 
 import (
-	"bufio"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/crc-org/crc/pkg/crc/network"
@@ -41,7 +39,7 @@ func getInterfaceNameserverValues(iface string) []string {
 	getDNSServerCommand := fmt.Sprintf(`(Get-DnsClientServerAddress "%s")[0].ServerAddresses`, iface)
 	stdOut, _, _ := powershell.Execute(getDNSServerCommand)
 
-	return parseLines(stdOut)
+	return crcstrings.SplitLines(stdOut)
 }
 
 func setInterfaceNameserverValue(iface string, address string) {
@@ -50,15 +48,4 @@ func setInterfaceNameserverValue(iface string, address string) {
 
 	// ignore the error as this is useless (prefer not to use nolint here)
 	_ = win32.ShellExecuteAsAdmin(fmt.Sprintf("add dns server address to interface %s", iface), win32.HwndDesktop, exe, args, "", 0)
-}
-
-func parseLines(input string) []string {
-	output := []string{}
-
-	s := bufio.NewScanner(strings.NewReader(input))
-	for s.Scan() {
-		output = append(output, s.Text())
-	}
-
-	return output
 }

--- a/pkg/drivers/hyperv/hyperv_windows.go
+++ b/pkg/drivers/hyperv/hyperv_windows.go
@@ -94,18 +94,18 @@ func (d *Driver) GetState() (state.State, error) {
 		return state.Error, fmt.Errorf("Failed to find the VM status: %v - %s", err, stderr)
 	}
 
-	resp := crcstrings.SplitLines(stdout)
-	if len(resp) < 1 {
+	resp := crcstrings.FirstLine(stdout)
+	if resp == "" {
 		return state.Error, fmt.Errorf("unexpected Hyper-V state %s", stdout)
 	}
 
-	switch resp[0] {
+	switch resp {
 	case "Starting", "Running", "Stopping":
 		return state.Running, nil
 	case "Off":
 		return state.Stopped, nil
 	default:
-		return state.Error, fmt.Errorf("unexpected Hyper-V state %s", resp[0])
+		return state.Error, fmt.Errorf("unexpected Hyper-V state %s", resp)
 	}
 }
 
@@ -398,12 +398,12 @@ func (d *Driver) GetIP() (string, error) {
 		return "", err
 	}
 
-	resp := crcstrings.SplitLines(stdout)
-	if len(resp) < 1 {
+	resp := crcstrings.FirstLine(stdout)
+	if resp == "" {
 		return "", fmt.Errorf("IP not found")
 	}
 
-	return resp[0], nil
+	return resp, nil
 }
 
 func (d *Driver) GetSharedDirs() ([]drivers.SharedDir, error) {

--- a/pkg/drivers/hyperv/hyperv_windows.go
+++ b/pkg/drivers/hyperv/hyperv_windows.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/crc-org/crc/pkg/crc/logging"
 	crcos "github.com/crc-org/crc/pkg/os"
 	"github.com/crc-org/crc/pkg/os/windows/powershell"
+	crcstrings "github.com/crc-org/crc/pkg/strings"
 	"github.com/crc-org/machine/libmachine/drivers"
 	"github.com/crc-org/machine/libmachine/state"
 )
@@ -93,7 +94,7 @@ func (d *Driver) GetState() (state.State, error) {
 		return state.Error, fmt.Errorf("Failed to find the VM status: %v - %s", err, stderr)
 	}
 
-	resp := parseLines(stdout)
+	resp := crcstrings.SplitLines(stdout)
 	if len(resp) < 1 {
 		return state.Error, fmt.Errorf("unexpected Hyper-V state %s", stdout)
 	}
@@ -256,7 +257,7 @@ func (d *Driver) chooseVirtualSwitch() (string, error) {
 		return "", err
 	}
 
-	switches := parseLines(stdout)
+	switches := crcstrings.SplitLines(stdout)
 
 	found := false
 	for _, name := range switches {
@@ -397,7 +398,7 @@ func (d *Driver) GetIP() (string, error) {
 		return "", err
 	}
 
-	resp := parseLines(stdout)
+	resp := crcstrings.SplitLines(stdout)
 	if len(resp) < 1 {
 		return "", fmt.Errorf("IP not found")
 	}

--- a/pkg/drivers/hyperv/powershell_windows.go
+++ b/pkg/drivers/hyperv/powershell_windows.go
@@ -31,8 +31,8 @@ func hypervAvailable() error {
 		return err
 	}
 
-	resp := crcstrings.SplitLines(stdout)
-	if resp[0] != "Hyper-V" {
+	resp := crcstrings.FirstLine(stdout)
+	if resp != "Hyper-V" {
 		return ErrNotInstalled
 	}
 
@@ -62,8 +62,8 @@ func isHypervAdministrator() bool {
 		return false
 	}
 
-	resp := crcstrings.SplitLines(stdout)
-	return resp[0] == "True"
+	resp := crcstrings.FirstLine(stdout)
+	return resp == "True"
 }
 
 func isWindowsAdministrator() (bool, error) {
@@ -72,8 +72,8 @@ func isWindowsAdministrator() (bool, error) {
 		return false, err
 	}
 
-	resp := crcstrings.SplitLines(stdout)
-	return resp[0] == "True", nil
+	resp := crcstrings.FirstLine(stdout)
+	return resp == "True", nil
 }
 
 func quote(text string) string {

--- a/pkg/drivers/hyperv/powershell_windows.go
+++ b/pkg/drivers/hyperv/powershell_windows.go
@@ -1,13 +1,12 @@
 package hyperv
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
-	"strings"
 
 	log "github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/os/windows/powershell"
+	crcstrings "github.com/crc-org/crc/pkg/strings"
 )
 
 var (
@@ -26,24 +25,13 @@ func cmd(args ...string) error {
 	return err
 }
 
-func parseLines(stdout string) []string {
-	resp := []string{}
-
-	s := bufio.NewScanner(strings.NewReader(stdout))
-	for s.Scan() {
-		resp = append(resp, s.Text())
-	}
-
-	return resp
-}
-
 func hypervAvailable() error {
 	stdout, err := cmdOut("@(Get-Module -ListAvailable hyper-v).Name | Get-Unique")
 	if err != nil {
 		return err
 	}
 
-	resp := parseLines(stdout)
+	resp := crcstrings.SplitLines(stdout)
 	if resp[0] != "Hyper-V" {
 		return ErrNotInstalled
 	}
@@ -74,7 +62,7 @@ func isHypervAdministrator() bool {
 		return false
 	}
 
-	resp := parseLines(stdout)
+	resp := crcstrings.SplitLines(stdout)
 	return resp[0] == "True"
 }
 
@@ -84,7 +72,7 @@ func isWindowsAdministrator() (bool, error) {
 		return false, err
 	}
 
-	resp := parseLines(stdout)
+	resp := crcstrings.SplitLines(stdout)
 	return resp[0] == "True", nil
 }
 

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -1,5 +1,10 @@
 package strings
 
+import (
+	"bufio"
+	"strings"
+)
+
 func Contains(input []string, match string) bool {
 	for _, v := range input {
 		if v == match {
@@ -7,4 +12,16 @@ func Contains(input []string, match string) bool {
 		}
 	}
 	return false
+}
+
+// Split a multi line string in an array of string, one for each line
+func SplitLines(input string) []string {
+	output := []string{}
+
+	s := bufio.NewScanner(strings.NewReader(input))
+	for s.Scan() {
+		output = append(output, s.Text())
+	}
+
+	return output
 }

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -25,3 +25,12 @@ func SplitLines(input string) []string {
 
 	return output
 }
+
+func FirstLine(input string) string {
+	lines := SplitLines(input)
+	if len(lines) == 0 {
+		return ""
+	}
+
+	return lines[0]
+}

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -1,0 +1,10 @@
+package strings
+
+func Contains(input []string, match string) bool {
+	for _, v := range input {
+		if v == match {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/strings/strings_test.go
+++ b/pkg/strings/strings_test.go
@@ -93,3 +93,46 @@ func TestSplitLines(t *testing.T) {
 		}
 	})
 }
+
+type firstLineTest struct {
+	input     string
+	firstLine string
+}
+
+var firstLineTests = map[string]firstLineTest{
+	"ThreeLines": {
+		input:     "line1\nline2\nline3\n",
+		firstLine: "line1",
+	},
+	"ThreeLinesNoFinalEOL": {
+		input:     "line1\nline2\nline3",
+		firstLine: "line1",
+	},
+	"WindowsEOL": {
+		input:     "line1\r\nline2\r\nline3\r\n",
+		firstLine: "line1",
+	},
+	"EmptyString": {
+		input:     "",
+		firstLine: "",
+	},
+	"EOLOnly": {
+		input:     "\n",
+		firstLine: "",
+	},
+	"NoEOL": {
+		input:     "line1",
+		firstLine: "line1",
+	},
+}
+
+func TestFirstLine(t *testing.T) {
+	t.Run("FirstLine", func(t *testing.T) {
+		for name, test := range firstLineTests {
+			t.Run(name, func(t *testing.T) {
+				firstLine := FirstLine(test.input)
+				assert.Equal(t, test.firstLine, firstLine)
+			})
+		}
+	})
+}

--- a/pkg/strings/strings_test.go
+++ b/pkg/strings/strings_test.go
@@ -1,0 +1,52 @@
+package strings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type containsTest struct {
+	input []string
+	match string
+	found bool
+}
+
+var containsTests = map[string]containsTest{
+	"Found": {
+		input: []string{"a", "b", "c"},
+		match: "b",
+		found: true,
+	},
+	"NotFound": {
+		input: []string{"a", "b", "c"},
+		match: "d",
+		found: false,
+	},
+	"OneElement": {
+		input: []string{"a"},
+		match: "a",
+		found: true,
+	},
+	"EmptyArray": {
+		input: []string{},
+		match: "a",
+		found: false,
+	},
+	"EmptyArrayEmptySearch": {
+		input: []string{},
+		match: "",
+		found: false,
+	},
+}
+
+func TestContains(t *testing.T) {
+	t.Run("Contains", func(t *testing.T) {
+		for name, test := range containsTests {
+			t.Run(name, func(t *testing.T) {
+				found := Contains(test.input, test.match)
+				assert.Equal(t, test.found, found)
+			})
+		}
+	})
+}

--- a/pkg/strings/strings_test.go
+++ b/pkg/strings/strings_test.go
@@ -50,3 +50,46 @@ func TestContains(t *testing.T) {
 		}
 	})
 }
+
+type splitLinesTest struct {
+	input       string
+	splitOutput []string
+}
+
+var splitLinesTests = map[string]splitLinesTest{
+	"ThreeLines": {
+		input:       "line1\nline2\nline3\n",
+		splitOutput: []string{"line1", "line2", "line3"},
+	},
+	"ThreeLinesNoFinalEOL": {
+		input:       "line1\nline2\nline3",
+		splitOutput: []string{"line1", "line2", "line3"},
+	},
+	"WindowsEOL": {
+		input:       "line1\r\nline2\r\nline3\r\n",
+		splitOutput: []string{"line1", "line2", "line3"},
+	},
+	"EmptyString": {
+		input:       "",
+		splitOutput: []string{},
+	},
+	"EOLOnly": {
+		input:       "\n",
+		splitOutput: []string{""},
+	},
+	"NoEOL": {
+		input:       "line1",
+		splitOutput: []string{"line1"},
+	},
+}
+
+func TestSplitLines(t *testing.T) {
+	t.Run("SplitLines", func(t *testing.T) {
+		for name, test := range splitLinesTests {
+			t.Run(name, func(t *testing.T) {
+				output := SplitLines(test.input)
+				assert.Equal(t, test.splitOutput, output)
+			})
+		}
+	})
+}


### PR DESCRIPTION
In the hyperv code, there are many occurrences of resp :=
os.SplitLines(stdout) if resp[0] == ...

This does not check if `resp` is empty before trying to reference it, which
recently triggered a panic in crc ( 
https://github.com/crc-org/crc/issues/3764 )

This code adds a `getFirstLine` helper which will return an empty string if
stdout is "".

This should fix https://github.com/crc-org/crc/issues/3764