### PR TITLE
[Spike] Use `crc config` to use custom location for .crc directory

### DIFF
--- a/cmd/crc-embedder/cmd/root.go
+++ b/cmd/crc-embedder/cmd/root.go
@@ -23,7 +23,7 @@ when building the crc executable for release`,
 }
 
 func init() {
-	err := constants.EnsureBaseDirectoriesExist()
+	err := constants.EnsureBaseDirectoriesExist("")
 	if err != nil {
 		fmt.Println("CRC base directories are missing: ", err)
 		os.Exit(1)

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -46,12 +46,13 @@ var (
 )
 
 func init() {
-	if err := constants.EnsureBaseDirectoriesExist(); err != nil {
-		logging.Fatal(err.Error())
-	}
 	var err error
 	config, viper, err = newConfig()
 	if err != nil {
+		logging.Fatal(err.Error())
+	}
+
+	if err := constants.EnsureBaseDirectoriesExist(crcConfig.GetConfigDir(config)); err != nil {
 		logging.Fatal(err.Error())
 	}
 

--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -181,4 +182,29 @@ func TestPath(t *testing.T) {
 		IsDefault: false,
 		IsSecret:  false,
 	}, cfg.Get(ProxyCAFile))
+}
+
+func TestDirectory(t *testing.T) {
+	cfg, err := newInMemoryConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     constants.GetHomeDir(),
+		Invalid:   false,
+		IsDefault: true,
+		IsSecret:  false,
+	}, cfg.Get(CrcDir))
+
+	tmpDir, err := os.MkdirTemp("", "tempdir")
+	require.NoError(t, err)
+	defer os.Remove(tmpDir)
+	_, err = cfg.Set(CrcDir, tmpDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     tmpDir,
+		Invalid:   false,
+		IsDefault: false,
+		IsSecret:  false,
+	}, cfg.Get(CrcDir))
 }

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -103,6 +103,13 @@ func validatePath(value interface{}) (bool, string) {
 	return true, ""
 }
 
+func validateDirectory(value interface{}) (bool, string) {
+	if err := validation.ValidateDirectory(cast.ToString(value)); err != nil {
+		return false, err.Error()
+	}
+	return true, ""
+}
+
 // validateHTTPProxy checks if given URI is valid for a HTTP proxy
 func validateHTTPProxy(value interface{}) (bool, string) {
 	if err := httpproxy.ValidateProxyURL(cast.ToString(value), false); err != nil {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -164,7 +164,8 @@ func GetHomeDir() string {
 }
 
 // EnsureBaseDirectoriesExist creates ~/.crc, ~/.crc/bin and ~/.crc/cache directories if it is not present
-func EnsureBaseDirectoriesExist() error {
+func EnsureBaseDirectoriesExist(configDir string) error {
+	initialiseAllDirectories(configDir)
 	baseDirectories := []string{CrcBaseDir, MachineCacheDir, CrcBinDir}
 	for _, baseDir := range baseDirectories {
 		err := os.MkdirAll(baseDir, 0750)
@@ -173,6 +174,26 @@ func EnsureBaseDirectoriesExist() error {
 		}
 	}
 	return nil
+}
+
+func initialiseAllDirectories(crcDir string) {
+	if crcDir == "" {
+		return
+	}
+	CrcBaseDir = filepath.Join(crcDir, ".crc")
+	CrcBinDir = filepath.Join(CrcBaseDir, "bin")
+	CrcOcBinDir = filepath.Join(CrcBinDir, "oc")
+	CrcPodmanBinDir = filepath.Join(CrcBinDir, "podman")
+	CrcSymlinkPath = filepath.Join(CrcBinDir, "crc")
+	ConfigPath = filepath.Join(CrcBaseDir, ConfigFile)
+	LogFilePath = filepath.Join(CrcBaseDir, LogFile)
+	DaemonLogFilePath = filepath.Join(CrcBaseDir, DaemonLogFile)
+	MachineBaseDir = CrcBaseDir
+	MachineCacheDir = filepath.Join(MachineBaseDir, "cache")
+	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
+	DaemonSocketPath = filepath.Join(CrcBaseDir, "crc.sock")
+	KubeconfigFilePath = filepath.Join(MachineInstanceDir, DefaultName, "kubeconfig")
+	PasswdFilePath = filepath.Join(MachineInstanceDir, DefaultName, "passwd")
 }
 
 func GetPublicKeyPath() string {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -21,7 +21,7 @@ import (
 func bundleCheck(bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) Check {
 	return Check{
 		configKeySuffix:  "check-bundle-extracted",
-		checkDescription: "Checking if CRC bundle is extracted in '$HOME/.crc'",
+		checkDescription: fmt.Sprintf("Checking if CRC bundle is extracted in %q", bundlePath),
 		check:            checkBundleExtracted(bundlePath),
 		fixDescription:   "Getting bundle for the CRC executable",
 		fix:              fixBundleExtracted(bundlePath, preset, enableBundleQuayFallback),

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -168,6 +168,16 @@ func ValidatePath(path string) error {
 	return nil
 }
 
+// ValidateDirectory checks if provided path exists and has sufficient permissions
+func ValidateDirectory(path string) error {
+	file, err := os.CreateTemp(path, "tempfile")
+	if err != nil {
+		return &invalidPath{path: path}
+	}
+	defer os.Remove(file.Name())
+	return nil
+}
+
 type imagePullSecret struct {
 	Auths map[string]map[string]interface{} `json:"auths"`
 }


### PR DESCRIPTION
**Fixes:** Issue #3966 

## Solution/Idea
The location for .crc directory is made configurable for the user through `crc config`.
Currently, this PR will use the value set in the config as the new base directory.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

- Add a new config key called `crc-dir`
- Initialise Crc base directory variables based on the saved config
- New config will take effect after rerunning `crc setup`

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

```
gvyas-mac:crc gvyas$ crc config view
- consent-telemetry                     : no
- preset                                : microshift

gvyas-mac:crc gvyas$ crc config set crc-dir ~/test1
Changes to configuration property 'crc-dir' are only applied during 'crc setup'.
Please run 'crc setup' for this configuration to take effect.

gvyas-mac:crc gvyas$ crc config view
- consent-telemetry                     : no
- crc-dir                               : /Users/gvyas/test1
- preset                                : microshift

```
```
gvyas-mac:crc gvyas$ crc setup
INFO Using bundle path /Users/gvyas/test1/.crc/cache/crc_microshift_vfkit_4.15.3_amd64.crcbundle 
INFO Checking if running macOS version >= 13.x    
INFO Checking if running as non-root              
INFO Checking if crc-admin-helper executable is cached 
INFO Caching crc-admin-helper executable          
INFO Using root access: Changing ownership of /Users/gvyas/test1/.crc/bin/crc-admin-helper-darwin 
Password:
INFO Using root access: Setting suid for /Users/gvyas/test1/.crc/bin/crc-admin-helper-darwin 
INFO Checking if running on a supported CPU architecture 
INFO Checking if crc executable symlink exists    
INFO Creating symlink for crc executable          
INFO Checking minimum RAM requirements            
INFO Check if Podman binary exists in: /Users/gvyas/test1/.crc/bin/oc 
INFO Checking if running emulated on Apple silicon 
INFO Checking if vfkit is installed               
INFO Setting up virtualization with vfkit         
INFO Checking if CRC bundle is extracted in "/Users/gvyas/test1/.crc/cache/crc_microshift_vfkit_4.15.3_amd64.crcbundle" 
INFO Checking if /Users/gvyas/test1/.crc/cache/crc_microshift_vfkit_4.15.3_amd64.crcbundle exists 
INFO Checking if old launchd config for tray and/or daemon exists 
INFO Checking if crc daemon plist file is present and loaded 
INFO Adding crc daemon plist file and loading it  
INFO Checking SSH port availability               
Your system is correctly setup for using CRC. Use 'crc start' to start the instance
```
```
gvyas-mac:crc gvyas$ crc start
INFO Using bundle path /Users/gvyas/test1/.crc/cache/crc_microshift_vfkit_4.15.3_amd64.crcbundle 
INFO Checking if running macOS version >= 13.x    
INFO Checking if running as non-root              
INFO Checking if crc-admin-helper executable is cached 
INFO Checking if running on a supported CPU architecture 
INFO Checking if crc executable symlink exists    
INFO Checking minimum RAM requirements            
INFO Check if Podman binary exists in: /Users/gvyas/test1/.crc/bin/oc 
INFO Checking if running emulated on Apple silicon 
INFO Checking if vfkit is installed               
INFO Checking if old launchd config for tray and/or daemon exists 
INFO Checking if crc daemon plist file is present and loaded 
INFO Checking SSH port availability               
INFO Loading bundle: crc_microshift_vfkit_4.15.3_amd64... 
INFO Creating CRC VM for MicroShift 4.15.3...     
INFO Generating new SSH key pair...               
INFO Starting CRC VM for microshift 4.15.3...     
INFO CRC instance is running with IP 127.0.0.1    
INFO CRC VM is running                            
INFO Updating authorized keys...                  
INFO Configuring shared directories
INFO Check internal and public DNS query...       
INFO Check DNS query from host...                 
INFO Starting Microshift service... [takes around 1min] 
INFO Check internal and public DNS query...       
INFO Check DNS query from host...                 
INFO Starting Microshift service... [takes around 1min] 
INFO Waiting for kube-apiserver availability... [takes around 2min] 
INFO Adding microshift context to kubeconfig...   
Started the MicroShift cluster.

Use the 'oc' command line interface:
  $ eval $(crc oc-env)
  $ oc COMMAND
```
