### PR TITLE
Add preflight check for vsock SSH port

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -38,6 +38,7 @@ const (
 
 	VSockGateway = "192.168.127.1"
 	VsockSSHPort = 2222
+	LocalIP      = "127.0.0.1"
 
 	OkdPullSecret = `{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}` // #nosec G101
 

--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -78,7 +78,6 @@ const (
 	virtualMachineIP = "192.168.127.2"
 	hostVirtualIP    = "192.168.127.254"
 	internalSSHPort  = "22"
-	localIP          = "127.0.0.1"
 	remoteHTTPPort   = "80"
 	remoteHTTPSPort  = "443"
 	apiPort          = "6443"
@@ -95,7 +94,7 @@ func vsockPorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint)
 	exposeRequest := []types.ExposeRequest{
 		{
 			Protocol: "tcp",
-			Local:    net.JoinHostPort(localIP, strconv.Itoa(constants.VsockSSHPort)),
+			Local:    net.JoinHostPort(constants.LocalIP, strconv.Itoa(constants.VsockSSHPort)),
 			Remote:   net.JoinHostPort(virtualMachineIP, internalSSHPort),
 		},
 		{
@@ -110,7 +109,7 @@ func vsockPorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint)
 		exposeRequest = append(exposeRequest,
 			types.ExposeRequest{
 				Protocol: "tcp",
-				Local:    net.JoinHostPort(localIP, apiPort),
+				Local:    net.JoinHostPort(constants.LocalIP, apiPort),
 				Remote:   net.JoinHostPort(virtualMachineIP, apiPort),
 			},
 			types.ExposeRequest{
@@ -127,7 +126,7 @@ func vsockPorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint)
 		exposeRequest = append(exposeRequest,
 			types.ExposeRequest{
 				Protocol: "tcp",
-				Local:    net.JoinHostPort(localIP, cockpitPort),
+				Local:    net.JoinHostPort(constants.LocalIP, cockpitPort),
 				Remote:   net.JoinHostPort(virtualMachineIP, cockpitPort),
 			})
 	default:

--- a/pkg/crc/preflight/preflight_checks_nonlinux.go
+++ b/pkg/crc/preflight/preflight_checks_nonlinux.go
@@ -81,7 +81,7 @@ func sshPortCheck() Check {
 		configKeySuffix:  "check-ssh-port",
 		checkDescription: "Checking SSH port availability",
 		check:            checkSSHPortFree(),
-		fixDescription:   fmt.Sprintf("crc uses %d to run SSH", constants.VsockSSHPort),
+		fixDescription:   fmt.Sprintf("crc uses port %d to run SSH", constants.VsockSSHPort),
 		flags:            NoFix,
 		labels:           None,
 	}

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -114,6 +114,7 @@ func getChecks(_ network.Mode, bundlePath string, preset crcpreset.Preset, enabl
 	checks = append(checks, bundleCheck(bundlePath, preset, enableBundleQuayFallback))
 	checks = append(checks, trayLaunchdCleanupChecks...)
 	checks = append(checks, daemonLaunchdChecks...)
+	checks = append(checks, sshPortCheck())
 
 	return checks
 }

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -13,13 +13,13 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage(), config.NewEmptyInMemorySecretStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 11)
+	assert.Len(t, cfg.AllConfigs(), 12)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 17)
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 17)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 18)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 18)
 
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 16)
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 16)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 17)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 17)
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -221,6 +221,7 @@ func getChecks(bundlePath string, preset crcpreset.Preset, enableBundleQuayFallb
 	checks = append(checks, cleanupCheckRemoveCrcVM)
 	checks = append(checks, daemonTaskChecks...)
 	checks = append(checks, adminHelperServiceCheks...)
+	checks = append(checks, sshPortCheck())
 	return checks
 }
 

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -13,13 +13,13 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage(), config.NewEmptyInMemorySecretStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 14)
+	assert.Len(t, cfg.AllConfigs(), 15)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 22)
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 22)
+	assert.Len(t, getPreflightChecks(false, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 23)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 23)
 
-	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 21)
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 21)
+	assert.Len(t, getPreflightChecks(false, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 22)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 22)
 }


### PR DESCRIPTION
**Relates to:**  First part for https://github.com/crc-org/crc/issues/3855

## Solution/Idea

PR's add preflight check for SSH port(`2222`) in not used before start. 


## Testing

1. Occupy `2222` port on your laptop( you may use `nc -lkv 127.0.0.1 2222` command)
2. Start daemon
3. Try to start CRC VM
4. Ensure that you have error during preflight checks
5. Free port `2222`
6. Try to start CRC again
7. Ensure that CRC starts normally 
