### PR TITLE
Add app routes for microshift preset

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -40,9 +40,10 @@ const (
 
 	OkdPullSecret = `{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}` // #nosec G101
 
-	RegistryURI   = "quay.io/crcont"
-	ClusterDomain = ".crc.testing"
-	AppsDomain    = ".apps-crc.testing"
+	RegistryURI         = "quay.io/crcont"
+	ClusterDomain       = ".crc.testing"
+	AppsDomain          = ".apps-crc.testing"
+	MicroShiftAppDomain = ".apps.crc.testing"
 
 	OpenShiftIngressHTTPPort  = 80
 	OpenShiftIngressHTTPSPort = 443

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -16,6 +16,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/extract"
 	crcos "github.com/crc-org/crc/pkg/os"
+	crcstrings "github.com/crc-org/crc/pkg/strings"
 	"github.com/pkg/errors"
 )
 
@@ -54,8 +55,11 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 	}
 
 	if !bundleInfo.IsPodman() {
-		if fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain) != constants.AppsDomain {
-			return nil, fmt.Errorf("unexpected bundle, it must have %s apps domain", constants.AppsDomain)
+		// TODO: update this logic after major release of bundle like 4.14
+		// As of now we are using this logic to support older bundles of microshift and it need to be updated
+		// to only provide app domain route information as per preset.
+		if !crcstrings.Contains([]string{constants.AppsDomain, constants.MicroShiftAppDomain}, fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain)) {
+			return nil, fmt.Errorf("unexpected bundle, it must have %s or %s apps domain", constants.AppsDomain, constants.MicroShiftAppDomain)
 		}
 		if bundleInfo.GetAPIHostname() != fmt.Sprintf("api%s", constants.ClusterDomain) {
 			return nil, fmt.Errorf("unexpected bundle, it must have %s base domain", constants.ClusterDomain)


### PR DESCRIPTION
Till now, microshift preset have app route `apps-crc.testing` instead of `apps.crc.testing` and because of that routes created by the an app were not accessible from the host so we put
https://github.com/crc-org/snc/pull/797 to updte the bundle metadata with correct route information but with current code it fails to validate the bundle. This PR adds another constant `MicroshiftAppDomain` and implement logic such that older bundle also supported which have `apps-crc.testing` as part of metadata.

We need to update this logic as part of a major openshift (4.14) release so that instead of `apps-crc.testing` or `apps.crc.testing` it will only check the `apps.crc.testing` for microshift and `apps-crc.testing` for OCP.


