### PR TITLE
e2e: Add scenario for microshift preset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,8 @@ e2e-story-marketplace: install
 	@go test $(REPOPATH)/test/e2e --ldflags="$(VERSION_VARIABLES)" -v --godog.tags="$(GOOS) && ~@startstop && @story_marketplace" --cleanup-home=false
 e2e-story-registry: install
 	@go test $(REPOPATH)/test/e2e --ldflags="$(VERSION_VARIABLES)" -v --godog.tags="$(GOOS) && ~@startstop && @story_registry" --cleanup-home=false
-
+e2e-story-microshift: install
+	@go test $(REPOPATH)/test/e2e -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --godog.tags="$(GOOS) && @microshift" --cleanup-home=false
 
 .PHONY: fmt
 fmt: $(TOOLS_BINDIR)/goimports

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -33,7 +33,7 @@ func init() {
 func TestMain(m *testing.M) {
 
 	pflag.Parse()
-
+	testsuite.GodogTags = opts.Tags
 	status := godog.TestSuite{
 		Name:                 "crc",
 		TestSuiteInitializer: testsuite.InitializeTestSuite,

--- a/test/e2e/features/story_microshift.feature
+++ b/test/e2e/features/story_microshift.feature
@@ -1,0 +1,36 @@
+@story_microshift
+Feature: Microshift test stories
+
+	Background:
+		Given setting config property "preset" to value "microshift" succeeds
+		And setting config property "network-mode" to value "user" succeeds
+		And executing single crc setup command succeeds
+		And starting CRC with default bundle succeeds
+
+	# End-to-end health check
+
+	@microshift @testdata @linux @windows @darwin
+	Scenario: Start and expose a basic HTTP service and check after restart
+		Given executing "oc create namespace testproj" succeeds
+		And executing "oc config set-context --current --namespace=testproj" succeeds
+		When executing "oc apply -f httpd-example.yaml" succeeds
+		And executing "oc rollout status deployment httpd-example" succeeds
+		Then stdout should contain "successfully rolled out"
+		When executing "oc create configmap www-content --from-file=index.html=httpd-example-index.html" succeeds
+		Then stdout should contain "configmap/www-content created"
+		When executing "oc set volume deployment/httpd-example --add --type configmap --configmap-name www-content --name www --mount-path /var/www/html" succeeds
+		Then stdout should contain "deployment.apps/httpd-example volume updated"
+		When executing "oc expose deployment httpd-example --port 8080" succeeds
+		Then stdout should contain "httpd-example exposed"
+		When executing "oc expose svc httpd-example" succeeds
+		Then stdout should contain "httpd-example exposed"
+		When with up to "20" retries with wait period of "5s" http response from "http://httpd-example-testproj.apps.crc.testing" has status code "200"
+		Then executing "curl -s http://httpd-example-testproj.apps.crc.testing" succeeds
+		And stdout should contain "Hello CRC!"
+		When executing "crc stop" succeeds
+		And starting CRC with default bundle succeeds
+		And checking that CRC is running
+		And with up to "4" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps.crc.testing" has status code "200"
+		Then executing "curl -s http://httpd-example-testproj.apps.crc.testing" succeeds
+		And stdout should contain "Hello CRC!"
+		Then with up to "4" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps.crc.testing" has status code "200"

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -89,10 +89,10 @@ func InitializeTestSuite(tctx *godog.TestSuiteContext) {
 		}
 
 		if bundleLocation == "" {
-			fmt.Println("Expecting the bundle provided by the user")
 			userProvidedBundle = false
 			bundleName = constants.GetDefaultBundle(preset.OpenShift)
 		} else {
+			fmt.Println("Expecting the bundle provided by the user")
 			userProvidedBundle = true
 			_, bundleName = filepath.Split(bundleLocation)
 		}

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -39,9 +39,9 @@ func ParseFlags() {
 	pflag.StringVar(&util.TestDir, "test-dir", "out", "Path to the directory in which to execute the tests")
 	pflag.StringVar(&testWithShell, "test-shell", "", "Specifies shell to be used for the testing.")
 
-	pflag.StringVar(&bundleLocation, "bundle-location", "/path/to/bundle.crcbundle", "Path to the bundle to be used in tests")
+	pflag.StringVar(&bundleLocation, "bundle-location", "", "Path to the bundle to be used in tests")
 	pflag.StringVar(&pullSecretFile, "pull-secret-file", "/path/to/pull-secret", "Path to the file containing pull secret")
-	pflag.StringVar(&CRCExecutable, "crc-binary", "/path/to/binary/crc", "Path to the CRC executable to be tested")
+	pflag.StringVar(&CRCExecutable, "crc-binary", "", "Path to the CRC executable to be tested")
 	pflag.BoolVar(&cleanupHome, "cleanup-home", false, "Try to remove crc home folder before starting the suite") // TODO: default=true
 	pflag.StringVar(&CRCVersion, "crc-version", "", "Version of CRC to be tested")
 }

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -31,12 +31,7 @@ var (
 	testWithShell      string
 	CRCVersion         string
 
-	GodogFormat              string
-	GodogTags                string
-	GodogShowStepDefinitions bool
-	GodogStopOnFailure       bool
-	GodogNoColors            bool
-	GodogPaths               string
+	GodogTags string
 )
 
 func ParseFlags() {

--- a/test/testdata/httpd-example.yaml
+++ b/test/testdata/httpd-example.yaml
@@ -75,4 +75,6 @@ spec:
       schedulerName: default-scheduler
       securityContext: 
         runAsNonRoot: true
+        seccompProfile:
+          type: "RuntimeDefault"
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
With this we can able to test out the microshift preset functionality.
```
$ BUNDLE_LOCATION='--bundle-location=/home/prkumar/.crc/cache/crc_microshift_libvirt_4.13.3_amd64.crcbundle' PULL_SECRET_FILE='--pull-secret-file=/home/prkumar/pull-secret' CRC_BINARY='--crc-binary=/home/prkumar/work/github/crc/out/linux-amd64/' make e2e-story-microshift

  Background:
    Given setting config property "preset" to value "microshift" succeeds                                                                                      # testsuite.go:860 -> github.com/crc-org/crc/test/e2e/testsuite.SetConfigPropertyToValueSucceedsOrFails
[sudo] password for prkumar: 
    And executing single crc setup command succeeds        

[...]
```