### PR TITLE
Check daemon version before failing in checkDaemonSystemdService

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -372,7 +372,7 @@ func checkDaemonStarted() error {
 	if err != nil {
 		return err
 	}
-	return daemonclient.CheckIfOlderVersion(v)
+	return daemonclient.CheckVersionMismatch(v)
 }
 
 func portFallbackWarning() string {

--- a/pkg/crc/daemonclient/client.go
+++ b/pkg/crc/daemonclient/client.go
@@ -39,7 +39,7 @@ func GetVersionFromDaemonAPI() (*client.VersionResult, error) {
 	return &version, nil
 }
 
-func CheckIfOlderVersion(version *client.VersionResult) error {
+func CheckVersionMismatch(version *client.VersionResult) error {
 	if version.CrcVersion != crcversion.GetCRCVersion() {
 		return fmt.Errorf("The executable version (%s) doesn't match the daemon version (%s)", crcversion.GetCRCVersion(), version.CrcVersion)
 	}

--- a/pkg/crc/preflight/errors_linux.go
+++ b/pkg/crc/preflight/errors_linux.go
@@ -1,0 +1,42 @@
+package preflight
+
+import (
+	"errors"
+	"fmt"
+)
+
+type unitStatusErr struct {
+	shouldBeRunning bool
+	unitName        string
+}
+
+func (err *unitStatusErr) Error() string {
+	if err.shouldBeRunning {
+		return fmt.Sprintf("%s is not running", err.unitName)
+	}
+
+	return fmt.Sprintf("%s should not be running", err.unitName)
+}
+
+func (err *unitStatusErr) Is(target error) bool {
+	var castTarget *unitStatusErr
+	if !errors.As(target, &castTarget) {
+		return false
+	}
+
+	return err.shouldBeRunning == castTarget.shouldBeRunning && err.unitName == castTarget.unitName
+}
+
+func unitShouldBeRunningErr(unitName string) error {
+	return &unitStatusErr{
+		shouldBeRunning: true,
+		unitName:        unitName,
+	}
+}
+
+func unitShouldNotBeRunningErr(unitName string) error {
+	return &unitStatusErr{
+		shouldBeRunning: false,
+		unitName:        unitName,
+	}
+}

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -330,9 +330,9 @@ func checkSystemdUnit(unitName string, unitContent string, shouldBeRunning bool)
 	logging.Debugf("Checking if %s is running", unitName)
 	running := systemdUnitRunning(sd, unitName)
 	if !running && shouldBeRunning {
-		return fmt.Errorf("%s is not running", unitName)
+		return unitShouldBeRunningErr(unitName)
 	} else if running && !shouldBeRunning {
-		return fmt.Errorf("%s should not be running", unitName)
+		return unitShouldNotBeRunningErr(unitName)
 	}
 
 	logging.Debugf("Checking if %s has the expected content", unitName)

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -372,7 +372,7 @@ func checkDaemonSystemdService() error {
 	if err != nil {
 		return shouldNotBeRunningErr
 	}
-	return daemonclient.CheckIfOlderVersion(version)
+	return daemonclient.CheckVersionMismatch(version)
 }
 
 func fixSystemdUnit(unitName string, unitContent string, shouldBeRunning bool) error {

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -332,7 +332,7 @@ func checkSystemdUnit(unitName string, unitContent string, shouldBeRunning bool)
 	if !running && shouldBeRunning {
 		return fmt.Errorf("%s is not running", unitName)
 	} else if running && !shouldBeRunning {
-		return fmt.Errorf("%s is running", unitName)
+		return fmt.Errorf("%s should not be running", unitName)
 	}
 
 	logging.Debugf("Checking if %s has the expected content", unitName)


### PR DESCRIPTION
On linux, checkDaemonSystemdService returns an error when the daemon is already running as we want to restart the daemon to handle upgrade scenarios.
This check currently fails even if there were no crc upgrades in the mean time. This is usually harmless as stopping the daemon is quick and transparent to the user.

This becomes a problem in this scenario:
```
$ crc setup
$ crc setup --check-only
$ echo $?
0

# do something which starts the daemon, crc start for example

$ crc setup --check-only
$ echo $?
2
```

`crc setup` would fix this, but it's unfortunate that it has to be run again and again for `crc setup --check-only` to succeed.

This commit improves checkDaemonSystemdService, when it detects that the daemon is running, it checks its version, if it matches the current crc version, then the check is successful.
If the crc version does not match, then the check is unsuccessful.

This will cause one change during development: when working on the daemon, it will have to be manually stopped.
In current git, `crc setup` would do this for you.

This fixes https://github.com/crc-org/crc-extension/issues/186