### PR TITLE
images: Switch to ubi8/go-toolset:1.20

### DIFF
--- a/images/build-e2e/Dockerfile
+++ b/images/build-e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.15 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS builder
 
 USER root
 WORKDIR /workspace

--- a/images/build-integration/Dockerfile
+++ b/images/build-integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.15 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS builder
 
 USER root
 WORKDIR /workspace

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.15
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20
 MAINTAINER CRC <devtools-cdk@redhat.com>
 
 WORKDIR $APP_ROOT/src

--- a/update-go-version.sh
+++ b/update-go-version.sh
@@ -12,6 +12,7 @@ echo "Updating golang version to $golang_base_version"
 go mod edit -go ${golang_base_version}
 go mod edit -go ${golang_base_version} tools/go.mod
 sed -i "s,^\(FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-\)1.[0-9]\+,\1${golang_base_version}," images/*/Dockerfile
+sed -i "s,^FROM registry.access.redhat.com/ubi8/go-toolset:[.0-9]\+,FROM registry.access.redhat.com/ubi8/go-toolset:${golang_base_version}," images/*/Dockerfile
 for f in .github/workflows/*.yml; do
     yq eval --inplace ".jobs.build.strategy.matrix.go[0] = ${golang_base_version}" "$f";
 done


### PR DESCRIPTION
latest ubi8/go-toolset images now ship with go 1.20, we can switch away
from the registry.ci.openshift images which required authentication, and
are quite verbose during go builds.

images/openshift-ci/Dockerfile keeps using
registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.15
since it's used in OpenShift CI (?)