### PR TITLE
[bug] kubeconfig: use correct clusterURL to append to username 

### DIFF
--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -176,7 +176,7 @@ func addContext(cfg *api.Config, ip string, clusterConfig *types.ClusterConfig, 
 	}
 
 	// append /clustername to AuthInfo
-	clusterUser, err := appendClusternameToUser(username, host)
+	clusterUser, err := appendClusternameToUser(username, clusterConfig.ClusterAPI)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes the following bug when adding new entries to `kubeconfig`:
```
contexts:
  - context:
      cluster: api-crc-testing:6443
      namespace: default
      user: kubeadmin/
    name: crc-admin
  - context:
      cluster: api-crc-testing:6443
      namespace: default
      user: developer/
    name: crc-developer
current-context: crc-admin
kind: Config
preferences: {}
users:
  - name: developer/
    user:
      token: sha256~CBgT896e1SBxirkR9_ZoJ4GqwxJhimyA2uP3G8siOJc
  - name: kubeadmin/
    user:
      token: sha256~PhiS_HFPQfxMC4Fg5Y41hDSWuXXRVB-efCHMDyGhB3k
```

notice how the users list has `name: kubeadmin/` without the clustername it should be `name: kubeadmin/api-crc-testing:6443`