### PR TITLE
e2e: tekton webhook check revisited

### DIFF
--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -75,7 +75,7 @@ Feature: 4 Openshift stories
 		Given executing "oc new-project testproj" succeeds
 		When executing "oc apply -f pipeline-sub.yaml" succeeds
 		Then with up to "10" retries with wait period of "30s" command "oc get csv" output matches ".*pipelines-operator(.*)Succeeded$"
-		Then with up to "20" retries with wait period of "30s" command "oc get pods -n openshift-pipelines" output matches ".*tekton-pipelines-webhook(.*)Running.*"
+		Then with up to "20" retries with wait period of "30s" command "oc get pods -n openshift-pipelines" output matches ".*tekton-pipelines-webhook(.*)1/1(.*)Running.*"
 		When with up to "60" retries with wait period of "5s" command "oc explain task" output matches ".*KIND(.*)Task.*"
 		When with up to "60" retries with wait period of "5s" command "oc explain taskruns" output matches ".*KIND(.*)TaskRun.*"
 		# install tekton task


### PR DESCRIPTION
**Fixes:** Issue #3864

The check was returning success even if the pod wasn't running yet (`0/1`). This should fix it.