### PR TITLE
Fix downloads from github

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -17,9 +17,9 @@ import (
 	"github.com/crc-org/crc/pkg/crc/daemonclient"
 	crcErrors "github.com/crc-org/crc/pkg/crc/errors"
 	"github.com/crc-org/crc/pkg/crc/logging"
+	"github.com/crc-org/crc/pkg/crc/machine/bundle"
 	"github.com/crc-org/crc/pkg/crc/machine/types"
 	"github.com/crc-org/crc/pkg/crc/network"
-	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	"github.com/crc-org/crc/pkg/crc/preflight"
 	"github.com/crc-org/crc/pkg/crc/preset"
 	"github.com/crc-org/crc/pkg/crc/validation"
@@ -214,7 +214,7 @@ func checkIfNewVersionAvailable(noUpdateCheck bool) error {
 }
 
 func newVersionAvailable() (bool, string, string, error) {
-	release, err := crcversion.GetCRCLatestVersionFromMirror(httpproxy.HTTPTransport())
+	release, err := bundle.FetchLatestReleaseInfo()
 	if err != nil {
 		return false, "", "", err
 	}
@@ -228,7 +228,7 @@ func newVersionAvailable() (bool, string, string, error) {
 	return release.Version.CrcVersion.GreaterThan(currentVersion), release.Version.CrcVersion.String(), downloadLink(release), nil
 }
 
-func downloadLink(release *crcversion.CrcReleaseInfo) string {
+func downloadLink(release *bundle.ReleaseInfo) string {
 	if link, ok := release.Links[runtime.GOOS]; ok {
 		return link
 	}

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -18,9 +18,7 @@ import (
 	"github.com/crc-org/crc/pkg/crc/gpg"
 	"github.com/crc-org/crc/pkg/crc/image"
 	"github.com/crc-org/crc/pkg/crc/logging"
-	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
 	crcPreset "github.com/crc-org/crc/pkg/crc/preset"
-	"github.com/crc-org/crc/pkg/crc/version"
 	"github.com/crc-org/crc/pkg/download"
 )
 
@@ -300,10 +298,7 @@ func getBundleDownloadInfo(preset crcPreset.Preset) (*download.RemoteFile, error
 // then verifies it is signed by redhat release key, if signature is valid it returns the hash
 // for the default bundle of preset from the file
 func getDefaultBundleVerifiedHash(preset crcPreset.Preset) (string, error) {
-	res, err := download.InMemory(constants.GetDefaultBundleSignedHashURL(preset),
-		version.UserAgent(),
-		httpproxy.HTTPTransport(),
-	)
+	res, err := download.InMemory(constants.GetDefaultBundleSignedHashURL(preset))
 	if err != nil {
 		return "", err
 	}
@@ -381,7 +376,7 @@ type ReleaseInfo struct {
 
 func FetchLatestReleaseInfo() (*ReleaseInfo, error) {
 	const releaseInfoLink = "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/release-info.json"
-	response, err := download.InMemory(releaseInfoLink, version.UserAgent(), httpproxy.HTTPTransport())
+	response, err := download.InMemory(releaseInfoLink)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -1,17 +1,12 @@
 package version
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/crc-org/crc/pkg/crc/logging"
 	crcPreset "github.com/crc-org/crc/pkg/crc/preset"
-	"github.com/crc-org/crc/pkg/download"
 )
 
 // The following variables are private fields and should be set when compiling with ldflags, for example --ldflags="-X github.com/crc-org/crc/pkg/version.crcVersion=vX.Y.Z
@@ -40,22 +35,10 @@ var (
 )
 
 const (
-	releaseInfoLink = "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
 	crcTrayElectronVersion = "1.2.9"
 	crcAdminHelperVersion  = "0.0.12"
 )
-
-type CrcReleaseInfo struct {
-	Version Version           `json:"version"`
-	Links   map[string]string `json:"links"`
-}
-
-type Version struct {
-	CrcVersion       *semver.Version `json:"crcVersion"`
-	GitSha           string          `json:"gitSha"`
-	OpenshiftVersion string          `json:"openshiftVersion"`
-}
 
 func GetCRCVersion() string {
 	return crcVersion
@@ -108,26 +91,6 @@ func InstallPath() string {
 		return filepath.Dir(currentExecutablePath)
 	}
 	return filepath.Dir(src)
-}
-
-func GetCRCLatestVersionFromMirror(transport http.RoundTripper) (*CrcReleaseInfo, error) {
-	response, err := download.InMemory(releaseInfoLink, UserAgent(), transport)
-	if err != nil {
-		return nil, err
-	}
-	defer response.Close()
-
-	releaseMetaData, err := io.ReadAll(response)
-	if err != nil {
-		return nil, err
-	}
-
-	var releaseInfo CrcReleaseInfo
-	if err := json.Unmarshal(releaseMetaData, &releaseInfo); err != nil {
-		return nil, fmt.Errorf("Error unmarshaling JSON metadata: %v", err)
-	}
-
-	return &releaseInfo, nil
 }
 
 func GetDefaultPreset() crcPreset.Preset {

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -64,6 +64,7 @@ func Download(uri, destination string, mode os.FileMode, sha256sum []byte) (stri
 	logging.Debugf("Downloading %s to %s", uri, destination)
 
 	client := grab.NewClient()
+	client.UserAgent = version.UserAgent()
 	client.HTTPClient = &http.Client{Transport: httpproxy.HTTPTransport()}
 	req, err := grab.NewRequest(destination, uri)
 	if err != nil {

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -92,18 +92,12 @@ func Download(uri, destination string, mode os.FileMode, sha256sum []byte) (stri
 func InMemory(url string) (io.ReadCloser, error) {
 	client := grab.NewClient()
 	client.HTTPClient = &http.Client{Transport: httpproxy.HTTPTransport()}
+	client.UserAgent = version.UserAgent()
 
-	httpReq, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http request: %w", err)
-	}
-	httpReq.Header.Set("User-Agent", version.UserAgent())
-
-	grabReq, err := grab.NewRequest("", "")
+	grabReq, err := grab.NewRequest("", url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create grab request: %w", err)
 	}
-	grabReq.HTTPRequest = httpReq
 	// do not write the downloaded file to disk
 	grabReq.NoStore = true
 

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/crc-org/crc/pkg/crc/logging"
 	"github.com/crc-org/crc/pkg/crc/network/httpproxy"
+	"github.com/crc-org/crc/pkg/crc/version"
 	"github.com/crc-org/crc/pkg/os/terminal"
 
 	"github.com/cavaliergopher/grab/v3"
@@ -88,15 +89,15 @@ func Download(uri, destination string, mode os.FileMode, sha256sum []byte) (stri
 
 // Download takes an URL and the User-Agent string to use in the http request
 // it takes  http.RoundTripper as the third argument to be used by the client
-func InMemory(url, userAgent string, transport http.RoundTripper) (io.ReadCloser, error) {
+func InMemory(url string) (io.ReadCloser, error) {
 	client := grab.NewClient()
-	client.HTTPClient = &http.Client{Transport: transport}
+	client.HTTPClient = &http.Client{Transport: httpproxy.HTTPTransport()}
 
 	httpReq, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create http request: %w", err)
 	}
-	httpReq.Header.Set("User-Agent", userAgent)
+	httpReq.Header.Set("User-Agent", version.UserAgent())
 
 	grabReq, err := grab.NewRequest("", "")
 	if err != nil {


### PR DESCRIPTION
download attempts from github lead to 403 errors. This comes from the user
agent used in our request.
This PR fixes this, but starts with refactors to allow importing
pkg/crc/version from pkg/download.

In particular, this moves GetLatestCRCVersionFromMirror() to
pkg/crc/machine/bundle, which is not a great place for it, but I'm not sure
where to put it otherwise, open to suggestions!

This fixes https://github.com/crc-org/crc/issues/3827