### PR TITLE
Merge kubeconfigs using clientcmd.ModifyConfig

### DIFF
--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -84,6 +84,10 @@ func writeKubeconfig(ip string, clusterConfig *types.ClusterConfig, ingressHTTPS
 
 func getGlobalKubeConfig() (string, *api.Config, error) {
 	kubeconfig := getGlobalKubeConfigPath()
+	return getKubeConfigFromFile(kubeconfig)
+}
+
+func getKubeConfigFromFile(kubeconfig string) (string, *api.Config, error) {
 	config, err := clientcmd.LoadFromFile(kubeconfig)
 	if err != nil && !os.IsNotExist(err) {
 		return "", nil, err
@@ -246,7 +250,12 @@ func contains(arr []string, str string) bool {
 }
 
 func mergeKubeConfigFile(kubeConfigFile string) error {
-	globalConfigPath, globalConf, err := getGlobalKubeConfig()
+	return mergeConfigHelper(kubeConfigFile, getGlobalKubeConfigPath())
+}
+
+func mergeConfigHelper(kubeConfigFile, globalConfigFile string) error {
+
+	globalConfigPath, globalConf, err := getKubeConfigFromFile(globalConfigFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -256,23 +256,18 @@ func mergeKubeConfigFile(kubeConfigFile string) error {
 		return err
 	}
 	// Merge the currentConf to globalConfig
-	mergedConfig, err := clientcmd.NewDefaultClientConfig(*globalConf, &clientcmd.ConfigOverrides{}).ConfigAccess().GetStartingConfig()
-	if err != nil {
-		return err
-	}
-
 	for name, cluster := range currentConf.Clusters {
-		mergedConfig.Clusters[name] = cluster
+		globalConf.Clusters[name] = cluster
 	}
 
 	for name, authInfo := range currentConf.AuthInfos {
-		mergedConfig.AuthInfos[name] = authInfo
+		globalConf.AuthInfos[name] = authInfo
 	}
 
 	for name, context := range currentConf.Contexts {
-		mergedConfig.Contexts[name] = context
+		globalConf.Contexts[name] = context
 	}
 
-	mergedConfig.CurrentContext = currentConf.CurrentContext
-	return clientcmd.WriteToFile(*mergedConfig, globalConfigPath)
+	globalConf.CurrentContext = currentConf.CurrentContext
+	return clientcmd.WriteToFile(*globalConf, globalConfigPath)
 }


### PR DESCRIPTION
**Fixes:** Issue #3602 

## Solution/Idea

Use `clientcmd.ModifyConfig` to merge custom config with a primary config (global kubeconfig in default case)

## Proposed changes

Changed the function call to ModifyConfig in `start`

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` should merge the custom kubeconfig to the global kubeconfig file
