### PR TITLE
macos: Require macOS 12

### DIFF
--- a/docs/modules/getting_started/partials/ref_minimum-system-requirements.adoc
+++ b/docs/modules/getting_started/partials/ref_minimum-system-requirements.adoc
@@ -50,7 +50,7 @@ To assign more resources to the {prod} instance, see link:{crc-gsg-url}#configur
 
 === Requirements on {mac}
 
-* On {mac}, {prod} requires {mac} 11 Big Sur or later.
+* On {mac}, {prod} requires {mac} 12 Monterey or later.
 {prod} does not work on earlier versions of {mac}.
 
 === Requirements on Linux

--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -20,9 +20,9 @@ function installCheck() {
         return false;
 	}
 
-    if(!(system.compareVersions(system.version.ProductVersion, '11.0.0') >= 0)) {
+    if(!(system.compareVersions(system.version.ProductVersion, '12.0.0') >= 0)) {
         my.result.title = 'Unable to install';
-        my.result.message = 'Red Hat OpenShift Local requires macOS 11 or later.';
+        my.result.message = 'Red Hat OpenShift Local requires macOS 12 or later.';
         my.result.type = 'Fatal';
         return false;
     }


### PR DESCRIPTION
macOS 14 has been released recently, macOS 11 is likely to become
unsupported soon. This commit officially drops support for macOS 11.