### PR TITLE
telemetry: do not return an error when identify hash file is malformed

### DIFF
--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -140,7 +140,8 @@ func readIdentifyHash(identifyHashPath string) (uint64, error) {
 	}
 
 	if length := len(cachedHashBytes); length != 8 {
-		return 0, fmt.Errorf("Got %d bytes hash, expected 8", length)
+		logging.Warnf("Got %d bytes hash (expected 8), identify hash file will be regenerated", length)
+		return 0, nil
 	}
 
 	return binary.LittleEndian.Uint64(cachedHashBytes), nil


### PR DESCRIPTION
**Fixes:** Issue #4023

## Solution/Idea

A malformed identify hash file should no longer trigger an error when reading it. Now there is a warning displayed and the hash file is treated like it doesn't exist yet. Therefore, it will be regenerated with the correct content.

## Proposed changes

1. Add a warning log to the console with a description of what is wrong and what will happen.
2. Remove error from the return.

## Testing

When the file does not exist yet, no warning should be shown. If it is malformed (does not contain exactly 8 bytes), the warning should show and after the program exits, the file should contain the correct hash.