### PR TITLE
test: microshift: Don't force network-mode to 'user'

### DIFF
--- a/test/e2e/features/story_microshift.feature
+++ b/test/e2e/features/story_microshift.feature
@@ -3,12 +3,10 @@ Feature: Microshift test stories
 
 	Background:
 		Given setting config property "preset" to value "microshift" succeeds
-		And ensuring network mode user
 		And executing single crc setup command succeeds
 		And starting CRC with default bundle succeeds
 		And ensuring oc command is available
 		And ensuring microshift cluster is fully operational
-		
 	# End-to-end health check
 
 	@microshift @testdata @linux @windows @darwin @cleanup

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -1002,10 +1002,6 @@ func setPodmanEnv() error {
 }
 
 func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expected string) error {
-	// Since network-mode is only supported on Linux, we skip this property test for non-linux platforms
-	if property == "network-mode" && runtime.GOOS != "linux" {
-		return nil
-	}
 	if value == "current bundle" {
 		if !userProvidedBundle {
 			value = filepath.Join(util.CRCHome, "cache", bundleName)

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -552,8 +552,6 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		DeleteFileFromCRCHome)
 	s.Step(`^decode base64 file "(.*)" to "(.*)"$`,
 		DecodeBase64File)
-	s.Step(`^ensuring network mode user$`,
-		EnsureUserNetworkmode)
 	s.Step(`^ensuring microshift cluster is fully operational$`,
 		EnsureMicroshiftClusterIsOperational)
 	s.Step(`^kubeconfig is cleaned up$`,
@@ -1125,14 +1123,6 @@ func DecodeBase64File(inputFile, outputFile string) error {
 		cmd = fmt.Sprintf("base64 -d -i %s > %s", inputFile, outputFile)
 	}
 	return util.ExecuteCommandSucceedsOrFails(cmd, "succeeds")
-}
-
-func EnsureUserNetworkmode() error {
-	if runtime.GOOS == "linux" {
-		return crcCmd.SetConfigPropertyToValueSucceedsOrFails(
-			"network-mode", "user", "succeeds")
-	}
-	return nil
 }
 
 func EnsureKubeConfigIsCleanedUp() error {


### PR DESCRIPTION
Filing this now so that we don't forget it when we have bundles with https://github.com/crc-org/snc/pull/797. This will be put on hold until this happens.

We want our testing to be as close as possible to what end-users will 
experience. Changing `network-mode` is a significant difference from the 
default. With https://github.com/crc-org/snc/pull/797 fixed, we no longer
need to force it to `user`.