### PR TITLE
e2e: Split minimal feature by preset

### DIFF
--- a/test/e2e/features/minimal.feature
+++ b/test/e2e/features/minimal.feature
@@ -10,9 +10,17 @@ Feature: Minimal user story
         And starting CRC with default bundle succeeds
         Then checking that CRC is running
 
-        Examples:
+            @podman-preset
+            Scenarios:
             | preset-value |
             | podman       |
-            | microshift   |
-            | openshift    |
 
+            @microshift-preset
+            Scenarios:
+            | preset-value |
+            | microshift   |
+
+            @openshift-preset
+            Scenarios:
+            | preset-value |
+            | openshift    |


### PR DESCRIPTION
Being able to restrict execution to a specific preset allows us to run the Scenario with user-provided bundles. Therefore, the test can be used e.g. for #3773. Without specifying `x-preset` tags, the test remains effectively unchanged.

To run e.g. `microshift-preset` case only with a user-provided bundle, make sure you specify the following before running `make e2e`.

```make
GODOG_OPTS = --godog.tags="@minimal && @microshift-preset"
BUNDLE_LOCATION = --bundle-location=path/to/microshift-bundle
```

`minimal` Feature is excluded from the CI checks, so here's a run I did locally.

```feature
Using existing bundle: /home/jsliacan/Downloads/crc_microshift_libvirt_4.13.6_amd64.crcbundle
Feature: Minimal user story
  User starts CRC cluster and checks status.

    Examples:
      | preset-value |
      | microshift   |
Deleted CRC instance (if one existed).

1 scenarios (1 passed)
4 steps (4 passed)
4m9.323780413s
```