### PR TITLE
Fix docs-related make targets so they run on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ RELEASE_INFO := release-info.json
 CUSTOM_EMBED ?= false
 EMBED_DOWNLOAD_DIR ?= tmp-embed
 
+SELINUX_VOLUME_LABEL = :Z
+ifeq ($(GOOS),darwin)
+SELINUX_VOLUME_LABEL :=
+endif
+
 # Check that given variables are set and all have non-empty values,
 # die with an error otherwise.
 #
@@ -142,15 +147,15 @@ test-rpmbuild: spec
 
 .PHONY: build_docs
 build_docs:
-	${CONTAINER_RUNTIME} run -v $(CURDIR):/antora:Z --rm $(DOCS_BUILD_CONTAINER) --stacktrace antora-playbook.yml
+	${CONTAINER_RUNTIME} run -v $(CURDIR):/antora$(SELINUX_VOLUME_LABEL) --rm $(DOCS_BUILD_CONTAINER) --stacktrace antora-playbook.yml
 
 .PHONY: docs_serve
 docs_serve: build_docs
-	${CONTAINER_RUNTIME} run -it -v $(CURDIR)/docs/build:/usr/local/apache2/htdocs/:Z --rm -p 8088:80/tcp $(DOCS_SERVE_CONTAINER)
+	${CONTAINER_RUNTIME} run -it -v $(CURDIR)/docs/build:/usr/local/apache2/htdocs/$(SELINUX_VOLUME_LABEL) --rm -p 8088:80/tcp $(DOCS_SERVE_CONTAINER)
 
 .PHONY: docs_check_links
 docs_check_links:
-	${CONTAINER_RUNTIME} run -v $(CURDIR):/test:Z --rm $(DOCS_TEST_CONTAINER) -c .htmltest.yml
+	${CONTAINER_RUNTIME} run -v $(CURDIR):/test$(SELINUX_VOLUME_LABEL) --rm $(DOCS_TEST_CONTAINER) -c .htmltest.yml
 
 .PHONY: clean_docs clean_macos_package
 clean_docs:


### PR DESCRIPTION
Calling `podman run -v` with the `:Z` SELinux volume label is currently not supported on MacOS. 

Avoid adding `:Z` when `$(GOOS)` is `darwin`. 

