### PR TITLE
macos: remove tray during upgrade

### DIFF
--- a/packaging/darwin/postinstall.in
+++ b/packaging/darwin/postinstall.in
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+pkill -9 crc-tray || true
+rm -fr /Applications/Red\ Hat\ OpenShift\ Local.app || true
+
 rm -fr  /Applications/CodeReady\ Containers.app || true
 
 chmod 755 "__INSTALL_PATH__"/crc


### PR DESCRIPTION
since the tray app is now discontinued this
removes an existing tray app during upgrade