### PR TITLE
build: Add missing /v2/ to imports

### DIFF
--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/crc-org/crc/pkg/crc/constants"
-	"github.com/crc-org/crc/pkg/os"
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/os"
 	"github.com/spf13/cast"
 )
 


### PR DESCRIPTION
I broke the build by pushing too hastily a PR made before the /v2/
changes :-/