### PR TITLE
Validate proxy taken from env variables and allow only absolute paths for config proxy-ca-file

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -56,7 +56,7 @@ func init() {
 	}
 
 	if err := setProxyDefaults(); err != nil {
-		logging.Fatal(err.Error())
+		logging.Warn(err.Error())
 	}
 
 	// Initiate segment client

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -196,6 +196,9 @@ func TestConfigGetAll(t *testing.T) {
 		switch v := v.Value.(type) {
 		case int:
 			configs[k] = float64(v)
+		// when config of type Path is converted to JSON it is converted to string
+		case crcConfig.Path:
+			configs[k] = string(v)
 		default:
 			configs[k] = v
 		}

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 
 	"github.com/crc-org/crc/v2/pkg/crc/preset"
@@ -101,6 +102,14 @@ func (c *Config) Set(key string, value interface{}) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf(invalidProp, value, key, err)
 		}
+	case Path:
+		path := cast.ToString(value)
+		path, err := filepath.Abs(path)
+		if err != nil {
+			return "", fmt.Errorf(invalidProp, value, key, err)
+		}
+		castValue = path
+
 	case preset.Preset:
 		castValue = cast.ToString(value)
 	default:
@@ -200,6 +209,8 @@ func (c *Config) Get(key string) SettingValue {
 		}
 	case string:
 		value = cast.ToString(value)
+	case Path:
+		value = Path(cast.ToString(value))
 	case bool:
 		value, err = cast.ToBoolE(value)
 		if err != nil {

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -122,7 +122,7 @@ func RegisterSettings(cfg *Config) {
 		"HTTPS proxy URL (string, like 'https://my-proxy.com:8443')")
 	cfg.AddSetting(NoProxy, "", validateNoProxy, SuccessfullyApplied,
 		"Hosts, ipv4 addresses or CIDR which do not use a proxy (string, comma-separated list such as '127.0.0.1,192.168.100.1/24')")
-	cfg.AddSetting(ProxyCAFile, "", validatePath, SuccessfullyApplied,
+	cfg.AddSetting(ProxyCAFile, Path(""), validatePath, SuccessfullyApplied,
 		"Path to an HTTPS proxy certificate authority (CA)")
 
 	cfg.AddSetting(EnableClusterMonitoring, false, ValidateBool, SuccessfullyApplied,

--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
@@ -157,4 +158,27 @@ func TestUnsetPreset(t *testing.T) {
 		IsDefault: true,
 		IsSecret:  false,
 	}, cfg.Get(CPUs))
+}
+
+func TestPath(t *testing.T) {
+	cfg, err := newInMemoryConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     Path(""),
+		Invalid:   false,
+		IsDefault: true,
+		IsSecret:  false,
+	}, cfg.Get(ProxyCAFile))
+
+	_, err = cfg.Set(ProxyCAFile, "testdata/foo.crt")
+	require.NoError(t, err)
+	expectedPath, err := filepath.Abs("testdata/foo.crt")
+	require.NoError(t, err)
+	assert.Equal(t, SettingValue{
+		Value:     Path(expectedPath),
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(ProxyCAFile))
 }

--- a/pkg/crc/config/types.go
+++ b/pkg/crc/config/types.go
@@ -55,3 +55,10 @@ type RawStorage interface {
 	Set(key string, value interface{}) error
 	Unset(key string) error
 }
+
+// type Path is used for a setting which is a file path
+type Path string
+
+func (p Path) String() string {
+	return string(p)
+}


### PR DESCRIPTION
- validate proxy urls taken from env vairbles
- validate that proxy certificate file exists before trying to read it
- only allow absolute paths for the `proxy-ca-file` config setting

Fixes #3690 #3098 #3641