### PR TITLE
preflight: accept lower case drive letter in daemon posh script check

### DIFF
--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -211,8 +211,10 @@ func getDaemonPoshScriptContent() []byte {
 	if err != nil {
 		return []byte{}
 	}
+	drive := filepath.VolumeName(binPath)
+	binPathWithSmallCaseDriveLetter := strings.Replace(binPath, drive, strings.ToLower(drive), 1)
 	daemonCmdArgs := `daemon --log-level debug`
-	return []byte(fmt.Sprintf(daemonPoshScriptTemplate, binPath, daemonCmdArgs))
+	return []byte(fmt.Sprintf(daemonPoshScriptTemplate, binPathWithSmallCaseDriveLetter, daemonCmdArgs))
 }
 
 func checkDaemonPoshScript() error {


### PR DESCRIPTION
in the preflight check for existence of the powershell script used for starting the daemon, we check that the current crc executable path  is present

when crc is executed by the extension, the current executable path   is
returned with a small case drive letter whereas crc directly invoked by
a user returns a path with upper case drive letter and fails this check

with this commit we are not matching the whole content of the file but
only checking if either lower case or upper case varient of the   path
exists in the script
