### PR TITLE
update macos preflight checks unit test

### DIFF
--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -13,13 +13,13 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage(), config.NewEmptyInMemorySecretStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 13)
+	assert.Len(t, cfg.AllConfigs(), 14)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 19)
-	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 19)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 20)
+	assert.Len(t, getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 20)
 
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 18)
-	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 18)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 19)
+	assert.Len(t, getPreflightChecks(true, network.UserNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false), 19)
 }


### PR DESCRIPTION
fixes the following unit test error:
```
=== RUN   TestCountConfigurationOptions
    preflight_darwin_test.go:16:
        	Error Trace:	/Users/runner/work/crc/crc/pkg/crc/preflight/preflight_darwin_test.go:16
        	Error:      	"map[skip-check-admin-helper-cached:{false false true false} skip-check-bundle-extracted:{false false true false} skip-check-crc-symlink:{false false true false} skip-check-daemon-launchd-plist:{false false true false} skip-check-m1-cpu:{false false true false} skip-check-mac-version:{false false true false} skip-check-old-autostart:{false false true false} skip-check-podman-in-ocbindir:{false false true false} skip-check-ram:{false false true false} skip-check-resolver-file-permissions:{false false true false} skip-check-root-user:{false false true false} skip-check-ssh-port:{false false true false} skip-check-supported-cpu-arch:{false false true false} skip-check-vfkit-installed:{false false true false}]" should have 13 item(s), but has 14
        	Test:       	TestCountConfigurationOptions
--- FAIL: TestCountConfigurationOptions (0.00s)
```