### PR TITLE
Add persistent volume size option to config

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -81,6 +81,8 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		EnableSharedDirs:  config.Get(crcConfig.EnableSharedDirs).AsBool(),
 
 		EmergencyLogin: config.Get(crcConfig.EmergencyLogin).AsBool(),
+
+		PersistentVolumeSize: config.Get(crcConfig.PersistentVolumeSize).AsInt(),
 	}
 
 	client := newMachine()

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -35,6 +35,7 @@ const (
 	IngressHTTPPort         = "ingress-http-port"
 	IngressHTTPSPort        = "ingress-https-port"
 	EmergencyLogin          = "enable-emergency-login"
+	PersistentVolumeSize    = "persistent-volume-size"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -91,6 +92,8 @@ func RegisterSettings(cfg *Config) {
 		"Enable experimental features (true/false, default: false)")
 	cfg.AddSetting(EmergencyLogin, false, ValidateBool, SuccessfullyApplied,
 		"Enable emergency login for 'core' user. Password is randomly generated. (true/false, default: false)")
+	cfg.AddSetting(PersistentVolumeSize, constants.DefaultPersistentVolumeSize, validatePersistentVolumeSize, SuccessfullyApplied,
+		fmt.Sprintf("Total size in GiB of the persistent volume used by the CSI driver for %s preset (must be greater than or equal to '%d')", preset.Microshift, constants.DefaultPersistentVolumeSize))
 
 	// Shared directories configs
 	if runtime.GOOS == "windows" {

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -41,6 +41,19 @@ func validateDiskSize(value interface{}) (bool, string) {
 	return true, ""
 }
 
+// validatePersistentVolumeSize checks if provided disk size is valid in the config
+func validatePersistentVolumeSize(value interface{}) (bool, string) {
+	diskSize, err := cast.ToIntE(value)
+	if err != nil {
+		return false, fmt.Sprintf("could not convert '%s' to integer", value)
+	}
+	if err := validation.ValidatePersistentVolumeSize(diskSize); err != nil {
+		return false, err.Error()
+	}
+
+	return true, ""
+}
+
 // validateCPUs checks if provided cpus count is valid in the config
 func validateCPUs(value interface{}, preset crcpreset.Preset) (bool, string) {
 	v, err := cast.ToIntE(value)

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -15,6 +15,8 @@ const (
 	DefaultName     = "crc"
 	DefaultDiskSize = 31
 
+	DefaultPersistentVolumeSize = 15
+
 	DefaultSSHUser = "core"
 	DefaultSSHPort = 22
 

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -40,6 +40,9 @@ type StartConfig struct {
 
 	// Enable emergency login
 	EmergencyLogin bool
+
+	// Persistent volume size
+	PersistentVolumeSize int
 }
 
 type ClusterConfig struct {

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -42,6 +42,14 @@ func ValidateDiskSize(value int) error {
 	return nil
 }
 
+func ValidatePersistentVolumeSize(value int) error {
+	if value < constants.DefaultPersistentVolumeSize {
+		return fmt.Errorf("requires disk size in GiB >= %d", constants.DefaultPersistentVolumeSize)
+	}
+
+	return nil
+}
+
 // ValidateEnoughMemory checks if enough memory is installed on the host
 func ValidateEnoughMemory(value int) error {
 	totalMemory := memory.TotalMemory()


### PR DESCRIPTION
This pr enable user to specify the size which is used by persistent volume in case of microshift preset. As of now we just extend the disk size to root mounted partition and free space (which used for pvc) is only 15GiB. Some users want to have more free space to consume it for pvc as per the workload and with this option now it is possible.

```
$ crc config set disk-size 50
$ crc config set persistent-volume-size 20
$ crc start
[...]
<crc_vm> $ sudo vgdisplay
  --- Volume group ---
  VG Name               rhel
  System ID
  Format                lvm2
  Metadata Areas        1
  Metadata Sequence No  5
  VG Access             read/write
  VG Status             resizable
  MAX LV                0
  Cur LV                1
  Open LV               1
  Max PV                0
  Cur PV                1
  Act PV                1
  VG Size               <49.02 GiB
  PE Size               4.00 MiB
  Total PE              12549
  Alloc PE / Size       7429 / <29.02 GiB
  Free  PE / Size       5120 / 20.00 GiB
  VG UUID               O7d5v9-F8HE-E0Dj-e9sE-1qgv-F74d-CZz34d
```


**Fixes:** Issue #3747 