### PR TITLE
[e2e] Change tag for httpd image on openshift story

### DIFF
--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -41,7 +41,7 @@ Feature: 4 Openshift stories
 		Given executing "oc new-project testproj" succeeds
 		# mirror
 		When executing "oc registry login --insecure=true" succeeds
-		Then executing "oc image mirror quay.io/centos7/httpd-24-centos7:latest=default-route-openshift-image-registry.apps-crc.testing/testproj/hello:test --insecure=true --filter-by-os=linux/amd64" succeeds
+		Then executing "oc image mirror quay.io/centos7/httpd-24-centos7:centos7=default-route-openshift-image-registry.apps-crc.testing/testproj/hello:test --insecure=true --filter-by-os=linux/amd64" succeeds
 		And executing "oc set image-lookup hello" succeeds
 		# deploy
 		When executing "oc apply -f hello.yaml" succeeds
@@ -56,7 +56,7 @@ Feature: 4 Openshift stories
 	Scenario: Pull image locally, push to registry, deploy
 		Given podman command is available
 		And executing "oc new-project testproj" succeeds
-		When pulling image "quay.io/centos7/httpd-24-centos7", logging in, and pushing local image to internal registry succeeds
+		When pulling image "quay.io/centos7/httpd-24-centos7:centos7", logging in, and pushing local image to internal registry succeeds
 		And executing "oc apply -f hello.yaml" succeeds
 		When executing "oc rollout status deployment hello" succeeds
 		Then stdout should contain "successfully rolled out"

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -1002,7 +1002,7 @@ func PullLoginTagPushImageSucceeds(image string) error {
 		return err
 	}
 
-	_, err = cmd.RunPodmanExpectSuccess("tag", "quay.io/centos7/httpd-24-centos7", "default-route-openshift-image-registry.apps-crc.testing/testproj/hello:test")
+	_, err = cmd.RunPodmanExpectSuccess("tag", image, "default-route-openshift-image-registry.apps-crc.testing/testproj/hello:test")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix #4089 

Previously we were using latest tag for centos7-httpd image, that tag has been deleted from the registry, this commit change the tag to other tag referring to the same image.
