### PR TITLE
Remove the Podman preset and all its usages

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -44,11 +44,7 @@ jobs:
           path: "./out/macos-universal/crc-macos-installer.pkg"
       - name: Install crc pkg
         run: sudo installer -pkg out/macos-universal/crc-macos-installer.pkg -target /
-      - name: Set podman preset as part of config
-        run: crc config set preset podman
+      - name: Set microshift preset as part of config
+        run: crc config set preset microshift
       - name: Run crc setup command
         run: crc setup
-      - name: Wait 10 sec for the daemon to serve
-        run: sleep 10
-      - name: Run crc with podman preset
-        run: crc start

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -87,10 +87,6 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		EnableBundleQuayFallback: config.Get(crcConfig.EnableBundleQuayFallback).AsBool(),
 	}
 
-	if startConfig.Preset == preset.Podman {
-		logging.Warn(preset.PodmanDeprecatedWarning)
-	}
-
 	client := newMachine()
 	isRunning, _ := client.IsRunning()
 

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -196,9 +196,6 @@ func (s *status) prettyPrintTo(writer io.Writer) error {
 	if s.Preset == preset.OpenShift {
 		lines = append(lines, line{"OpenShift", openshiftStatus(s)})
 	}
-	if s.Preset == preset.Podman {
-		lines = append(lines, line{"Podman", s.PodmanVersion})
-	}
 	if s.Preset == preset.Microshift {
 		lines = append(lines, line{"MicroShift", openshiftStatus(s)})
 	}

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -77,7 +77,7 @@ func NewNonInteractivePullSecretLoader(config crcConfig.Storage, path string) Pu
 
 func (loader *nonInteractivePullSecretLoader) Value() (string, error) {
 	// If crc is built from an OKD bundle or podman bundle is used, then use the fake pull secret in constants.
-	if crcConfig.GetPreset(loader.config) == preset.OKD || crcConfig.GetPreset(loader.config) == preset.Podman {
+	if crcConfig.GetPreset(loader.config) == preset.OKD {
 		return constants.OkdPullSecret, nil
 	}
 

--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
-	"github.com/crc-org/crc/v2/pkg/crc/logging"
-	"github.com/crc-org/crc/v2/pkg/crc/preset"
 	"github.com/crc-org/crc/v2/pkg/os"
 	"github.com/spf13/cast"
 )
@@ -23,11 +21,7 @@ func RequiresDeleteMsg(key string, _ interface{}) string {
 		"delete the CRC instance with 'crc delete' and start it with 'crc start'.", key)
 }
 
-func RequiresDeleteAndSetupMsg(key string, value interface{}) string {
-
-	if key == Preset && value == string(preset.Podman) {
-		logging.Warn(preset.PodmanDeprecatedWarning)
-	}
+func RequiresDeleteAndSetupMsg(key string, _ interface{}) string {
 	// since we cannot easily import the machine package here to check for existence of the CRC vm
 	// we rely on the existence of the machine config file to determine if a VM exists
 	if os.FileExists(filepath.Join(constants.MachineInstanceDir, "crc", "config.json")) {

--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -36,7 +36,7 @@ func newInMemoryConfig() (*Config, error) {
 }
 
 // Check that with the default preset, we cannot set less CPUs than the defaultCPUs
-// but that it is allowed with a different preset with less requirements (podman)
+// but that it is allowed with a different preset with less requirements (microshift)
 func TestCPUsValidate(t *testing.T) {
 	cfg, err := newInMemoryConfig()
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestCPUsValidate(t *testing.T) {
 		IsSecret:  false,
 	}, cfg.Get(CPUs))
 
-	_, err = cfg.Set(Preset, crcpreset.Podman)
+	_, err = cfg.Set(Preset, crcpreset.Microshift)
 	require.NoError(t, err)
 	_, err = cfg.Set(CPUs, defaultCPUs-1)
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestSetPreset(t *testing.T) {
 	cfg, err := newInMemoryConfig()
 	require.NoError(t, err)
 
-	_, err = cfg.Set(Preset, crcpreset.Podman)
+	_, err = cfg.Set(Preset, crcpreset.Microshift)
 	require.NoError(t, err)
 	_, err = cfg.Set(Memory, 10800)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestUnsetPreset(t *testing.T) {
 	cfg, err := newInMemoryConfig()
 	require.NoError(t, err)
 
-	_, err = cfg.Set(Preset, crcpreset.Podman)
+	_, err = cfg.Set(Preset, crcpreset.Microshift)
 	require.NoError(t, err)
 	_, err = cfg.Set(Memory, 10800)
 	require.NoError(t, err)

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -205,7 +205,7 @@ func GetDefaultCPUs(preset crcpreset.Preset) int {
 	switch preset {
 	case crcpreset.OpenShift, crcpreset.OKD:
 		return 4
-	case crcpreset.Podman, crcpreset.Microshift:
+	case crcpreset.Microshift:
 		return 2
 	default:
 		// should not be reached

--- a/pkg/crc/image/image.go
+++ b/pkg/crc/image/image.go
@@ -102,8 +102,6 @@ func getPresetNameE(imageName string) (crcpreset.Preset, error) {
 		return crcpreset.OpenShift, nil
 	case "okd-bundle":
 		return crcpreset.OKD, nil
-	case "podman-bundle":
-		return crcpreset.Podman, nil
 	case "microshift-bundle":
 		return crcpreset.Microshift, nil
 	default:

--- a/pkg/crc/machine/bundle/copier.go
+++ b/pkg/crc/machine/bundle/copier.go
@@ -70,13 +70,10 @@ func (copier *Copier) CopyPrivateSSHKey(srcPath string) error {
 }
 
 func (copier *Copier) CopyKubeConfig() error {
-	if !copier.srcBundle.IsPodman() {
-		kubeConfigFileName := filepath.Base(copier.srcBundle.GetKubeConfigPath())
-		srcPath := copier.srcBundle.GetKubeConfigPath()
-		destPath := copier.resolvePath(kubeConfigFileName)
-		return crcos.CopyFileContents(srcPath, destPath, 0640)
-	}
-	return nil
+	kubeConfigFileName := filepath.Base(copier.srcBundle.GetKubeConfigPath())
+	srcPath := copier.srcBundle.GetKubeConfigPath()
+	destPath := copier.resolvePath(kubeConfigFileName)
+	return crcos.CopyFileContents(srcPath, destPath, 0640)
 }
 
 func (copier *Copier) CopyFilesFromFileList() error {

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -196,6 +196,10 @@ func (bundle *CrcBundleInfo) IsMicroshift() bool {
 	return bundle.GetBundleType() == crcPreset.Microshift
 }
 
+func (bundle *CrcBundleInfo) IsPodman() bool {
+	return bundle.GetBundleType() == crcPreset.Podman
+}
+
 func (bundle *CrcBundleInfo) verify() error {
 	files := []string{
 		bundle.GetSSHKeyPath(),

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -167,21 +167,12 @@ func (bundle *CrcBundleInfo) GetBundleBuildTime() (time.Time, error) {
 	return time.Parse(time.RFC3339, strings.TrimSpace(bundle.BuildInfo.BuildTime))
 }
 
-func (bundle *CrcBundleInfo) GetOpenshiftVersion() string {
+func (bundle *CrcBundleInfo) GetVersion() string {
 	return bundle.ClusterInfo.OpenShiftVersion.String()
 }
 
 func (bundle *CrcBundleInfo) GetPodmanVersion() string {
 	return bundle.Nodes[0].PodmanVersion
-}
-
-func (bundle *CrcBundleInfo) GetVersion() string {
-	switch bundle.GetBundleType() {
-	case crcPreset.Podman:
-		return bundle.GetPodmanVersion()
-	default:
-		return bundle.GetOpenshiftVersion()
-	}
 }
 
 func (bundle *CrcBundleInfo) GetBundleNameWithoutExtension() string {
@@ -205,22 +196,14 @@ func (bundle *CrcBundleInfo) IsMicroshift() bool {
 	return bundle.GetBundleType() == crcPreset.Microshift
 }
 
-func (bundle *CrcBundleInfo) IsPodman() bool {
-	return bundle.GetBundleType() == crcPreset.Podman
-}
-
 func (bundle *CrcBundleInfo) verify() error {
 	files := []string{
 		bundle.GetSSHKeyPath(),
 		bundle.GetDiskImagePath(),
 		bundle.GetKernelPath(),
 		bundle.GetInitramfsPath(),
-	}
-	if !bundle.IsPodman() {
-		files = append(files, []string{
-			bundle.GetOcPath(),
-			bundle.GetKubeConfigPath()}...)
-	}
+		bundle.GetOcPath(),
+		bundle.GetKubeConfigPath()}
 
 	for _, file := range files {
 		if file == "" {
@@ -352,7 +335,7 @@ func Download(preset crcPreset.Preset, bundleURI string, enableBundleQuayFallbac
 				return image.PullBundle(constants.GetDefaultBundleImageRegistry(preset))
 			}
 			return downloadedBundlePath, err
-		case crcPreset.Podman, crcPreset.OKD:
+		case crcPreset.OKD:
 			fallthrough
 		default:
 			return image.PullBundle(constants.GetDefaultBundleImageRegistry(preset))

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -55,17 +55,16 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 		return nil, err
 	}
 
-	if !bundleInfo.IsPodman() {
-		// TODO: update this logic after major release of bundle like 4.14
-		// As of now we are using this logic to support older bundles of microshift and it need to be updated
-		// to only provide app domain route information as per preset.
-		if !crcstrings.Contains([]string{constants.AppsDomain, constants.MicroShiftAppDomain}, fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain)) {
-			return nil, fmt.Errorf("unexpected bundle, it must have %s or %s apps domain", constants.AppsDomain, constants.MicroShiftAppDomain)
-		}
-		if bundleInfo.GetAPIHostname() != fmt.Sprintf("api%s", constants.ClusterDomain) {
-			return nil, fmt.Errorf("unexpected bundle, it must have %s base domain", constants.ClusterDomain)
-		}
+	// TODO: update this logic after major release of bundle like 4.14
+	// As of now we are using this logic to support older bundles of microshift and it need to be updated
+	// to only provide app domain route information as per preset.
+	if !crcstrings.Contains([]string{constants.AppsDomain, constants.MicroShiftAppDomain}, fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain)) {
+		return nil, fmt.Errorf("unexpected bundle, it must have %s or %s apps domain", constants.AppsDomain, constants.MicroShiftAppDomain)
 	}
+	if bundleInfo.GetAPIHostname() != fmt.Sprintf("api%s", constants.ClusterDomain) {
+		return nil, fmt.Errorf("unexpected bundle, it must have %s base domain", constants.ClusterDomain)
+	}
+
 	return &bundleInfo, nil
 }
 

--- a/pkg/crc/machine/bundle/repository_test.go
+++ b/pkg/crc/machine/bundle/repository_test.go
@@ -43,7 +43,7 @@ func TestExtract(t *testing.T) {
 
 	bundle, err := repo.Get(testBundle(t))
 	assert.NoError(t, err)
-	assert.Equal(t, "4.6.1", bundle.GetOpenshiftVersion())
+	assert.Equal(t, "4.6.1", bundle.GetVersion())
 
 	_ = os.Remove(bundle.GetKubeConfigPath())
 	bundle, err = repo.Get(testBundle(t))

--- a/pkg/crc/machine/console.go
+++ b/pkg/crc/machine/console.go
@@ -1,8 +1,6 @@
 package machine
 
 import (
-	"fmt"
-
 	"github.com/crc-org/crc/v2/pkg/crc/machine/types"
 	"github.com/pkg/errors"
 )
@@ -17,10 +15,6 @@ func (client *client) GetConsoleURL() (*types.ConsoleResult, error) {
 		return nil, errors.Wrap(err, "Cannot load machine")
 	}
 	defer vm.Close()
-
-	if vm.bundle.IsPodman() {
-		return nil, fmt.Errorf("Only supported with OpenShift bundles")
-	}
 
 	vmState, err := vm.State()
 	if err != nil {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -340,6 +340,10 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 	defer vm.Close()
 
+	// Return with an error redirecting user to use podman machine instead
+	if vm.bundle.IsPodman() {
+		return &types.StartResult{}, fmt.Errorf("error: %s", crcPreset.PodmanDeprecatedWarning)
+	}
 	currentBundleName := vm.bundle.GetBundleName()
 	if currentBundleName != bundleName {
 		logging.Debugf("Bundle '%s' was requested, but the existing VM is using '%s'",
@@ -679,6 +683,9 @@ func (client *client) IsRunning() (bool, error) {
 }
 
 func (client *client) validateStartConfig(startConfig types.StartConfig) error {
+	if startConfig.Preset == crcPreset.Podman {
+		return fmt.Errorf(crcPreset.PodmanDeprecatedWarning)
+	}
 	if client.monitoringEnabled() && startConfig.Memory < minimumMemoryForMonitoring {
 		return fmt.Errorf("Too little memory (%s) allocated to the virtual machine to start the monitoring stack, %s is the minimum",
 			units.BytesSize(float64(startConfig.Memory)*1024*1024),

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -35,16 +35,13 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 		CrcStatus: vmStatus,
 	}
 	switch {
-	case vm.bundle.IsPodman():
-		clusterStatusResult.PodmanVersion = vm.bundle.GetPodmanVersion()
-		clusterStatusResult.Preset = preset.Podman
 	case vm.bundle.IsMicroshift():
 		clusterStatusResult.OpenshiftStatus = types.OpenshiftStopped
-		clusterStatusResult.OpenshiftVersion = vm.bundle.GetOpenshiftVersion()
+		clusterStatusResult.OpenshiftVersion = vm.bundle.GetVersion()
 		clusterStatusResult.Preset = preset.Microshift
 	default:
 		clusterStatusResult.OpenshiftStatus = types.OpenshiftStopped
-		clusterStatusResult.OpenshiftVersion = vm.bundle.GetOpenshiftVersion()
+		clusterStatusResult.OpenshiftVersion = vm.bundle.GetVersion()
 		clusterStatusResult.Preset = preset.OpenShift
 	}
 

--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -122,13 +122,6 @@ func vsockPorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint)
 				Local:    fmt.Sprintf(":%d", ingressHTTPPort),
 				Remote:   net.JoinHostPort(virtualMachineIP, remoteHTTPPort),
 			})
-	case crcPreset.Podman:
-		exposeRequest = append(exposeRequest,
-			types.ExposeRequest{
-				Protocol: "tcp",
-				Local:    net.JoinHostPort(constants.LocalIP, cockpitPort),
-				Remote:   net.JoinHostPort(virtualMachineIP, cockpitPort),
-			})
 	default:
 		logging.Errorf("Invalid preset: %s", preset)
 	}

--- a/pkg/crc/preset/preset.go
+++ b/pkg/crc/preset/preset.go
@@ -16,16 +16,10 @@ const (
 )
 
 var presetMap = map[Preset]string{
-	Podman:     string(Podman),
 	OpenShift:  string(OpenShift),
 	OKD:        string(OKD),
 	Microshift: string(Microshift),
 }
-
-const (
-	PodmanDeprecatedWarning = "The Podman preset is deprecated and will be removed in a future release. Consider" +
-		" rather using a Podman Machine managed by Podman Desktop: https://podman-desktop.io"
-)
 
 func AllPresets() []Preset {
 	var keys []Preset

--- a/pkg/crc/preset/preset.go
+++ b/pkg/crc/preset/preset.go
@@ -21,6 +21,11 @@ var presetMap = map[Preset]string{
 	Microshift: string(Microshift),
 }
 
+const (
+	PodmanDeprecatedWarning = "The Podman preset is deprecated and will be removed in a future release. Consider" +
+		" rather using a Podman Machine managed by Podman Desktop: https://podman-desktop.io"
+)
+
 func AllPresets() []Preset {
 	var keys []Preset
 	for k := range presetMap {
@@ -52,6 +57,9 @@ func (preset Preset) ForDisplay() string {
 }
 
 func ParsePresetE(input string) (Preset, error) {
+	if string(Podman) == input {
+		return Podman, fmt.Errorf(PodmanDeprecatedWarning)
+	}
 	for pSet, pString := range presetMap {
 		if pString == input {
 			return pSet, nil
@@ -62,7 +70,7 @@ func ParsePresetE(input string) (Preset, error) {
 }
 func ParsePreset(input string) Preset {
 	preset, err := ParsePresetE(input)
-	if err != nil {
+	if err != nil && preset != Podman {
 		logging.Errorf("unexpected preset mode %s, using default", input)
 		return OpenShift
 	}

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -212,7 +212,3 @@ func addOpenShiftHosts(serviceConfig services.ServicePostStartConfig) error {
 		serviceConfig.BundleMetadata.GetAppHostname("canary-openshift-ingress-canary"),
 		serviceConfig.BundleMetadata.GetAppHostname("default-route-openshift-image-registry"))
 }
-
-func AddPodmanHosts(ip string) error {
-	return adminhelper.UpdateHostsFile(ip, "podman.crc.testing")
-}

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -47,6 +47,9 @@ func GetCommitSha() string {
 	return commitSha
 }
 
+// GetBundleVersion returns the version of the binaries present
+// inside the bundle. The `PodmanVersion` in this case refers to
+// the version of the podman binary present inside the bundle.
 func GetBundleVersion(preset crcPreset.Preset) string {
 	switch preset {
 	case crcPreset.Podman:

--- a/test/e2e/features/minimal.feature
+++ b/test/e2e/features/minimal.feature
@@ -12,7 +12,6 @@ Feature: Minimal user story
 
         Examples:
             | preset-value |
-            | podman       |
             | microshift   |
             | openshift    |
 

--- a/test/e2e/features/proxy.feature
+++ b/test/e2e/features/proxy.feature
@@ -12,11 +12,3 @@ Feature: Behind proxy test
         And executing "eval $(crc oc-env)" succeeds
         When checking that CRC is running
         Then login to the oc cluster succeeds
-
-    # inherits @proxy tag from Feature
-    @cleanup @podman-preset
-    Scenario: Cache podman bundle behind proxy under podman preset
-        * removing podman bundle from cache succeeds
-        * executing "crc config set preset podman" succeeds
-        When executing single crc setup command succeeds
-        Then executing "crc start" succeeds

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -658,15 +658,9 @@ func FileExistsInCRCHome(fileName string) error {
 	return err
 }
 
-func RemoveBundleFromCache(presetName string) error {
+func RemoveBundleFromCache(_ string) error {
 
-	var p preset.Preset
-
-	if presetName == "podman" {
-		p = preset.Podman
-	} else {
-		p = preset.OpenShift
-	}
+	var p = preset.OpenShift
 
 	theBundle := util.GetBundlePath(p)
 	theFolder := strings.TrimSuffix(theBundle, ".crcbundle")

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -184,11 +184,6 @@ func InitializeScenario(s *godog.ScenarioContext) {
 
 		for _, tag := range sc.Tags {
 
-			// if podman preset is activated, bundle will not be provided by the user
-			if tag.Name == "@podman-preset" {
-				userProvidedBundle = false
-			}
-
 			// copy data/config files to test dir
 			if tag.Name == "@testdata" {
 				err := util.CopyFilesToTestDir()
@@ -439,7 +434,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		util.DownloadFileIntoLocation)
 	s.Step(`^writing text "([^"]*)" to file "([^"]*)" succeeds$`,
 		util.WriteToFile)
-	s.Step(`^removing (podman|openshift) bundle from cache succeeds$`,
+	s.Step(`^removing (openshift) bundle from cache succeeds$`,
 		RemoveBundleFromCache)
 
 	// File content checks
@@ -658,7 +653,7 @@ func FileExistsInCRCHome(fileName string) error {
 	return err
 }
 
-func RemoveBundleFromCache(_ string) error {
+func RemoveBundleFromCache() error {
 
 	var p = preset.OpenShift
 

--- a/test/integration/podman_test.go
+++ b/test/integration/podman_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("podman preset", Serial, Ordered, Label("podman-preset"), func() {
+var _ = Describe("podman-remote", Serial, Ordered, Label("microshift-preset"), func() {
 
 	// runs 1x after all the It blocks (specs) inside this Describe node
 	AfterAll(func() {
@@ -28,7 +28,7 @@ var _ = Describe("podman preset", Serial, Ordered, Label("podman-preset"), func(
 	Describe("basic use", Serial, Ordered, func() {
 
 		It("write to config", func() {
-			Expect(RunCRCExpectSuccess("config", "set", "preset", "podman")).To(ContainSubstring("please run 'crc setup' before 'crc start'"))
+			Expect(RunCRCExpectSuccess("config", "set", "preset", "microshift")).To(ContainSubstring("please run 'crc setup' before 'crc start'"))
 		})
 
 		It("setup CRC", func() {
@@ -36,7 +36,7 @@ var _ = Describe("podman preset", Serial, Ordered, Label("podman-preset"), func(
 		})
 
 		It("start CRC", func() {
-			Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("podman runtime is now running"))
+			Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the MicroShift cluster"))
 		})
 
 		It("podman-env", func() {


### PR DESCRIPTION
**Fixes:** Issue #3970 

**Relates to:** Issue #3970, PR #4012
## Solution/Idea
This PR removes the usages of the `Podman` from the code. This is a follow-up to the PR: https://github.com/crc-org/crc/pull/4012 which added a deprecated warning for the users who chose the `Podman` preset.

## Proposed changes
The changes to remove the usage of Podman preset have been done in two PRs. (https://github.com/crc-org/crc/pull/4012)
- The first change was to print a deprecation warning for users using the preset. 
- In the current PR, the preset itself is being removed from the code.

## Testing
Setting and using `crc` with `Podman` preset should fail.