### PR TITLE
docs: fixed docs website publication

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -24,4 +24,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/build
+          publish_dir: ./docs/build/crc

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -2,8 +2,9 @@
 # Configuration file for htmltest
 # See: https://github.com/wjdp/htmltest
 
-DirectoryPath: docs/build # Not build/site to avoid false positives on 404.html
+DirectoryPath: docs/build
 OutputDir: .cache/htmltest
 CacheExpires: "12h" # Default is 2 weeks.
 ExternalTimeout: 60 # (seconds) default is 15.
-# IgnoreURLs:
+IgnoreURLs:
+  - https://crc.dev/crc


### PR DESCRIPTION
- For htmltest:
  - Continue building in the `docs/build/crc` directory for htmltest.
  - Ignore production website (for cases like today when it has published with mistakes).
  - Removed leftover comment.
- Publish the `./docs/build/crc` directory


fixes #3844
