### PR TITLE
e2e test: Ignore network-mode config property for non linux platform

### DIFF
--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -861,6 +861,10 @@ func EnsureUserIsLoggedIntoClusterSucceedsOrFails(expected string) error {
 }
 
 func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expected string) error {
+	// Since network-mode is only supported on Linux, we skip this property test for non-linux platforms
+	if property == "network-mode" && runtime.GOOS != "linux" {
+		return nil
+	}
 	if value == "current bundle" {
 		if !userProvidedBundle {
 			value = filepath.Join(util.CRCHome, "cache", bundleName)


### PR DESCRIPTION
Since network-mode is only supported on Linux for release bits of CRC, we skip this property test for non-linux platforms as part of e2e.


**Fixes:** #3796 

