### PR TITLE
deprecated preset: add warning for podman preset during  and  commands

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -87,6 +87,10 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		EnableBundleQuayFallback: config.Get(crcConfig.EnableBundleQuayFallback).AsBool(),
 	}
 
+	if startConfig.Preset == preset.Podman {
+		logging.Warn(preset.PodmanDeprecatedWarning)
+	}
+
 	client := newMachine()
 	isRunning, _ := client.IsRunning()
 

--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/crc/preset"
 	"github.com/crc-org/crc/v2/pkg/os"
 	"github.com/spf13/cast"
 )
@@ -21,7 +23,11 @@ func RequiresDeleteMsg(key string, _ interface{}) string {
 		"delete the CRC instance with 'crc delete' and start it with 'crc start'.", key)
 }
 
-func RequiresDeleteAndSetupMsg(key string, _ interface{}) string {
+func RequiresDeleteAndSetupMsg(key string, value interface{}) string {
+
+	if key == Preset && value == string(preset.Podman) {
+		logging.Warn(preset.PodmanDeprecatedWarning)
+	}
 	// since we cannot easily import the machine package here to check for existence of the CRC vm
 	// we rely on the existence of the machine config file to determine if a VM exists
 	if os.FileExists(filepath.Join(constants.MachineInstanceDir, "crc", "config.json")) {

--- a/pkg/crc/preset/preset.go
+++ b/pkg/crc/preset/preset.go
@@ -22,6 +22,11 @@ var presetMap = map[Preset]string{
 	Microshift: string(Microshift),
 }
 
+const (
+	PodmanDeprecatedWarning = "The Podman preset is deprecated and will be removed in a future release. Consider" +
+		" rather using a Podman Machine managed by Podman Desktop: https://podman-desktop.io"
+)
+
 func AllPresets() []Preset {
 	var keys []Preset
 	for k := range presetMap {


### PR DESCRIPTION
**Fixes:** Issue #3970 

## Solution/Idea

`podman` preset deprecation warning has been added in two places: `crc config set preset podman` and `crc start`

## Proposed changes

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `crc config set preset podman` should print a warning
2. `crc start` with already set preset `podman` should print a warning