### PR TITLE
preflight: add cleanup check to kill daemon process

### DIFF
--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -227,3 +227,12 @@ func checkDaemonPoshScript() error {
 func fixDaemonPoshScript() error {
 	return os.WriteFile(daemonPoshScriptPath, getDaemonPoshScriptContent(), 0600)
 }
+
+func killDaemonProcessIfRunning() error {
+	if daemonRunning() {
+		if err := killDaemonProcess(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -93,6 +93,13 @@ var vsockChecks = []Check{
 
 var daemonTaskChecks = []Check{
 	{
+		cleanupDescription: "Stop daemon process if it is running",
+		cleanup:            killDaemonProcessIfRunning,
+		flags:              CleanUpOnly,
+
+		labels: labels{Os: Windows},
+	},
+	{
 		configKeySuffix:    "check-daemon-task-posh-script-present",
 		checkDescription:   "Checking if the daemon task powershell script is present",
 		check:              checkDaemonPoshScript,

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -17,9 +17,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 21)
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 21)
+	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 22)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 22)
 
-	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 20)
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 20)
+	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 21)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift), 21)
 }


### PR DESCRIPTION
on windows recently it was observed that stopping the scheduled task did not stop the started daemon process

as workaround this cleanup is added to forcefully kill any running daemon process during 'crc cleanup'. This is needed since only one instance of the daemon is allowed to run, having a running  daemon prevents 'crc setup' from starting the daemon scheduled task
