### PR TITLE
Cluster: Remove all the lease from cluster

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -507,6 +507,6 @@ func DeleteMCOLeaderLease(ctx context.Context, ocConfig oc.Config) error {
 	if err := WaitForOpenshiftResource(ctx, ocConfig, "lease"); err != nil {
 		return err
 	}
-	_, _, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "lease", "--all")
+	_, _, err := ocConfig.RunOcCommand("delete", "-A", "lease", "--all")
 	return err
 }

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -497,8 +497,11 @@ func DeleteMCOLeaderLease(ctx context.Context, ocConfig oc.Config) error {
 	if err := WaitForOpenshiftResource(ctx, ocConfig, "configmap"); err != nil {
 		return err
 	}
-	if _, _, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "configmap", "machine-config-controller"); err != nil {
-		return err
+
+	if _, stderr, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "configmap", "machine-config-controller"); err != nil {
+		if !strings.Contains(stderr, "\"machine-config-controller\" not found") {
+			return err
+		}
 	}
 	// https://issues.redhat.com/browse/OCPBUGS-7583 as workaround
 	if err := WaitForOpenshiftResource(ctx, ocConfig, "lease"); err != nil {


### PR DESCRIPTION
lease is a mechanism to lock shared resources in k8s and since we start
a stopped cluster better to remove all the lease so that lock is not
around for longer period of time in case older lease expire and only
renew once respective resource ask for it.

Also during 4.14 testing we found out if we only remove lease from
`openshift-machine-config-operator` namespace then having the
pull-secret on the disk takes a longer time then usual. I am still not
sure where it is stuck but https://issues.redhat.com/browse/OCPBUGS-7583
is closed as expected behaviour and till 4.13 we used the workaround.
From 4.14 that workaround doesn't work because there is no configmap and
just removing lease of this namespace not helpful so I am removing all
the lease from older cluster which atleast perfrom better.

fixes: #3883 