### PR TITLE
metadata: Add logic to fallback to quay if mirror is unreachable 

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -83,6 +83,8 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		EmergencyLogin: config.Get(crcConfig.EmergencyLogin).AsBool(),
 
 		PersistentVolumeSize: config.Get(crcConfig.PersistentVolumeSize).AsInt(),
+
+		EnableBundleQuayFallback: config.Get(crcConfig.EnableBundleQuayFallback).AsBool(),
 	}
 
 	client := newMachine()

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -119,18 +119,19 @@ func (h *Handler) Start(c *context) error {
 
 func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartConfig {
 	return types.StartConfig{
-		BundlePath:        cfg.Get(crcConfig.Bundle).AsString(),
-		Memory:            cfg.Get(crcConfig.Memory).AsInt(),
-		DiskSize:          cfg.Get(crcConfig.DiskSize).AsInt(),
-		CPUs:              cfg.Get(crcConfig.CPUs).AsInt(),
-		NameServer:        cfg.Get(crcConfig.NameServer).AsString(),
-		PullSecret:        cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
-		KubeAdminPassword: cfg.Get(crcConfig.KubeAdminPassword).AsString(),
-		IngressHTTPPort:   cfg.Get(crcConfig.IngressHTTPPort).AsUInt(),
-		IngressHTTPSPort:  cfg.Get(crcConfig.IngressHTTPSPort).AsUInt(),
-		Preset:            crcConfig.GetPreset(cfg),
-		EnableSharedDirs:  cfg.Get(crcConfig.EnableSharedDirs).AsBool(),
-		EmergencyLogin:    cfg.Get(crcConfig.EmergencyLogin).AsBool(),
+		BundlePath:               cfg.Get(crcConfig.Bundle).AsString(),
+		Memory:                   cfg.Get(crcConfig.Memory).AsInt(),
+		DiskSize:                 cfg.Get(crcConfig.DiskSize).AsInt(),
+		CPUs:                     cfg.Get(crcConfig.CPUs).AsInt(),
+		NameServer:               cfg.Get(crcConfig.NameServer).AsString(),
+		PullSecret:               cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
+		KubeAdminPassword:        cfg.Get(crcConfig.KubeAdminPassword).AsString(),
+		IngressHTTPPort:          cfg.Get(crcConfig.IngressHTTPPort).AsUInt(),
+		IngressHTTPSPort:         cfg.Get(crcConfig.IngressHTTPSPort).AsUInt(),
+		Preset:                   crcConfig.GetPreset(cfg),
+		EnableSharedDirs:         cfg.Get(crcConfig.EnableSharedDirs).AsBool(),
+		EmergencyLogin:           cfg.Get(crcConfig.EmergencyLogin).AsBool(),
+		EnableBundleQuayFallback: cfg.Get(crcConfig.EnableBundleQuayFallback).AsBool(),
 	}
 }
 

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -12,30 +12,31 @@ import (
 )
 
 const (
-	Bundle                  = "bundle"
-	CPUs                    = "cpus"
-	Memory                  = "memory"
-	DiskSize                = "disk-size"
-	NameServer              = "nameserver"
-	PullSecretFile          = "pull-secret-file"
-	DisableUpdateCheck      = "disable-update-check"
-	ExperimentalFeatures    = "enable-experimental-features"
-	NetworkMode             = "network-mode"
-	HostNetworkAccess       = "host-network-access"
-	HTTPProxy               = "http-proxy"
-	HTTPSProxy              = "https-proxy"
-	NoProxy                 = "no-proxy"
-	ProxyCAFile             = "proxy-ca-file"
-	ConsentTelemetry        = "consent-telemetry"
-	EnableClusterMonitoring = "enable-cluster-monitoring"
-	KubeAdminPassword       = "kubeadmin-password"
-	Preset                  = "preset"
-	EnableSharedDirs        = "enable-shared-dirs"
-	SharedDirPassword       = "shared-dir-password" // #nosec G101
-	IngressHTTPPort         = "ingress-http-port"
-	IngressHTTPSPort        = "ingress-https-port"
-	EmergencyLogin          = "enable-emergency-login"
-	PersistentVolumeSize    = "persistent-volume-size"
+	Bundle                   = "bundle"
+	CPUs                     = "cpus"
+	Memory                   = "memory"
+	DiskSize                 = "disk-size"
+	NameServer               = "nameserver"
+	PullSecretFile           = "pull-secret-file"
+	DisableUpdateCheck       = "disable-update-check"
+	ExperimentalFeatures     = "enable-experimental-features"
+	NetworkMode              = "network-mode"
+	HostNetworkAccess        = "host-network-access"
+	HTTPProxy                = "http-proxy"
+	HTTPSProxy               = "https-proxy"
+	NoProxy                  = "no-proxy"
+	ProxyCAFile              = "proxy-ca-file"
+	ConsentTelemetry         = "consent-telemetry"
+	EnableClusterMonitoring  = "enable-cluster-monitoring"
+	KubeAdminPassword        = "kubeadmin-password"
+	Preset                   = "preset"
+	EnableSharedDirs         = "enable-shared-dirs"
+	SharedDirPassword        = "shared-dir-password" // #nosec G101
+	IngressHTTPPort          = "ingress-http-port"
+	IngressHTTPSPort         = "ingress-https-port"
+	EmergencyLogin           = "enable-emergency-login"
+	PersistentVolumeSize     = "persistent-volume-size"
+	EnableBundleQuayFallback = "enable-bundle-quay-fallback"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -137,6 +138,9 @@ func RegisterSettings(cfg *Config) {
 		fmt.Sprintf("HTTP port to use for OpenShift ingress/routes on the host (1024-65535, default: %d)", constants.OpenShiftIngressHTTPPort))
 	cfg.AddSetting(IngressHTTPSPort, constants.OpenShiftIngressHTTPSPort, validatePort, RequiresHTTPSPortChangeWarning,
 		fmt.Sprintf("HTTPS port to use for OpenShift ingress/routes on the host (1024-65535, default: %d)", constants.OpenShiftIngressHTTPSPort))
+
+	cfg.AddSetting(EnableBundleQuayFallback, false, ValidateBool, SuccessfullyApplied,
+		"If bundle download from the default location fails, fallback to quay.io (true/false, default: false)")
 
 	if err := cfg.RegisterNotifier(Preset, presetChanged); err != nil {
 		logging.Debugf("Failed to register notifier for Preset: %v", err)

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -234,6 +234,8 @@ func getImageName(preset crcpreset.Preset) string {
 		return "podman-bundle"
 	case crcpreset.OKD:
 		return "okd-bundle"
+	case crcpreset.Microshift:
+		return "microshift-bundle"
 	default:
 		return "openshift-bundle"
 	}

--- a/pkg/crc/image/image.go
+++ b/pkg/crc/image/image.go
@@ -104,8 +104,10 @@ func getPresetNameE(imageName string) (crcpreset.Preset, error) {
 		return crcpreset.OKD, nil
 	case "podman-bundle":
 		return crcpreset.Podman, nil
+	case "microshift-bundle":
+		return crcpreset.Microshift, nil
 	default:
-		return crcpreset.OpenShift, fmt.Errorf("invalid image name '%s' (Should be openshift-bundle, okd-bundle or podman-bundle)", imageName)
+		return crcpreset.OpenShift, fmt.Errorf("invalid image name '%s' (Should be openshift-bundle, okd-bundle, podman-bundle or microshift-bundle)", imageName)
 	}
 }
 func GetPresetName(imageName string) crcpreset.Preset {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -46,7 +46,7 @@ import (
 
 const minimumMemoryForMonitoring = 14336
 
-func getCrcBundleInfo(preset crcPreset.Preset, bundleName, bundlePath string) (*bundle.CrcBundleInfo, error) {
+func getCrcBundleInfo(preset crcPreset.Preset, bundleName, bundlePath string, enableBundleQuayFallback bool) (*bundle.CrcBundleInfo, error) {
 	bundleInfo, err := bundle.Use(bundleName)
 	if err == nil {
 		logging.Infof("Loading bundle: %s...", bundleName)
@@ -54,7 +54,7 @@ func getCrcBundleInfo(preset crcPreset.Preset, bundleName, bundlePath string) (*
 	}
 	logging.Debugf("Failed to load bundle %s: %v", bundleName, err)
 	logging.Infof("Downloading bundle: %s...", bundleName)
-	bundlePath, err = bundle.Download(preset, bundlePath)
+	bundlePath, err = bundle.Download(preset, bundlePath, enableBundleQuayFallback)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	bundleName := bundle.GetBundleNameWithoutExtension(bundle.GetBundleNameFromURI(startConfig.BundlePath))
-	crcBundleMetadata, err := getCrcBundleInfo(startConfig.Preset, bundleName, startConfig.BundlePath)
+	crcBundleMetadata, err := getCrcBundleInfo(startConfig.Preset, bundleName, startConfig.BundlePath, startConfig.EnableBundleQuayFallback)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting bundle metadata")
 	}

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -43,6 +43,9 @@ type StartConfig struct {
 
 	// Persistent volume size
 	PersistentVolumeSize int
+
+	// Enable bundle quay fallback
+	EnableBundleQuayFallback bool
 }
 
 type ClusterConfig struct {

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -156,8 +156,9 @@ func getPreflightChecksHelper(config crcConfig.Storage) []Check {
 	mode := crcConfig.GetNetworkMode(config)
 	bundlePath := config.Get(crcConfig.Bundle).AsString()
 	preset := crcConfig.GetPreset(config)
+	enableBundleQuayFallback := config.Get(crcConfig.EnableBundleQuayFallback).AsBool()
 	logging.Infof("Using bundle path %s", bundlePath)
-	return getPreflightChecks(experimentalFeatures, mode, bundlePath, preset)
+	return getPreflightChecks(experimentalFeatures, mode, bundlePath, preset, enableBundleQuayFallback)
 }
 
 // StartPreflightChecks performs the preflight checks before starting the cluster

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -18,13 +18,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func bundleCheck(bundlePath string, preset crcpreset.Preset) Check {
+func bundleCheck(bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) Check {
 	return Check{
 		configKeySuffix:  "check-bundle-extracted",
 		checkDescription: "Checking if CRC bundle is extracted in '$HOME/.crc'",
 		check:            checkBundleExtracted(bundlePath),
 		fixDescription:   "Getting bundle for the CRC executable",
-		fix:              fixBundleExtracted(bundlePath, preset),
+		fix:              fixBundleExtracted(bundlePath, preset, enableBundleQuayFallback),
 		flags:            SetupOnly,
 
 		labels: None,
@@ -96,7 +96,7 @@ func checkBundleExtracted(bundlePath string) func() error {
 	}
 }
 
-func fixBundleExtracted(bundlePath string, preset crcpreset.Preset) func() error {
+func fixBundleExtracted(bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) func() error {
 	// Should be removed after 1.19 release
 	// This check will ensure correct mode for `~/.crc/cache` directory
 	// in case it exists.
@@ -112,7 +112,7 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset) func() error
 		}
 		var err error
 		logging.Infof("Downloading bundle: %s...", bundlePath)
-		if bundlePath, err = bundle.Download(preset, bundlePath); err != nil {
+		if bundlePath, err = bundle.Download(preset, bundlePath, enableBundleQuayFallback); err != nil {
 			return err
 		}
 

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -99,10 +99,10 @@ var daemonLaunchdChecks = []Check{
 // Passing 'SystemNetworkingMode' to getPreflightChecks currently achieves this
 // as there are no user networking specific checks
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift)
+	return getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false)
 }
 
-func getChecks(_ network.Mode, bundlePath string, preset crcpreset.Preset) []Check {
+func getChecks(_ network.Mode, bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) []Check {
 	checks := []Check{}
 
 	checks = append(checks, nonWinPreflightChecks...)
@@ -111,16 +111,16 @@ func getChecks(_ network.Mode, bundlePath string, preset crcpreset.Preset) []Che
 	checks = append(checks, genericCleanupChecks...)
 	checks = append(checks, vfkitPreflightChecks...)
 	checks = append(checks, resolverPreflightChecks...)
-	checks = append(checks, bundleCheck(bundlePath, preset))
+	checks = append(checks, bundleCheck(bundlePath, preset, enableBundleQuayFallback))
 	checks = append(checks, trayLaunchdCleanupChecks...)
 	checks = append(checks, daemonLaunchdChecks...)
 
 	return checks
 }
 
-func getPreflightChecks(_ bool, mode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {
+func getPreflightChecks(_ bool, mode network.Mode, bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) []Check {
 	filter := newFilter()
 	filter.SetNetworkMode(mode)
 
-	return filter.Apply(getChecks(mode, bundlePath, preset))
+	return filter.Apply(getChecks(mode, bundlePath, preset, enableBundleQuayFallback))
 }

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -17,9 +17,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 17)
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 17)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 17)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 17)
 
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 16)
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 16)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 16)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 16)
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -343,26 +343,26 @@ func getAllPreflightChecks() []Check {
 	filter.SetDistro(distro())
 	filter.SetSystemdUser(distro())
 
-	return filter.Apply(getChecks(distro(), constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift))
+	return filter.Apply(getChecks(distro(), constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false))
 }
 
-func getPreflightChecks(_ bool, networkMode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {
+func getPreflightChecks(_ bool, networkMode network.Mode, bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
 
-	return getPreflightChecksForDistro(distro(), networkMode, usingSystemdResolved == nil, bundlePath, preset)
+	return getPreflightChecksForDistro(distro(), networkMode, usingSystemdResolved == nil, bundlePath, preset, enableBundleQuayFallback)
 }
 
-func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mode, usingSystemdResolved bool, bundlePath string, preset crcpreset.Preset) []Check {
+func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mode, usingSystemdResolved bool, bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) []Check {
 	filter := newFilter()
 	filter.SetDistro(distro)
 	filter.SetSystemdUser(distro)
 	filter.SetNetworkMode(networkMode)
 	filter.SetSystemdResolved(usingSystemdResolved)
 
-	return filter.Apply(getChecks(distro, bundlePath, preset))
+	return filter.Apply(getChecks(distro, bundlePath, preset, enableBundleQuayFallback))
 }
 
-func getChecks(distro *linux.OsRelease, bundlePath string, preset crcpreset.Preset) []Check {
+func getChecks(distro *linux.OsRelease, bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) []Check {
 	var checks []Check
 	checks = append(checks, nonWinPreflightChecks...)
 	checks = append(checks, wsl2PreflightCheck)
@@ -376,7 +376,7 @@ func getChecks(distro *linux.OsRelease, bundlePath string, preset crcpreset.Pres
 	checks = append(checks, dnsmasqPreflightChecks...)
 	checks = append(checks, libvirtNetworkPreflightChecks...)
 	checks = append(checks, vsockPreflightCheck)
-	checks = append(checks, bundleCheck(bundlePath, preset))
+	checks = append(checks, bundleCheck(bundlePath, preset, enableBundleQuayFallback))
 
 	return checks
 }

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -509,7 +509,7 @@ func assertFuncEqual(t *testing.T, func1 interface{}, func2 interface{}) {
 }
 
 func assertExpectedPreflights(t *testing.T, distro *crcos.OsRelease, networkMode network.Mode, systemdResolved bool) {
-	preflights := getPreflightChecksForDistro(distro, networkMode, systemdResolved, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift)
+	preflights := getPreflightChecksForDistro(distro, networkMode, systemdResolved, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false)
 	var expected checkListForDistro
 	for _, expected = range checkListForDistros {
 		if expected.distro == distro && expected.networkMode == networkMode && expected.systemdResolved == systemdResolved {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -207,17 +207,17 @@ func checkVsock() error {
 // Passing 'UserNetworkingMode' to getPreflightChecks currently achieves this
 // as there are no system networking specific checks
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift)
+	return getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false)
 }
 
-func getChecks(bundlePath string, preset crcpreset.Preset) []Check {
+func getChecks(bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) []Check {
 	checks := []Check{}
 	checks = append(checks, memoryCheck(preset))
 	checks = append(checks, hypervPreflightChecks...)
 	checks = append(checks, crcUsersGroupExistsCheck)
 	checks = append(checks, userPartOfCrcUsersAndHypervAdminsGroupCheck)
 	checks = append(checks, vsockChecks...)
-	checks = append(checks, bundleCheck(bundlePath, preset))
+	checks = append(checks, bundleCheck(bundlePath, preset, enableBundleQuayFallback))
 	checks = append(checks, genericCleanupChecks...)
 	checks = append(checks, cleanupCheckRemoveCrcVM)
 	checks = append(checks, daemonTaskChecks...)
@@ -225,9 +225,9 @@ func getChecks(bundlePath string, preset crcpreset.Preset) []Check {
 	return checks
 }
 
-func getPreflightChecks(_ bool, networkMode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {
+func getPreflightChecks(_ bool, networkMode network.Mode, bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) []Check {
 	filter := newFilter()
 	filter.SetNetworkMode(networkMode)
 
-	return filter.Apply(getChecks(bundlePath, preset))
+	return filter.Apply(getChecks(bundlePath, preset, enableBundleQuayFallback))
 }

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -17,9 +17,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 22)
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 22)
+	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 22)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 22)
 
-	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 21)
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 21)
+	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 21)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 21)
 }


### PR DESCRIPTION
Since we are going to put bundles on quay and mirror where quay serve as
fallback solution. This PR makes user aware in case mirror fails to
download bundle.

```
INFO Getting bundle for the CRC executable
INFO Downloading bundle: /home/prkumar/.crc/cache/crc_microshift_libvirt_4.13.9_amd64.crcbundle...
INFO Unable to download bundle from mirror, falling back to quay
Getting image source signatures
Copying blob d37da0367460 done
Copying config f3021495d6 done
Writing manifest to image destination
Storing signatures
INFO Extracting the image bundle layer...
crc_microshift_libvirt_4.13.9_amd64.crcbundle:  1.46 GiB / 1.46 GiB [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
INFO Verifying the bundle signature...
INFO Uncompressing /home/prkumar/.crc/cache/crc_microshift_libvirt_4.13.9_amd64.crcbundle
crc.qcow2:  4.28 GiB / 4.28 GiB [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
oc:  141.85 MiB / 141.85 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
Your system is correctly setup for using CRC. Use 'crc start' to start the instance
```
