### PR TITLE
Refactor: Move logic to get default image uri to constants

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -221,3 +221,18 @@ func GetDefaultMemory(preset crcpreset.Preset) int {
 		return 9216
 	}
 }
+
+func GetDefaultBundleImageRegistry(preset crcpreset.Preset) string {
+	return fmt.Sprintf("//%s/%s:%s", RegistryURI, getImageName(preset), version.GetBundleVersion(preset))
+}
+
+func getImageName(preset crcpreset.Preset) string {
+	switch preset {
+	case crcpreset.Podman:
+		return "podman-bundle"
+	case crcpreset.OKD:
+		return "okd-bundle"
+	default:
+		return "openshift-bundle"
+	}
+}

--- a/pkg/crc/image/image.go
+++ b/pkg/crc/image/image.go
@@ -19,17 +19,12 @@ import (
 	"github.com/crc-org/crc/v2/pkg/crc/gpg"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	crcpreset "github.com/crc-org/crc/v2/pkg/crc/preset"
-	"github.com/crc-org/crc/v2/pkg/crc/version"
 	"github.com/crc-org/crc/v2/pkg/extract"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type imageHandler struct {
 	imageURI string
-}
-
-func defaultURI(preset crcpreset.Preset) string {
-	return fmt.Sprintf("//%s/%s:%s", constants.RegistryURI, getImageName(preset), version.GetBundleVersion(preset))
 }
 
 func ValidateURI(uri *url.URL) error {
@@ -101,17 +96,6 @@ func getLayerPath(m *v1.Manifest, index int, mediaType string) (string, error) {
 	return strings.TrimPrefix(m.Layers[index].Digest.String(), "sha256:"), nil
 }
 
-func getImageName(preset crcpreset.Preset) string {
-	switch preset {
-	case crcpreset.Podman:
-		return "podman-bundle"
-	case crcpreset.OKD:
-		return "okd-bundle"
-	default:
-		return "openshift-bundle"
-	}
-}
-
 func getPresetNameE(imageName string) (crcpreset.Preset, error) {
 	switch imageName {
 	case "openshift-bundle":
@@ -129,10 +113,7 @@ func GetPresetName(imageName string) crcpreset.Preset {
 	return preset
 }
 
-func PullBundle(preset crcpreset.Preset, imageURI string) (string, error) {
-	if imageURI == "" {
-		imageURI = defaultURI(preset)
-	}
+func PullBundle(imageURI string) (string, error) {
 	imgHandler := imageHandler{
 		imageURI: strings.TrimPrefix(imageURI, "docker:"),
 	}

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -350,14 +350,14 @@ func Download(preset crcPreset.Preset, bundleURI string) (string, error) {
 		case crcPreset.Podman, crcPreset.OKD:
 			fallthrough
 		default:
-			return image.PullBundle(preset, "")
+			return image.PullBundle(constants.GetDefaultBundleImageRegistry(preset))
 		}
 	}
 	switch {
 	case strings.HasPrefix(bundleURI, "http://"), strings.HasPrefix(bundleURI, "https://"):
 		return download.Download(bundleURI, constants.MachineCacheDir, 0644, nil)
 	case strings.HasPrefix(bundleURI, "docker://"):
-		return image.PullBundle(preset, bundleURI)
+		return image.PullBundle(bundleURI)
 	}
 	// the `bundleURI` parameter turned out to be a local path
 	return bundleURI, nil


### PR DESCRIPTION
Right now, to pull default image we pass empty string to `image/PullBundle` function and have logic to get default image URI in case the empty string for URI which is bit confusing. In this PR we are adding `GetDefaultBundleImageRegistryURL` function to constants pkg to get this info and change `image/PullBundle` signature.


