### PR TITLE
Validation: Don't fail if the bundle path is same as default path 

### DIFF
--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -60,10 +60,8 @@ func runSetup(_ []string) error {
 		}
 	}
 
-	if !config.Get(crcConfig.Bundle).IsDefault {
-		if err := validation.ValidateBundlePath(config.Get(crcConfig.Bundle).AsString(), crcConfig.GetPreset(config)); err != nil {
-			return err
-		}
+	if err := validation.ValidateBundle(config.Get(crcConfig.Bundle).AsString(), crcConfig.GetPreset(config)); err != nil {
+		return err
 	}
 
 	// set global variable to force terminal output

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -110,17 +110,6 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset) func() error
 		if err := os.MkdirAll(bundleDir, 0775); err != nil {
 			return fmt.Errorf("Cannot create directory %s: %v", bundleDir, err)
 		}
-		if err := validation.ValidateBundle(bundlePath, preset); err != nil {
-			var e *validation.InvalidPath
-			if !errors.As(err, &e) {
-				return err
-			}
-			if bundlePath != constants.GetDefaultBundlePath(preset) {
-				/* This message needs to be improved when the bundle has been set in crc config for example */
-				return fmt.Errorf("%s is invalid or missing, run 'crc setup' to download the bundle", bundlePath)
-			}
-		}
-
 		var err error
 		logging.Infof("Downloading bundle: %s...", bundlePath)
 		if bundlePath, err = bundle.Download(preset, bundlePath); err != nil {

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -87,6 +87,9 @@ func ValidateBundle(bundlePath string, preset crcpreset.Preset) error {
 	bundleName := bundle.GetBundleNameFromURI(bundlePath)
 	bundleMetadata, err := bundle.Get(bundleName)
 	if err != nil {
+		if bundlePath == constants.GetDefaultBundlePath(preset) {
+			return nil
+		}
 		return ValidateBundlePath(bundlePath, preset)
 	}
 	bundleMismatchWarning(bundleMetadata.GetBundleName(), preset)

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -68,10 +68,15 @@ func ValidateBundlePath(bundlePath string, preset crcpreset.Preset) error {
 	logging.Debugf("Got bundle path: %s", bundlePath)
 	if err := ValidateURL(bundlePath); err != nil {
 		var urlError *url.Error
+		var invalidPathError *invalidPath
+		// If error occur due to invalid path, then return with a more meaningful error message
+		if errors.As(err, &invalidPathError) {
+			return fmt.Errorf("%s is invalid or missing, run 'crc setup' to download the default bundle", bundlePath)
+		}
 		// Some local paths (for example relative paths) can't be parsed/validated by `ValidateURL` and will be validated here
 		if errors.As(err, &urlError) {
 			if err1 := ValidatePath(bundlePath); err1 != nil {
-				return err1
+				return fmt.Errorf("%s is invalid or missing, run 'crc setup' to download the default bundle", bundlePath)
 			}
 		} else {
 			return err

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -146,11 +146,11 @@ func ValidateURL(uri string) error {
 	}
 }
 
-type InvalidPath struct {
+type invalidPath struct {
 	path string
 }
 
-func (e *InvalidPath) Error() string {
+func (e *invalidPath) Error() string {
 	return fmt.Sprintf("file '%s' does not exist", e.path)
 
 }
@@ -158,7 +158,7 @@ func (e *InvalidPath) Error() string {
 // ValidatePath check if provide path is exist
 func ValidatePath(path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return &InvalidPath{path: path}
+		return &invalidPath{path: path}
 	}
 	return nil
 }


### PR DESCRIPTION
ValidateBundle function try to get the bundle info if the bundle is
already extracted or run ValidateBundlePath which in case check if the
bundle exist for provided path and for default bundle it give error in
case not persent in the default location. Ideally ValidateBundle should
just return nil in case default bundle path is provided.

With this change, same function can consme as part of `cmd/setup` which
right now have addition logic to ignore default bundle path.