### PR TITLE
Revert "proxy: Add fallback to x509.NewCertPool() on Windows"

### DIFF
--- a/pkg/crc/network/httpproxy/proxy.go
+++ b/pkg/crc/network/httpproxy/proxy.go
@@ -207,7 +207,7 @@ func (p *ProxyConfig) tlsConfig() (*tls.Config, error) {
 	caCertPool, err := x509.SystemCertPool()
 	if err != nil {
 		logging.Warnf("Could not load system CA pool: %v", err)
-		caCertPool = x509.NewCertPool()
+		return nil, err
 	}
 	ok := caCertPool.AppendCertsFromPEM([]byte(p.ProxyCACert))
 	if !ok {


### PR DESCRIPTION
This reverts commit f5a980949d6bcfd4f6df115b2f6d08bbb450c71f.

Prior to golang 1.18, SystemCertPool() was not available on Windows.
This was added in golang 1.18 https://go.dev/doc/go1.18

Since crc now uses golang 1.19 or newer, we no longer need this fallback
to x509.NewCertPool(). This keeps the explicit warning for now in case
there still would be issues with this.