### PR TITLE
Avoid using syscall.Sysctl to get macOS version

### DIFF
--- a/pkg/os/darwin/release_info.go
+++ b/pkg/os/darwin/release_info.go
@@ -5,10 +5,11 @@ package darwin
 import (
 	"fmt"
 	"sync"
-	"syscall"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/os"
+	"github.com/crc-org/crc/v2/pkg/strings"
 	"github.com/pkg/errors"
 )
 
@@ -20,8 +21,12 @@ var (
 
 func AtLeast(targetVersion string) (bool, error) {
 	once.Do(func() {
-		macCurrentVersion, errGettingVersion = syscall.Sysctl("kern.osproductversion")
-		logging.Debugf("kern.osproductversion is: %s", macCurrentVersion)
+		// syscall.Sysctl("kern.osproductversion") is not providing the consistent version info for intel and silicon macs
+		// so using sw_vers -productVersion to get the version info consistently
+		// https://github.com/golang/go/issues/58722
+		macCurrentVersion, _, errGettingVersion = os.RunWithDefaultLocale("sw_vers", "-productVersion")
+		macCurrentVersion = strings.TrimTrailingEOL(macCurrentVersion)
+		logging.Debugf("sw_vers -productVersion is: %s", macCurrentVersion)
 	})
 	if errGettingVersion != nil {
 		return false, errGettingVersion


### PR DESCRIPTION
Looks like `syscall.Sysctl` is not reliable when it comes to get macOS version on different arch (Intel vs silicon) because of [0]. This PR uses `sw_vers` cmd result which seems to be consistent on both platform.

[0] https://github.com/golang/go/issues/58722

fixes: #4086


