### PR TITLE
Add status change event

### DIFF
--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/daemonclient"
 	crcErrors "github.com/crc-org/crc/v2/pkg/crc/errors"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/types"
 	"github.com/crc-org/crc/v2/pkg/crc/preset"
 	"github.com/docker/go-units"
@@ -151,6 +152,9 @@ func getStatus(client *daemonclient.Client, cacheDir string) *status {
 			return &status{Success: false, Error: crcErrors.ToSerializableError(crcErrors.DaemonNotRunning)}
 		}
 		return &status{Success: false, Error: crcErrors.ToSerializableError(err)}
+	}
+	if clusterStatus.CrcStatus == string(state.NoVM) {
+		return &status{Success: false, Error: crcErrors.ToSerializableError(crcErrors.VMNotExist)}
 	}
 	var size int64
 	err = filepath.Walk(cacheDir, func(_ string, info os.FileInfo, err error) error {

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -88,7 +88,7 @@ func runWatchStatus(writer io.Writer, client *daemonclient.Client, cacheDir stri
 		}
 	}()
 
-	err = client.SSEClient.Status(func(loadResult *types.ClusterLoadResult) {
+	err = client.SSEClient.ClusterLoad(func(loadResult *types.ClusterLoadResult) {
 		if !isPoolInit {
 			ramBar, cpuBars = createBars(loadResult.CPUUse, writer)
 			barPool = pb.NewPool(append([]*pb.ProgressBar{ramBar}, cpuBars...)...)

--- a/pkg/crc/api/client/sse_client.go
+++ b/pkg/crc/api/client/sse_client.go
@@ -21,8 +21,8 @@ func NewSSEClient(transport *http.Transport) *SSEClient {
 	}
 }
 
-func (c *SSEClient) Status(statusCallback func(*types.ClusterLoadResult)) error {
-	err := c.client.Subscribe("status", func(msg *sse.Event) {
+func (c *SSEClient) ClusterLoad(statusCallback func(*types.ClusterLoadResult)) error {
+	err := c.client.Subscribe("cluster_load", func(msg *sse.Event) {
 		wmState := &types.ClusterLoadResult{}
 		err := json.Unmarshal(msg.Data, wmState)
 		if err != nil {

--- a/pkg/crc/api/events/cluster_load_stream.go
+++ b/pkg/crc/api/events/cluster_load_stream.go
@@ -19,18 +19,18 @@ type TickListener struct {
 	tickPeriod time.Duration
 }
 
-func newStatusStream(server *EventServer) EventStream {
-	return newStream(NewStatusListener(server.machine), newEventPublisher(STATUS, server.sseServer))
+func newClusterLoadStream(server *EventServer) EventStream {
+	return newStream(newClusterLoadListener(server.machine), newEventPublisher(ClusterLoad, server.sseServer))
 }
 
-func NewStatusListener(machine crcMachine.Client) EventProducer {
+func newClusterLoadListener(machine crcMachine.Client) EventProducer {
 	getStatus := func() (interface{}, error) {
 		return machine.GetClusterLoad()
 	}
-	return NewTickListener(getStatus)
+	return newTickListener(getStatus)
 }
 
-func NewTickListener(generator genData) EventProducer {
+func newTickListener(generator genData) EventProducer {
 	return &TickListener{
 		done:       make(chan bool),
 		generator:  generator,

--- a/pkg/crc/api/events/event_server.go
+++ b/pkg/crc/api/events/event_server.go
@@ -56,6 +56,7 @@ func NewEventServer(machine machine.Client) *EventServer {
 
 	sseServer.CreateStream(Logs)
 	sseServer.CreateStream(ClusterLoad)
+	sseServer.CreateStream(StatusChange)
 	return eventServer
 }
 
@@ -69,6 +70,8 @@ func createEventStream(server *EventServer, streamID string) EventStream {
 		return newLogsStream(server)
 	case ClusterLoad:
 		return newClusterLoadStream(server)
+	case StatusChange:
+		return newStatusChangeStream(server)
 	}
 	return nil
 }

--- a/pkg/crc/api/events/event_server.go
+++ b/pkg/crc/api/events/event_server.go
@@ -54,8 +54,8 @@ func NewEventServer(machine machine.Client) *EventServer {
 		stream.RemoveSubscriber(sub)
 	}
 
-	sseServer.CreateStream(LOGS)
-	sseServer.CreateStream(STATUS)
+	sseServer.CreateStream(Logs)
+	sseServer.CreateStream(ClusterLoad)
 	return eventServer
 }
 
@@ -65,10 +65,10 @@ func (es *EventServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func createEventStream(server *EventServer, streamID string) EventStream {
 	switch streamID {
-	case LOGS:
+	case Logs:
 		return newLogsStream(server)
-	case STATUS:
-		return newStatusStream(server)
+	case ClusterLoad:
+		return newClusterLoadStream(server)
 	}
 	return nil
 }

--- a/pkg/crc/api/events/events.go
+++ b/pkg/crc/api/events/events.go
@@ -3,8 +3,9 @@ package events
 import "github.com/r3labs/sse/v2"
 
 const (
-	Logs        = "logs"         // Logs event channel, contains daemon logs
-	ClusterLoad = "cluster_load" // status event channel, contains VM load info
+	Logs         = "logs"          // Logs event channel, contains daemon logs
+	ClusterLoad  = "cluster_load"  // status event channel, contains VM load info
+	StatusChange = "status_change" // status change channel, fires on 'starting', 'stopping', etc
 )
 
 type EventPublisher interface {

--- a/pkg/crc/api/events/events.go
+++ b/pkg/crc/api/events/events.go
@@ -3,8 +3,8 @@ package events
 import "github.com/r3labs/sse/v2"
 
 const (
-	LOGS   = "logs"   // Logs event channel, contains daemon logs
-	STATUS = "status" // status event channel, contains VM load info
+	Logs        = "logs"         // Logs event channel, contains daemon logs
+	ClusterLoad = "cluster_load" // status event channel, contains VM load info
 )
 
 type EventPublisher interface {

--- a/pkg/crc/api/events/log_stream.go
+++ b/pkg/crc/api/events/log_stream.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"bytes"
+
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/r3labs/sse/v2"
 	"github.com/sirupsen/logrus"
@@ -56,7 +58,10 @@ func (s *streamHook) Fire(entry *logrus.Entry) error {
 		return err
 	}
 
-	s.server.Publish(LOGS, &sse.Event{Event: []byte(LOGS), Data: line})
+	// remove "Line Feed"("\n") character which add was added by json.Encoder
+	line = bytes.TrimRight(line, "\n")
+
+	s.server.Publish(Logs, &sse.Event{Event: []byte(Logs), Data: line})
 	return nil
 }
 

--- a/pkg/crc/api/events/status_change_stream.go
+++ b/pkg/crc/api/events/status_change_stream.go
@@ -1,0 +1,69 @@
+package events
+
+import (
+	"encoding/json"
+
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/crc/machine"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/types"
+	"github.com/crc-org/crc/v2/pkg/events"
+	"github.com/r3labs/sse/v2"
+)
+
+type serializableEvent struct {
+	Status *types.ClusterStatusResult `json:"status"`
+	Error  string                     `json:"error,omitempty"`
+}
+
+type statusChangeListener struct {
+	machineClient machine.Client
+	publisher     EventPublisher
+}
+
+func newStatusChangeStream(server *EventServer) EventStream {
+	return newStream(newStatusChangeListener(server.machine), newEventPublisher(StatusChange, server.sseServer))
+}
+
+func newStatusChangeListener(client machine.Client) EventProducer {
+	return &statusChangeListener{
+		machineClient: client,
+	}
+}
+
+func (st *statusChangeListener) Notify(changedEvent events.StatusChangedEvent) {
+	logging.Debugf("State Changed Event %s", changedEvent)
+	var event serializableEvent
+	status, err := st.machineClient.Status()
+	// if we cannot receive actual state, send error state with error description
+	if err != nil {
+		event = serializableEvent{Status: &types.ClusterStatusResult{
+			CrcStatus: state.Error,
+		}, Error: err.Error()}
+	} else {
+		// event could be fired, before actual code, which change state is called
+		// so status could contain 'old' state, replace it with state received in event
+		status.CrcStatus = changedEvent.State // override with actual reported state
+		event = serializableEvent{Status: status}
+		if changedEvent.Error != nil {
+			event.Error = changedEvent.Error.Error()
+		}
+
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		logging.Errorf("Could not serealize status changed event in to JSON: %s", err)
+		return
+	}
+	st.publisher.Publish(&sse.Event{Event: []byte(StatusChange), Data: data})
+}
+
+func (st *statusChangeListener) Start(publisher EventPublisher) {
+	st.publisher = publisher
+	events.StatusChanged.AddListener(st)
+
+}
+
+func (st *statusChangeListener) Stop() {
+	events.StatusChanged.RemoveListener(st)
+}

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -50,14 +50,6 @@ func NewHandler(config *crcConfig.Config, machine machine.Client, logger Logger,
 }
 
 func (h *Handler) Status(c *context) error {
-	exists, err := h.Client.Exists()
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return c.String(http.StatusInternalServerError, string(errors.VMNotExist))
-	}
-
 	res, err := h.Client.Status()
 	if err != nil {
 		return err

--- a/pkg/crc/machine/state/state.go
+++ b/pkg/crc/machine/state/state.go
@@ -10,6 +10,7 @@ const (
 	Stopped  State = "Stopped"
 	Stopping State = "Stopping"
 	Starting State = "Starting"
+	NoVM     State = "NoVM"
 	Error    State = "Error"
 )
 

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -18,8 +18,7 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	if err != nil {
 		if errors.Is(err, errMissingHost(client.name)) {
 			return &types.ClusterStatusResult{
-				CrcStatus:       state.Stopped,
-				OpenshiftStatus: types.OpenshiftStopped,
+				CrcStatus: state.NoVM,
 			}, nil
 		}
 		return nil, errors.Wrap(err, fmt.Sprintf("Cannot load '%s' virtual machine", client.name))

--- a/pkg/crc/machine/virtualmachine.go
+++ b/pkg/crc/machine/virtualmachine.go
@@ -32,6 +32,14 @@ func (err *MissingHostError) Error() string {
 	return fmt.Sprintf("no such libmachine vm: %s", err.name)
 }
 
+func (err *MissingHostError) Is(target error) bool {
+	var x *MissingHostError
+	if errors.As(target, &x) && x.name == err.name {
+		return true
+	}
+	return false
+}
+
 var errInvalidBundleMetadata = errors.New("Error loading bundle metadata")
 
 func loadVirtualMachine(name string, useVSock bool) (*virtualMachine, error) {

--- a/pkg/events/emitter.go
+++ b/pkg/events/emitter.go
@@ -1,0 +1,48 @@
+package events
+
+import (
+	"sync"
+)
+
+type Event[T any] interface {
+	AddListener(listener Notifiable[T])
+	RemoveListener(listener Notifiable[T])
+	Fire(data T)
+}
+
+type Notifiable[T any] interface {
+	Notify(event T)
+}
+
+type event[T any] struct {
+	listeners  map[Notifiable[T]]Notifiable[T]
+	eventMutex sync.Mutex
+}
+
+func NewEvent[T any]() Event[T] {
+	return &event[T]{
+		listeners: make(map[Notifiable[T]]Notifiable[T]),
+	}
+}
+
+func (e *event[T]) AddListener(listener Notifiable[T]) {
+	e.eventMutex.Lock()
+	defer e.eventMutex.Unlock()
+	e.listeners[listener] = listener
+}
+
+func (e *event[T]) RemoveListener(listener Notifiable[T]) {
+	e.eventMutex.Lock()
+	defer e.eventMutex.Unlock()
+	delete(e.listeners, listener)
+}
+
+func (e *event[T]) Fire(event T) {
+	e.eventMutex.Lock()
+	defer e.eventMutex.Unlock()
+	for _, listener := range e.listeners {
+		// shadowing for loop variable, need to remove after golang 1.22 migration
+		listener := listener
+		go listener.Notify(event)
+	}
+}

--- a/pkg/events/emitter_test.go
+++ b/pkg/events/emitter_test.go
@@ -1,0 +1,41 @@
+package events
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestEventData struct {
+	Foo string
+}
+
+type eventListener struct {
+	notifyCb func(e TestEventData)
+}
+
+func newEventListener(notifyCb func(e TestEventData)) *eventListener {
+	return &eventListener{notifyCb: notifyCb}
+}
+
+func (listener *eventListener) Notify(e TestEventData) {
+	listener.notifyCb(e)
+}
+
+func TestEmitter(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var data string
+
+	event := NewEvent[TestEventData]()
+	event.AddListener(newEventListener(func(e TestEventData) {
+		data = e.Foo
+		wg.Done()
+	}))
+	event.Fire(TestEventData{Foo: "bar"})
+
+	wg.Wait()
+
+	assert.Equal(t, "bar", data)
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,0 +1,14 @@
+package events
+
+import (
+	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
+)
+
+type StatusChangedEvent struct {
+	State state.State
+	Error error
+}
+
+var (
+	StatusChanged = NewEvent[StatusChangedEvent]()
+)


### PR DESCRIPTION
## Solution/Idea
PR adds event API and new SSE(server sent event) channel `status_change`.

## Proposed changes
PR adds event API implementation in `pkg/crc/api/events/events.go`
Modify `sync` client implementation to trigger event when status is changed.
Fixes in existing log events, rename constants related to SSE

## Testing

1. launch demon
2. connect to `status_change` channel with `curl -GET -i --unix-socket <path to socket>/crc-http.sock "http://localhost/events?stream=status_change"`
3.  start crc with `curl -GET -i --unix-socket ~/.crc/crc-http.sock  "http://localhost/api/start"`
4. Ensure that new events appeared, like:
```
id:                                                                                                                            │
data: {"status":{"CrcStatus":"Starting","OpenshiftStatus":"Starting","OpenshiftVersion":"","PodmanVersion":"","DiskUse":0,"DiskSize":0,"RAMUse":0,"RAMSize":0,"Preset":"microshift"}}
event: status_change
```