### PR TITLE
Check status of all the core pods for microshift

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -1064,7 +1064,10 @@ func startMicroshift(ctx context.Context, sshRunner *crcssh.Runner, ocConfig oc.
 		return err
 	}
 
-	return cluster.WaitForAPIServer(ctx, ocConfig)
+	if err := cluster.WaitForAPIServer(ctx, ocConfig); err != nil {
+		return err
+	}
+	return cluster.CheckCorePodsRunning(ctx, ocConfig)
 }
 
 func ensurePullSecretPresentInVM(sshRunner *crcssh.Runner, pullSec cluster.PullSecretLoader) error {


### PR DESCRIPTION
In past we observed having kube api access doesn't mean all the required service pods are running and cluster is working as expected. This PR adds a list of core namespace for microshift preset and make sure all the pods in that namespace is running before letting user to know to consume the cluster.


**Fixes:** Issue #3852 

