### PR TITLE
ci: Use pre-built e2e/integration test binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ GOARCH ?= $(shell go env GOARCH)
 HOST_BUILD_DIR=$(BUILD_DIR)/$(GOOS)-$(GOARCH)
 GOPATH ?= $(shell go env GOPATH)
 ORG := github.com/crc-org
-MODULEPATH ?= $(ORG)/crc/v2
+MODULEPATH = $(ORG)/crc/v2
 PACKAGE_DIR := packaging/$(GOOS)
 
 SOURCES := $(shell git ls-files  *.go ":^vendor")

--- a/Makefile
+++ b/Makefile
@@ -235,9 +235,6 @@ endif
 ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
-ifndef VERSION_TO_TEST
-	VERSION_TO_TEST = --crc-version=$(CRC_VERSION)+$(COMMIT_SHA)
-endif
 e2e:
 	@go test --timeout=180m $(MODULEPATH)/test/e2e -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) $(GODOG_OPTS) $(CLEANUP_HOME) $(VERSION_TO_TEST) $(INSTALLER_PATH) $(USER_PASSWORD)
 

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -9,7 +9,11 @@ RUN make release
 FROM quay.io/centos/centos:stream8
 COPY --from=builder /go/src/github.com/crc-org/crc /opt/crc
 COPY --from=builder /go/src/github.com/crc-org/crc/out/linux-amd64/crc /bin/crc
+COPY --from=builder /go/src/github.com/crc-org/crc/out/linux-amd64/e2e.test /bin/e2e.test
+COPY --from=builder /go/src/github.com/crc-org/crc/out/linux-amd64/e2e.test /bin/integration.test
 COPY --from=builder /go/src/github.com/crc-org/crc/out/windows-amd64/crc.exe /opt/crc.exe
+COPY --from=builder /go/src/github.com/crc-org/crc/out/windows-amd64/e2e.test.exe /opt/e2e.test.exe
+COPY --from=builder /go/src/github.com/crc-org/crc/out/windows-amd64/e2e.test.exe /opt/integration.test.exe
 COPY --from=builder /go/src/github.com/crc-org/crc/images/openshift-ci/mock-nss.sh /bin/mock-nss.sh
 COPY --from=builder /go/src/github.com/crc-org/crc/images/openshift-ci/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
 COPY --from=builder /go/src/github.com/crc-org/crc/images/openshift-ci/azure-cli.repo /etc/yum.repos.d/azure-cli.repo

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -20,11 +20,7 @@ COPY --from=builder /go/src/github.com/crc-org/crc/images/openshift-ci/azure-cli
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    genisoimage \
-    gettext \
     google-cloud-sdk \
-    libvirt-client \
-    libvirt-libs \
     nss_wrapper \
     unzip \
     sshpass \

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/crc-org/crc
 COPY . .
 RUN make release
 
-FROM quay.io/centos/centos:stream8
+FROM registry.access.redhat.com/ubi9/ubi
 COPY --from=builder /go/src/github.com/crc-org/crc /opt/crc
 COPY --from=builder /go/src/github.com/crc-org/crc/out/linux-amd64/crc /bin/crc
 COPY --from=builder /go/src/github.com/crc-org/crc/out/linux-amd64/e2e.test /bin/e2e.test

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/preset"
+	"github.com/crc-org/crc/v2/pkg/crc/version"
 	"github.com/crc-org/crc/v2/test/extended/crc/cmd"
 	crcCmd "github.com/crc-org/crc/v2/test/extended/crc/cmd"
 	"github.com/crc-org/crc/v2/test/extended/util"
@@ -34,6 +35,10 @@ var (
 	GodogTags string
 )
 
+func defaultCRCVersion() string {
+	return fmt.Sprintf("%s+%s", version.GetCRCVersion(), version.GetCommitSha())
+}
+
 func ParseFlags() {
 
 	pflag.StringVar(&util.TestDir, "test-dir", "out", "Path to the directory in which to execute the tests")
@@ -43,7 +48,7 @@ func ParseFlags() {
 	pflag.StringVar(&pullSecretFile, "pull-secret-file", "/path/to/pull-secret", "Path to the file containing pull secret")
 	pflag.StringVar(&CRCExecutable, "crc-binary", "", "Path to the CRC executable to be tested")
 	pflag.BoolVar(&cleanupHome, "cleanup-home", false, "Try to remove crc home folder before starting the suite") // TODO: default=true
-	pflag.StringVar(&CRCVersion, "crc-version", "", "Version of CRC to be tested")
+	pflag.StringVar(&CRCVersion, "crc-version", defaultCRCVersion(), "Version of CRC to be tested")
 }
 
 func InitializeTestSuite(tctx *godog.TestSuiteContext) {


### PR DESCRIPTION
This PR is a pre-requisite for https://github.com/crc-org/crc/pull/3861

When testing in prow, we currently use pre-built crc binaries on the
node running the test, but the e2e.test/integration.test binaries are rebuilt on the node
running the test.

This is problematic because the GCP image used has an older golang
(1.19) version than the builder used for the crc code. This will cause
issues if we add code to crc which requires golang 1.20+, which will
happen when we update the gvisor-tap-vsock code.

This PR uses test binaries built at the same time as the `crc` binary used for
testing, and does misc cleanups to the image which we are using to create our
GCP instance.