### PR TITLE
docs: fixed broken links and adopted htmltest - fixes #3834

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,9 @@
+---
+# Configuration file for htmltest
+# See: https://github.com/wjdp/htmltest
+
+DirectoryPath: docs/build # Not build/site to avoid false positives on 404.html
+OutputDir: .cache/htmltest
+CacheExpires: "12h" # Default is 2 weeks.
+ExternalTimeout: 60 # (seconds) default is 15.
+# IgnoreURLs:

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ RELEASE_DIR ?= release
 
 # Docs build related variables
 DOCS_BUILD_DIR ?= docs/build
-DOCS_TEST_CONTAINER ?= quay.io/crcont/docs-builder:latest
 DOCS_BUILD_CONTAINER ?= quay.io/crcont/antora:latest
+DOCS_SERVE_CONTAINER ?= docker.io/httpd:alpine
+DOCS_TEST_CONTAINER ?= docker.io/wjdp/htmltest:latest
 DOCS_BUILD_TARGET ?= /docs/source/getting_started/master.adoc
 
 GOOS ?= $(shell go env GOOS)
@@ -145,11 +146,11 @@ build_docs:
 
 .PHONY: docs_serve
 docs_serve: build_docs
-	${CONTAINER_RUNTIME} run -it -v $(CURDIR)/docs:/docs:Z --rm -p 8088:8088/tcp $(DOCS_TEST_CONTAINER) docs_serve
+	${CONTAINER_RUNTIME} run -it -v $(CURDIR)/docs/build:/usr/local/apache2/htdocs/:Z --rm -p 8088:80/tcp $(DOCS_SERVE_CONTAINER)
 
 .PHONY: docs_check_links
 docs_check_links:
-	${CONTAINER_RUNTIME} run -v $(CURDIR)/docs:/docs:Z --rm $(DOCS_TEST_CONTAINER) docs_check_links
+	${CONTAINER_RUNTIME} run -v $(CURDIR):/test:Z --rm $(DOCS_TEST_CONTAINER) -c .htmltest.yml
 
 .PHONY: clean_docs clean_macos_package
 clean_docs:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -2,7 +2,7 @@
 site:
   title: CRC Documentation
   start_page: getting_started:getting_started:introducing.adoc
-  url: https://crc.dev
+  url: https://crc.dev/crc
   robots: allow
 content:
   sources:
@@ -12,7 +12,7 @@ content:
       start_path: docs # Point to docs content
 output:
   clean: true # Delete stale content
-  dir: docs/build
+  dir: docs/build/crc
 runtime:
   cache_dir: .cache/antora # Use a local directory rather than $HOME
   log:
@@ -57,13 +57,12 @@ asciidoc:
     crc-gsg: CRC Getting Started Guide
     # URLs
     crc-download-url: https://console.redhat.com/openshift/create/local
-    crc-gsg-url: https://crc-org.github.io/crc/
-    openshift-installer-url: https://console.redhat.com/openshift/install
+    crc-gsg-url: https://crc.dev/crc/
+    openshift-installer-url: https://console.redhat.com/openshift/create
     openshift-docs-url: https://docs.openshift.com/container-platform/latest
     openshift-docs-url-landing-page: "{openshift-docs-url}/welcome/index.html#developer-activities"
     oc-download-url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/
-    odo-docs-url: "{openshift-docs-url}/cli_reference/developer_cli_odo/understanding-odo.html"
-    odo-docs-url-installing: "{openshift-docs-url}/cli_reference/developer_cli_odo/installing-odo.html"
-    odo-docs-url-single-component: "{openshift-docs-url}/cli_reference/developer_cli_odo/creating_and_deploying_applications_with_odo/creating-a-single-component-application-with-odo.html"
+    odo-docs-url: https://odo.dev/docs/introduction
+    odo-docs-url-installing: https://odo.dev/docs/overview/installation
     telemetry-notice-url: https://developers.redhat.com/article/tool-data-collection
     rhel-resolved-docs: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/using-different-dns-servers-for-different-domains_configuring-and-managing-networking

--- a/docs/supplemental-ui/partials/article-404.hbs
+++ b/docs/supplemental-ui/partials/article-404.hbs
@@ -1,0 +1,14 @@
+<article class="doc">
+  <h1 class="page">{{{or page.title "Page Not Found"}}}</h1>
+  <div class="paragraph">
+    <p>The page you&#8217;re looking for does not exist. It may have been moved.
+      You can return to the
+      <a href="{{site.url}}/index.html">start page</a>, or follow one of the
+      links in the navigation to the left.</p>
+  </div>
+  <div class="paragraph">
+    <p>If you arrived on this page by clicking on a link, please notify the
+      owner of the site that the link is broken. If you typed the URL of this
+      page manually, please double check that you entered the address correctly.</p>
+  </div>
+</article>


### PR DESCRIPTION
docs: fixed broken links and adopted htmltest
chore: use the standard `httpd` container image to serve the docs locally

fixes #3834

```
make build_docs docs_check_links
podman run -v /home/ffloreth/src/gh/themr0c/crc:/antora:Z --rm docker.io/antora/antora:latest antora-playbook.yml
podman run -v /home/ffloreth/src/gh/themr0c/crc:/test:Z --rm docker.io/wjdp/htmltest:latest -c .htmltest.yml
htmltest started at 01:15:50 on docs/build
========================================================================
✔✔✔ passed in 1.345655164s
tested 10 documents
```