### PR TITLE
Use 'Apple silicon' instead of 'M1'

### DIFF
--- a/docs/modules/getting_started/examples/snip_crc_preset_platforms.adoc
+++ b/docs/modules/getting_started/examples/snip_crc_preset_platforms.adoc
@@ -1,7 +1,7 @@
 .Preset and architecture compatibility
 [%header,format=csv,cols="3,1,1,1"]
 |===
-Preset, AMD64, Intel 64, M1
+Preset, AMD64, Intel 64, Apple silicon
 {ocp}, yes, yes,  yes
 {okd}, yes, yes, no
 {ushift}, yes, yes, yes

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -25,7 +25,7 @@ const (
 	resolverFile = "/etc/resolver/testing"
 )
 
-func checkM1CPU() error {
+func checkAppleSilicon() error {
 	if strings.HasPrefix(cpuid.CPU.BrandName, "VirtualApple") {
 		logging.Debugf("Running with an emulated x86_64 CPU")
 		return fmt.Errorf("This version of CRC for AMD64/Intel64 CPUs is unsupported on Apple M1 hardware")

--- a/pkg/crc/preflight/preflight_checks_unix.go
+++ b/pkg/crc/preflight/preflight_checks_unix.go
@@ -143,7 +143,7 @@ func checkSupportedCPUArch() error {
 	if runtime.GOARCH == "amd64" || (runtime.GOARCH == "arm64" && runtime.GOOS == "darwin") {
 		return nil
 	}
-	return fmt.Errorf("CRC can only run on AMD64/Intel64 CPUs and M1 CPUs")
+	return fmt.Errorf("CRC can only run on AMD64/Intel64 CPUs and Apple silicon")
 }
 
 func runtimeExecutablePath() (string, error) {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -14,9 +14,9 @@ import (
 var vfkitPreflightChecks = []Check{
 	{
 		configKeySuffix:  "check-m1-cpu",
-		checkDescription: "Checking if running emulated on a M1 CPU",
-		check:            checkM1CPU,
-		fixDescription:   "This version of CRC for AMD64/Intel64 CPUs is unsupported on Apple M1 hardware",
+		checkDescription: "Checking if running emulated on Apple silicon",
+		check:            checkAppleSilicon,
+		fixDescription:   "This version of CRC for AMD64/Intel64 CPUs is unsupported on Apple silicon",
 		flags:            NoFix,
 
 		labels: labels{Os: Darwin},


### PR DESCRIPTION
There are now M2 CPUs, and more generations to come. "Apple silicon" is
more generic.

This fixes https://github.com/crc-org/crc/issues/3889