### PR TITLE
preflight: Fix tests with go 1.21

### DIFF
--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -95,7 +95,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcNetworkManagerDispatcherFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -133,7 +133,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcDnsmasqConfigFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -165,7 +165,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkDaemonSystemdService},
 			{check: checkDaemonSystemdSockets},
 			{check: checkVsock},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -204,7 +204,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcNetworkManagerDispatcherFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -242,7 +242,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcDnsmasqConfigFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -274,7 +274,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkDaemonSystemdService},
 			{check: checkDaemonSystemdSockets},
 			{check: checkVsock},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -313,7 +313,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcNetworkManagerDispatcherFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -351,7 +351,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcDnsmasqConfigFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -383,7 +383,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkDaemonSystemdService},
 			{check: checkDaemonSystemdSockets},
 			{check: checkVsock},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -423,7 +423,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcNetworkManagerDispatcherFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -462,7 +462,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcDnsmasqConfigFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 	{
@@ -495,7 +495,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkDaemonSystemdSockets},
 			{configKeySuffix: "check-apparmor-profile-setup"},
 			{check: checkVsock},
-			{check: checkBundleExtracted(constants.GetDefaultBundlePath(preset.OpenShift))},
+			{configKeySuffix: "check-bundle-extracted"},
 		},
 	},
 }


### PR DESCRIPTION
If `check` is an anonymous functions, comparisons do not necessarily
work well, and this broke with go 1.21:

=== RUN   TestCountPreflights
    preflight_linux_test.go:508:
                Error Trace:    /home/anjan/Work/github.com/code-ready/main/pkg/crc/preflight/preflight_linux_test.go:508
                                                        /home/anjan/Work/github.com/code-ready/main/pkg/crc/preflight/preflight_linux_test.go:528
                                                        /home/anjan/Work/github.com/code-ready/main/pkg/crc/preflight/preflight_linux_test.go:540
                Error:          Not equal:
                                expected: 0x2659080
                                actual  : 0x2672120
                Test:           TestCountPreflights
                Messages:       github.com/crc-org/crc/v2/pkg/crc/preflight.bundleCheck.checkBundleExtracted.func1 != github.com/crc-org/crc/v2/pkg/crc/preflight.init.checkBundleExtracted.func2

This commit changes this to compare configKeySuffix instead.

This fixes https://github.com/crc-org/crc/issues/4030