### PR TITLE
crc status: remove redundant workaround on windows

### DIFF
--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -7,11 +7,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"text/tabwriter"
 
 	"github.com/cheggaaa/pb/v3"
-	"github.com/cheggaaa/pb/v3/termutil"
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/daemonclient"
 	crcErrors "github.com/crc-org/crc/v2/pkg/crc/errors"
@@ -96,12 +94,6 @@ func runWatchStatus(writer io.Writer, client *daemonclient.Client, cacheDir stri
 			barPool = pb.NewPool(append([]*pb.ProgressBar{ramBar}, cpuBars...)...)
 			if startErr := barPool.Start(); startErr != nil {
 				return
-			}
-			if runtime.GOOS == "windows" {
-				// Print and ignore the error to continue printing
-				if rawErr := termutil.RawModeOff(); rawErr != nil {
-					fmt.Fprintf(os.Stderr, "Failed to turn off raw mode due to error: %v\n", rawErr)
-				}
 			}
 			isPoolInit = true
 		} else if len(loadResult.CPUUse) > len(cpuBars) {


### PR DESCRIPTION

**Relates to:** PR #3955 

## Solution/Idea

PR #3955 was created as a workaround on windows to fix the terminal mode issue which is not required anymore.

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `crc status -w` prints as expected on Windows