### PR TITLE
Use ad-hoc signing on macOS, and bump minimum libvirt version

### DIFF
--- a/packaging/darwin/macos-pkg-build-and-sign.sh
+++ b/packaging/darwin/macos-pkg-build-and-sign.sh
@@ -3,14 +3,11 @@ set -euxo pipefail
 
 BASEDIR=$(dirname "$0")
 OUTPUT=$1
-CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-mock}
+CODESIGN_IDENTITY=${CODESIGN_IDENTITY:--}
 PRODUCTSIGN_IDENTITY=${PRODUCTSIGN_IDENTITY:-mock}
 NO_CODESIGN=${NO_CODESIGN:-0}
 
 function sign() {
-  if [ "${NO_CODESIGN}" -eq "1" ]; then
-    return
-  fi
   local opts=""
   entitlements="${BASEDIR}/$(basename "$1").entitlements"
   if [ -f "${entitlements}" ]; then

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// This is defined in https://github.com/crc-org/machine-driver-libvirt/blob/master/go.mod#L5
-	minSupportedLibvirtVersion = "3.4.0"
+	minSupportedLibvirtVersion = "8.0.0"
 )
 
 func checkRunningInsideWSL2() error {


### PR DESCRIPTION
2 unrelated commits in this PR, one to sync our macOS signing code with podman, and the other to bump the minimum libvirt version we require after the libvirt-machine-driver update.