### PR TITLE
start: Use `RunPrivate` for checking pull secret for microshift

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -1068,7 +1068,7 @@ func startMicroshift(ctx context.Context, sshRunner *crcssh.Runner, ocConfig oc.
 }
 
 func ensurePullSecretPresentInVM(sshRunner *crcssh.Runner, pullSec cluster.PullSecretLoader) error {
-	if pullSecret, _, err := sshRunner.RunPrivileged("Checking if pull secret already present in the VM", "cat", "/etc/crio/openshift-pull-secret"); err == nil {
+	if pullSecret, _, err := sshRunner.RunPrivate("sudo", "cat", "/etc/crio/openshift-pull-secret"); err == nil {
 		if err := validation.ImagePullSecret(pullSecret); err == nil {
 			return nil
 		}


### PR DESCRIPTION
As part of 211e9dd7, I used `RunPrivileged` which end up exposing pull secret to debug logs. With this PR we are going to use `RunPrivate` to make sure we hide the pull secret info.


**Fixes:** Issue #3857 

