### PR TITLE
Build e2e and integration test images as part of PR checks

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,0 +1,53 @@
+name: Build test images
+on:
+  push:
+    branches:
+      - "main"
+  pull_request: {}
+
+env:
+  IMAGE_NAME_E2E: crc-e2e
+  IMAGE_NAME_INTEGRATION: crc-integration
+
+jobs:
+  build-e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      
+      - name: Build and archive e2e image
+        # use github.sha as ID to correlate various workflows triggered by the same event
+        run: |
+          CRC_E2E_IMG_VERSION=id-${{ github.sha }} make containerized_e2e
+          podman save -o ${{ env.IMAGE_NAME_E2E }}.tar quay.io/crcont/${{ env.IMAGE_NAME_E2E}}:id-${{ github.sha }}
+
+      - name: Upload e2e image
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.IMAGE_NAME_E2E }}-id${{ github.sha }}
+          path: ${{ env.IMAGE_NAME_E2E }}.tar
+
+  build-integration:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      
+      - name: Build and archive integration image
+        # use github.sha as ID to correlate various workflows triggered by the same event
+        run: |
+          CRC_INTEGRATION_IMG_VERSION=id-${{ github.sha }} make containerized_integration
+          podman save -o ${{ env.IMAGE_NAME_INTEGRATION }}.tar quay.io/crcont/${{ env.IMAGE_NAME_INTEGRATION }}:id-${{ github.sha }}
+      
+      - name: Upload integration image
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.IMAGE_NAME_INTEGRATION }}-id${{ github.sha }}
+          path: ${{ env.IMAGE_NAME_INTEGRATION }}.tar


### PR DESCRIPTION
**Fixes:** Issue #3931 

Introduce a GH workflow with 2 jobs (run in parallel by default). 1 job builds e2e image and the other builds integration image. Both images are tagged with `id-${{github.sha}}`, archived as `.tar` files and uploaded as artifacts (instead of pushing to external registry). The purpose of these images is tied to the lifetime of a PR anyways.

These artifacts will be consumed by another workflow (windows-e2e/integration) which will use them to run e2e and integration PR checks on windows environment. 

**Note**
Using `${{github.sha}}` as the correlation number should work for both `pull_request` and `push to main` trigger events. For this, I have 2 `github` context dumps for each case (PR, push). Two workflows (test1 and test2) were triggered by the same event (PR or push to main) and context dump was saved. Comparing `github.sha` values suggests that they are the same for these workflows (as they should be). This generalizes the previous approach where we used PR# to correlate workflows. Moreover, the `sha` approach comes with another advantage. The `sha` changes from trigger to trigger, making sure that if we download an artifact with the correct `sha`, it will be the intended one and not one from a previous trigger. This would not be guaranteed when using PR# as id, because that does not change from trigger to trigger.

- [on pull 1](https://gist.github.com/jsliacan/e77c340177159e6cbbe311fd67cf1c23)
- [on pull 2](https://gist.github.com/jsliacan/75976f4c1ccc93567cae4858f8f26a74)
- [on push 1](https://gist.github.com/jsliacan/f2416e15dd0d87de7ec1ca16599cec7e)
- [on push 2](https://gist.github.com/jsliacan/c86bdf8622a4632b5bb2d559cfca8f01)


[gha-win-e2e.pdf](https://github.com/crc-org/crc/files/13583760/gha-win-e2e.pdf)
