### PR TITLE
docs: removed Podman preset mentions - fixes #4003

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,8 @@ image:https://github.com/crc-org/crc/actions/workflows/make-check-win.yml/badge.
 [[intro-to-crc]]
 == Introduction
 
-`crc` is a tool to run containers. It manages a local https://github.com/openshift/origin[OpenShift 4.x] cluster, https://github.com/openshift/okd[OKD] cluster or a https://github.com/containers/podman[Podman] VM optimized for testing and development purposes.
+`crc` is a tool to run containers.
+It manages a local https://github.com/openshift/origin[OpenShift 4.x] cluster, or an https://github.com/openshift/okd[OKD] cluster VM optimized for testing and development purposes.
 
 If you are looking for a solution for running OpenShift 3.x, you will need tools such as `oc cluster up`, http://github.com/minishift/minishift[Minishift] or https://developers.redhat.com/products/cdk/overview/[CDK].
 
@@ -24,12 +25,13 @@ If you are looking for a solution for running OpenShift 3.x, you will need tools
 
 The first time CRC is run, you will be asked to opt-in to Red Hat's telemetry collection program.
 
-With your approval, CRC collects pseudonymized usage data and sends it to Red Hat servers to help improve our products and services. Read our https://developers.redhat.com/article/tool-data-collection[privacy statement] to learn more about it. For the specific data points being collected, see xref:usage-data.adoc#data-table[Usage data].
+With your approval, CRC collects pseudonymized usage data and sends it to Red Hat servers to help improve our products and services.
+Read our https://developers.redhat.com/article/tool-data-collection[privacy statement] to learn more about it.
+For the specific data points being collected, see xref:usage-data.adoc#data-table[Usage data].
 
 === Manually configuring usage data collection
 
 You can manually change your preference about usage data collection by running `crc config set consent-telemetry <yes/no>` before the next `crc start`.
-
 
 [[documentation]]
 == Documentation

--- a/docs/extensions/get-versions.js
+++ b/docs/extensions/get-versions.js
@@ -13,10 +13,6 @@ module.exports.register = function () {
       "grep '^OPENSHIFT_VERSION' Makefile | cut -d' ' -f3 | cut -d'.' -f-2 | tr -d '\n'",
       { encoding: "utf8" }
     );
-    const podman_ver = child_process.execSync(
-      "grep '^PODMAN_VERSION' Makefile | cut -d' ' -f3 | tr -d '\n'",
-      { encoding: "utf8" }
-    );
     const prod_ver_full = child_process.execSync(
       "grep '^CRC_VERSION' Makefile | cut -d' ' -f3 | tr -d '\n'",
       { encoding: "utf8" }
@@ -33,7 +29,6 @@ module.exports.register = function () {
     // Display versions
     console.log("OpenShift patch version: " + ocp_ver_full);
     console.log("OpenShift minor version: " + ocp_ver);
-    console.log("Podman version: " + podman_ver);
     console.log("CRC patch version: " + prod_ver_full);
     console.log("CRC minor version: " + prod_ver);
     console.log("MicroShift version: " + ushift_ver);
@@ -42,7 +37,6 @@ module.exports.register = function () {
     Object.assign(playbook.asciidoc.attributes, {
       "ocp-ver": ocp_ver,
       "ocp-ver-full": ocp_ver_full,
-      "podman-ver": podman_ver,
       "prod-ver": prod_ver,
       "prod-ver-full": prod_ver_full,
       "ushift-ver": ushift_ver,

--- a/docs/modules/getting_started/examples/snip_crc_preset_list.adoc
+++ b/docs/modules/getting_started/examples/snip_crc_preset_list.adoc
@@ -1,4 +1,3 @@
 `openshift`:: {ocp}
 `okd`:: {okd}
 `microshift`::  {ushift}
-`podman`:: Podman container runtime

--- a/docs/modules/getting_started/examples/snip_crc_preset_names.adoc
+++ b/docs/modules/getting_started/examples/snip_crc_preset_names.adoc
@@ -5,5 +5,4 @@ Name, Preset
 `openshift`, {ocp}
 `okd`, {okd}
 `microshift`, {ushift}
-`podman`, Podman container runtime
 |===

--- a/docs/modules/getting_started/examples/snip_crc_preset_platforms.adoc
+++ b/docs/modules/getting_started/examples/snip_crc_preset_platforms.adoc
@@ -5,5 +5,4 @@ Preset, AMD64, Intel 64, Apple silicon
 {ocp}, yes, yes,  yes
 {okd}, yes, yes, no
 {ushift}, yes, yes, yes
-Podman container runtime, yes, yes, yes
 |===

--- a/docs/modules/getting_started/partials/con_about.adoc
+++ b/docs/modules/getting_started/partials/con_about.adoc
@@ -1,7 +1,7 @@
 = About {prod}
 
-{rh-prod} brings a minimal {ocp} 4 cluster and Podman container runtime to your local computer.
-These runtimes provide minimal environments for development and testing purposes.
+{rh-prod} brings a minimal {ocp} 4 cluster to your local computer.
+This runtime provides minimal environments for development and testing purposes.
 {prod} is mainly targeted at running on developers' desktops.
 For other {ocp} use cases, such as headless or multi-developer setups, use the link:{openshift-installer-url}[full {openshift} installer].
 

--- a/docs/modules/getting_started/partials/proc_setting-up.adoc
+++ b/docs/modules/getting_started/partials/proc_setting-up.adoc
@@ -21,14 +21,6 @@ Always run the [command]`{bin}` executable with your user account.
 ====
 
 .Procedure
-. (Optional) On Linux, the {ocp} preset is selected by default.
-To select the Podman container runtime preset:
-+
-[subs="+quotes,attributes"]
-----
-$ {bin} config set preset podman
-----
-
 . Set up your host machine for {prod}:
 +
 [subs="+quotes,attributes"]

--- a/docs/modules/getting_started/partials/ref_minimum-system-requirements.adoc
+++ b/docs/modules/getting_started/partials/ref_minimum-system-requirements.adoc
@@ -32,12 +32,6 @@ Some workloads might require more resources.
 To assign more resources to the {prod} instance, see link:{crc-gsg-url}#configuring-the-instance_gsg[Configuring the instance].
 ====
 
-=== For the Podman container runtime
-
-* 2 physical CPU cores
-* 2 GB of free memory
-* 35 GB of storage space
-
 == Operating system requirements
 
 {prod} requires the following minimum version of a supported operating system:


### PR DESCRIPTION
**Fixes:** Issue #4003

## Solution/Idea

The Podman preset is deprecated and will be removed in the next version. DOn't mention it in the documentation.

## Proposed changes

Removed Podman preset mentions from the documentation.

## Testing

The documentation does not mention the Podman preset.