### PR TITLE
Fixes #3866 check if the script exists before trying to remove

### DIFF
--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -236,3 +236,10 @@ func killDaemonProcessIfRunning() error {
 	}
 	return nil
 }
+
+func removeDaemonPoshScript() error {
+	if crcos.FileExists(daemonPoshScriptPath) {
+		return os.Remove(daemonPoshScriptPath)
+	}
+	return nil
+}

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -106,7 +106,7 @@ var daemonTaskChecks = []Check{
 		fixDescription:     "Creating the daemon task powershell script",
 		fix:                fixDaemonPoshScript,
 		cleanupDescription: "Removing the daemon task powershell script",
-		cleanup:            func() error { return os.Remove(daemonPoshScriptPath) },
+		cleanup:            removeDaemonPoshScript,
 
 		labels: labels{Os: Windows},
 	},


### PR DESCRIPTION
this prevents the following error on windows:
````
INFO Removing older logs
remove C:\Users\crcqe\.crc\bin\hidden_daemon.ps1: The system cannot find the file specified.
```

