### PR TITLE
CI: remove mac 11 from github action workflow

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-latest
-          - macOS-11
+          - macOS-13
+          - macOS-12
         go:
           - '1.20'
     steps:

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-11
-          - macOS-latest
+          - macOS-13
+          - macOS-12
           - ubuntu-latest
           - ubuntu-20.04
         go:


### PR DESCRIPTION
As per https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners mac-13 is in beta and mac-12 is latest so this PR explictly set mac versions instead usign latest to avoid confusion.


