### PR TITLE
start daemon posh script with RemoteSigned execution policy

### DIFF
--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -47,7 +47,7 @@ var (
   <Actions Context="Author">
     <Exec>
       <Command>powershell.exe</Command>
-      <Arguments>-WindowStyle Hidden -Command %s</Arguments>
+      <Arguments>-WindowStyle Hidden -ExecutionPolicy RemoteSigned -Command %s</Arguments>
     </Exec>
   </Actions>
 </Task>


### PR DESCRIPTION
the default effective policy is Restricted which prevents the hidden_daemon.ps1 script from running which is started from the scheduled task to run the  daemon

this fixes #3812
