### PR TITLE
skip TestGetVerifiedHash when internet connectivity is slow or missing

### DIFF
--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -60,7 +60,7 @@ export GOFLAGS="-mod=vendor"
 mkdir embed-files
 cp /usr/bin/crc-driver-libvirt embed-files
 cp /usr/bin/crc-admin-helper embed-files/crc-admin-helper-linux
-make COMMIT_SHA=__COMMIT_SHA__ GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ release
+make CRC_IN_DISCONNECTED_ENV=true COMMIT_SHA=__COMMIT_SHA__ GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ release
 
 %install
 # with fedora macros: gopkginstall

--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -3,6 +3,8 @@ package bundle
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode"
@@ -188,6 +190,11 @@ func TestGetBundleType(t *testing.T) {
 }
 
 func TestVerifiedHash(t *testing.T) {
+	// skip the test when running in disconnected env
+	if disconnected, _ := strconv.ParseBool(os.Getenv("CRC_IN_DISCONNECTED_ENV")); disconnected {
+		t.Skip("Skipping test since running in disconnected env")
+	}
+
 	sha256sum, err := getVerifiedHash("https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/bundles/openshift/4.13.0/sha256sum.txt.sig", "crc_libvirt_4.13.0_amd64.crcbundle")
 	require.NoError(t, err)
 	require.Equal(t, "6aad57019aaab95b670378f569b3f4a16398da0358dd1057996453a8d6d92212", sha256sum)


### PR DESCRIPTION
this is added to skip the tests primarily in brew environment where outside connectivity is not present and hence the test fails

