### PR TITLE
e2e: Fix syntax for commands to check cluster certs

### DIFF
--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -4,8 +4,9 @@ Feature: 4 Openshift stories
 	Background:
 		Given ensuring CRC cluster is running
 		And ensuring oc command is available
-		And executing "oc config view --raw -o jsonpath="{.clusters[?(@.name=='api-crc-testing:6443')].cluster.certificate-authority-data}"| base64 -d - > ca.crt" succeeds
-		And executing "echo | openssl s_client -connect api.crc.testing:6443 | openssl x509 -out server.crt" succeeds
+		And executing "oc config view --raw -o jsonpath="{.clusters[?(@.name=='api-crc-testing:6443')].cluster.certificate-authority-data}" > ca.base64" succeeds
+		And decode base64 file "ca.base64" to "ca.crt"
+		And executing "echo QUIT | openssl s_client -connect api.crc.testing:6443 | openssl x509 -out server.crt" succeeds
 		And executing "openssl verify -CAfile ca.crt server.crt" succeeds
 		And ensuring user is logged in succeeds
 

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -512,6 +512,8 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		ConfigFileInCRCHomeContainsKey)
 	s.Step(`removing file "(.*)" from CRC home folder succeeds$`,
 		DeleteFileFromCRCHome)
+	s.Step(`^decode base64 file "(.*)" to "(.*)"$`,
+		DecodeBase64File)
 
 	s.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
 
@@ -977,4 +979,15 @@ func PullLoginTagPushImageSucceeds(image string) error {
 	}
 
 	return nil
+}
+
+// Decode a file encoded with base64
+func DecodeBase64File(inputFile, outputFile string) error {
+	var cmd string
+	if runtime.GOOS == "windows" {
+		cmd = fmt.Sprintf("certutil.exe -decode %s %s", inputFile, outputFile)
+	} else {
+		cmd = fmt.Sprintf("base64 -d -i %s > %s", inputFile, outputFile)
+	}
+	return util.ExecuteCommandSucceedsOrFails(cmd, "succeeds")
 }


### PR DESCRIPTION
With https://github.com/crc-org/crc/commit/9bb4cac2bb8e65ee84e9019921db978742ad321f several steps were introduced to ensure the cert chain from the cluster, but the syntax on those steps fails on some of platforms / versions.

This PR fix the syntax making it supportable on all platforms.

