### PR TITLE
e2e: Add debug steps to verify the cert with CA

### DIFF
--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -3,6 +3,9 @@ Feature: 4 Openshift stories
 
 	Background:
 		Given ensuring CRC cluster is running
+		And executing "oc config view --raw -o jsonpath="{.clusters[?(@.name=='api-crc-testing:6443')].cluster.certificate-authority-data}"| base64 -d - > ca.crt" succeeds
+		And executing "echo | openssl s_client -connect api.crc.testing:6443 | openssl x509 -out server.crt" succeeds
+		And executing "openssl verify -CAfile ca.crt server.crt" succeeds
 		And ensuring user is logged in succeeds
 
 	# End-to-end health check


### PR DESCRIPTION
This is just for debug purpose to understand what is actually happen when oc login require `--insecure-skip-tls-verify`.

