### PR TITLE
proxy: Update trimTrailingEOL function to handle carriage return (\r)

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/ssh"
 	crctls "github.com/crc-org/crc/pkg/crc/tls"
 	"github.com/crc-org/crc/pkg/crc/validation"
+	crcstrings "github.com/crc-org/crc/pkg/strings"
 	"github.com/pborman/uuid"
 )
 
@@ -134,7 +135,7 @@ func EnsureSSHKeyPresentInTheCluster(ctx context.Context, ocConfig oc.Config, ss
 	if err != nil {
 		return err
 	}
-	sshPublicKey := strings.TrimRight(string(sshPublicKeyByte), "\r\n")
+	sshPublicKey := crcstrings.TrimTrailingEOL(string(sshPublicKeyByte))
 	if err := WaitForOpenshiftResource(ctx, ocConfig, "machineconfigs"); err != nil {
 		return err
 	}

--- a/pkg/crc/network/httpproxy/proxy.go
+++ b/pkg/crc/network/httpproxy/proxy.go
@@ -51,7 +51,7 @@ func readProxyCAData(proxyCAFile string) (string, error) {
 }
 
 func trimTrailingEOL(s string) string {
-	return strings.TrimRight(s, "\n")
+	return strings.TrimRight(s, "\r\n")
 }
 
 func NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) (*ProxyConfig, error) {

--- a/pkg/crc/network/httpproxy/proxy.go
+++ b/pkg/crc/network/httpproxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/logging"
 
 	"github.com/asaskevich/govalidator"
+	crcstrings "github.com/crc-org/crc/pkg/strings"
 	"github.com/pkg/errors"
 	"golang.org/x/net/http/httpproxy"
 )
@@ -47,11 +48,7 @@ func readProxyCAData(proxyCAFile string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return trimTrailingEOL(string(proxyCACert)), nil
-}
-
-func trimTrailingEOL(s string) string {
-	return strings.TrimRight(s, "\r\n")
+	return crcstrings.TrimTrailingEOL(string(proxyCACert)), nil
 }
 
 func NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) (*ProxyConfig, error) {

--- a/pkg/crc/network/httpproxy/proxy_test.go
+++ b/pkg/crc/network/httpproxy/proxy_test.go
@@ -15,3 +15,15 @@ func TestValidateProxyURL(t *testing.T) {
 	assert.EqualError(t, ValidateProxyURL("company.com:8080", true), "HTTPS proxy URL 'company.com:8080' is not valid: url should start with http:// or https://")
 	assert.EqualError(t, ValidateProxyURL("https://company.com", false), "HTTP proxy URL 'https://company.com' is not valid: url should start with http://")
 }
+func TestTrimTrailingEOL(t *testing.T) {
+	assert.Equal(t, "foo\nbar", trimTrailingEOL("foo\nbar\n"))
+	assert.Equal(t, "foo", trimTrailingEOL("foo\n"))
+	assert.Equal(t, "foo", trimTrailingEOL("foo\r\n"))
+	assert.Equal(t, "foo\r\nbar", trimTrailingEOL("foo\r\nbar\r\n"))
+	assert.Equal(t, "foo\r\nbar", trimTrailingEOL("foo\r\nbar\r\n\r\n"))
+	assert.Equal(t, "foo\nbar", trimTrailingEOL("foo\nbar\n\n"))
+	assert.Equal(t, "foo\nbar", trimTrailingEOL("foo\nbar\n\n\n"))
+	assert.Equal(t, "", trimTrailingEOL("\r\n"))
+	assert.Equal(t, "", trimTrailingEOL("\n"))
+	assert.Equal(t, "", trimTrailingEOL(""))
+}

--- a/pkg/crc/network/httpproxy/proxy_test.go
+++ b/pkg/crc/network/httpproxy/proxy_test.go
@@ -15,15 +15,3 @@ func TestValidateProxyURL(t *testing.T) {
 	assert.EqualError(t, ValidateProxyURL("company.com:8080", true), "HTTPS proxy URL 'company.com:8080' is not valid: url should start with http:// or https://")
 	assert.EqualError(t, ValidateProxyURL("https://company.com", false), "HTTP proxy URL 'https://company.com' is not valid: url should start with http://")
 }
-func TestTrimTrailingEOL(t *testing.T) {
-	assert.Equal(t, "foo\nbar", trimTrailingEOL("foo\nbar\n"))
-	assert.Equal(t, "foo", trimTrailingEOL("foo\n"))
-	assert.Equal(t, "foo", trimTrailingEOL("foo\r\n"))
-	assert.Equal(t, "foo\r\nbar", trimTrailingEOL("foo\r\nbar\r\n"))
-	assert.Equal(t, "foo\r\nbar", trimTrailingEOL("foo\r\nbar\r\n\r\n"))
-	assert.Equal(t, "foo\nbar", trimTrailingEOL("foo\nbar\n\n"))
-	assert.Equal(t, "foo\nbar", trimTrailingEOL("foo\nbar\n\n\n"))
-	assert.Equal(t, "", trimTrailingEOL("\r\n"))
-	assert.Equal(t, "", trimTrailingEOL("\n"))
-	assert.Equal(t, "", trimTrailingEOL(""))
-}

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -34,3 +34,7 @@ func FirstLine(input string) string {
 
 	return lines[0]
 }
+
+func TrimTrailingEOL(s string) string {
+	return strings.TrimRight(s, "\r\n")
+}

--- a/pkg/strings/strings_test.go
+++ b/pkg/strings/strings_test.go
@@ -136,3 +136,16 @@ func TestFirstLine(t *testing.T) {
 		}
 	})
 }
+
+func TestTrimTrailingEOL(t *testing.T) {
+	assert.Equal(t, "foo\nbar", TrimTrailingEOL("foo\nbar\n"))
+	assert.Equal(t, "foo", TrimTrailingEOL("foo\n"))
+	assert.Equal(t, "foo", TrimTrailingEOL("foo\r\n"))
+	assert.Equal(t, "foo\r\nbar", TrimTrailingEOL("foo\r\nbar\r\n"))
+	assert.Equal(t, "foo\r\nbar", TrimTrailingEOL("foo\r\nbar\r\n\r\n"))
+	assert.Equal(t, "foo\nbar", TrimTrailingEOL("foo\nbar\n\n"))
+	assert.Equal(t, "foo\nbar", TrimTrailingEOL("foo\nbar\n\n\n"))
+	assert.Equal(t, "", TrimTrailingEOL("\r\n"))
+	assert.Equal(t, "", TrimTrailingEOL("\n"))
+	assert.Equal(t, "", TrimTrailingEOL(""))
+}

--- a/test/extended/util/checks.go
+++ b/test/extended/util/checks.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	crcstrings "github.com/crc-org/crc/pkg/strings"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -91,7 +92,7 @@ func CompareExpectedWithActualNotMatchesRegex(notexpected string, actual string)
 }
 
 func CheckFormat(format string, actual string) error {
-	actual = strings.TrimRight(actual, "\n")
+	actual = crcstrings.TrimTrailingEOL(actual)
 	var err error
 	switch format {
 	case "URL":


### PR DESCRIPTION
It will fix the proxy parse issue in case user update the cert on windows and add blank line at the end of certificate. Unit test is also added for same.

fixes: #3785


