### PR TITLE
CI: Add .snyk file to consumed by openshift ci's security scanning

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+# References:
+# https://docs.snyk.io/snyk-cli/commands/test#exclude-less-than-name-greater-than-less-than-name-greater-than-...greater-than
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    # Ignore vendor/ directory since we're not (yet) concerned with scanning
+    # our dependencies on each CI run.
+    - 'vendor/**'


### PR DESCRIPTION
https://github.com/openshift/release/pull/48942 is currently merged which means now security scanning can run on the CI for each PR (non blocking) and `.snyk` config file have details what to run or ignore.

We need to review the CVEs which is raised by scanning to figure out if this is valid or not in crc context and take appropriate action.


