### PR TITLE
CI: Make sure oc command is available before any oc operations

### DIFF
--- a/test/e2e/features/story_microshift.feature
+++ b/test/e2e/features/story_microshift.feature
@@ -6,6 +6,7 @@ Feature: Microshift test stories
 		And setting config property "network-mode" to value "user" succeeds
 		And executing single crc setup command succeeds
 		And starting CRC with default bundle succeeds
+		And ensuring oc command is available
 
 	# End-to-end health check
 

--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -3,6 +3,7 @@ Feature: 4 Openshift stories
 
 	Background:
 		Given ensuring CRC cluster is running
+		And ensuring oc command is available
 		And executing "oc config view --raw -o jsonpath="{.clusters[?(@.name=='api-crc-testing:6443')].cluster.certificate-authority-data}"| base64 -d - > ca.crt" succeeds
 		And executing "echo | openssl s_client -connect api.crc.testing:6443 | openssl x509 -out server.crt" succeeds
 		And executing "openssl verify -CAfile ca.crt server.crt" succeeds


### PR DESCRIPTION
As part of https://github.com/crc-org/crc/pull/3782 debugging steps are added to figure out why the `oc login` require insecure sometimes but this logic fails in case the `oc` binary is not part of system path. This PR make sure that the oc command available before those debugging steps.

fixes: #3792


