### PR TITLE
telemetry: add no-op functionality to SegmentClient to make sure errors in initialization are not fatal

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -61,7 +61,8 @@ func init() {
 
 	// Initiate segment client
 	if segmentClient, err = segment.NewClient(config, httpproxy.HTTPTransport()); err != nil {
-		logging.Fatal(err.Error())
+		logging.Warn(err.Error())
+		logging.Warn("Error during segment client initialization, telemetry will be unavailable in this session")
 	}
 
 	// subcommands


### PR DESCRIPTION
**Fixes:** Issue #4085

A new field has been added to Client struct signalling whether the client has been initialized properly. Default value is `false` and it is set to `true` only if the initialization went as expected.
Methods on Client check if this field is true before progressing further.

In case of any error during initialization, an empty Client is returned (and its methods do nothing).