### PR TITLE
cert_renewal: Watch kubelet-serving signer along with kube-apiserver-client-kubelet

### DIFF
--- a/pkg/crc/cluster/cert_renewal.go
+++ b/pkg/crc/cluster/cert_renewal.go
@@ -18,7 +18,7 @@ func isPending(csr *k8scerts.CertificateSigningRequest) bool {
 }
 
 func approvePendingCSRs(ctx context.Context, ocConfig oc.Config, expectedSignerName string) error {
-	return crcerrors.Retry(ctx, 8*time.Minute, func() error {
+	return crcerrors.Retry(ctx, 10*time.Minute, func() error {
 		csrs, err := getCSRList(ctx, ocConfig, expectedSignerName)
 		if err != nil {
 			return &crcerrors.RetriableError{Err: err}
@@ -53,7 +53,7 @@ func ApproveCSRAndWaitForCertsRenewal(ctx context.Context, sshRunner *ssh.Runner
 	// Admin needs to approve it. The Kubernetes controller manager will then issue the cert, kubelet will fetch it and use it.
 	// Kubelet stores the cert in /var/lib/kubelet/pki/kubelet-client-current.pem
 	if client {
-		logging.Info("Kubelet client certificate has expired, renewing it... [will take up to 8 minutes]")
+		logging.Info("Kubelet client certificate has expired, renewing it... [will take up to 10 minutes]")
 		if err := approvePendingCSRs(ctx, ocConfig, kubeletClientSignerName); err != nil {
 			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSRs: %v", err)
 			return err

--- a/pkg/crc/cluster/cert_renewal.go
+++ b/pkg/crc/cluster/cert_renewal.go
@@ -45,7 +45,8 @@ func approvePendingCSRs(ctx context.Context, ocConfig oc.Config, expectedSignerN
 
 func ApproveCSRAndWaitForCertsRenewal(ctx context.Context, sshRunner *ssh.Runner, ocConfig oc.Config, client, server bool) error {
 	const (
-		kubeletClientSignerName = "kubernetes.io/kube-apiserver-client-kubelet"
+		kubeletClientSignerName  = "kubernetes.io/kube-apiserver-client-kubelet"
+		kubeletServingSignerName = "kubernetes.io/kubelet-serving"
 	)
 
 	// First, kubelet starts and tries to connect to API server. If its certificate is expired, it asks for a new one
@@ -55,6 +56,11 @@ func ApproveCSRAndWaitForCertsRenewal(ctx context.Context, sshRunner *ssh.Runner
 		logging.Info("Kubelet client certificate has expired, renewing it... [will take up to 8 minutes]")
 		if err := approvePendingCSRs(ctx, ocConfig, kubeletClientSignerName); err != nil {
 			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSRs: %v", err)
+			return err
+		}
+
+		if err := approvePendingCSRs(ctx, ocConfig, kubeletServingSignerName); err != nil {
+			logging.Debugf("Error approving pending kubelet-serving CSRs: %v", err)
 			return err
 		}
 

--- a/pkg/crc/cluster/cert_renewal.go
+++ b/pkg/crc/cluster/cert_renewal.go
@@ -74,7 +74,7 @@ func ApproveCSRAndWaitForCertsRenewal(ctx context.Context, sshRunner *ssh.Runner
 	// After kubelet connected to the API server, if the serving cert is expireed, kubelet asks for a new CSR.
 	// This CSR is automatically approved by the cluster-machine-approver. The k8s controller manager issues the cert and kubelet fetches it.
 	if server {
-		logging.Info("Kubelet serving certificate has expired, waiting for automatic renewal... [will take up to 8 minutes]")
+		logging.Info("Kubelet serving certificate has expired, waiting for automatic renewal... [will take up to 5 minutes]")
 		return crcerrors.Retry(ctx, 5*time.Minute, waitForCertRenewal(sshRunner, KubeletServerCert), time.Second*5)
 	}
 	return nil

--- a/pkg/crc/cluster/csr.go
+++ b/pkg/crc/cluster/csr.go
@@ -9,7 +9,6 @@ import (
 	crcerrors "github.com/crc-org/crc/v2/pkg/crc/errors"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/oc"
-	"github.com/pkg/errors"
 	k8scerts "k8s.io/api/certificates/v1beta1"
 )
 
@@ -25,21 +24,6 @@ func WaitForOpenshiftResource(ctx context.Context, ocConfig oc.Config, resource 
 		return nil
 	}
 	return crcerrors.Retry(ctx, 80*time.Second, waitForAPIServer, time.Second)
-}
-
-func deleteCSR(ctx context.Context, ocConfig oc.Config, expectedSignerName string) error {
-	csrs, err := getCSRList(ctx, ocConfig, expectedSignerName)
-	if err != nil {
-		return err
-	}
-	for _, csr := range csrs.Items {
-		logging.Debugf("Deleting csr %s (signerName: %s)", csr.ObjectMeta.Name, expectedSignerName)
-		_, stderr, err := ocConfig.RunOcCommand("delete", "csr", csr.ObjectMeta.Name)
-		if err != nil {
-			return errors.Wrapf(err, stderr, "Not able to delete csr (%v : %s)")
-		}
-	}
-	return nil
 }
 
 func getCSRList(ctx context.Context, ocConfig oc.Config, expectedSignerName string) (*k8scerts.CertificateSigningRequestList, error) {

--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -70,6 +70,12 @@ Feature: 4 Openshift stories
 	@darwin @linux @windows @testdata @story_marketplace @cleanup @needs_namespace
 	Scenario: Install new operator
 		Given executing "oc new-project testproj" succeeds
+		And executing "oc delete pods --all -n openshift-marketplace" succeeds
+		Then with up to "20" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*certified-operators(.*)1/1(.*)Running.*"
+		Then with up to "4" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*community-operators(.*)1/1(.*)Running.*"
+		Then with up to "4" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*marketplace-operator(.*)1/1(.*)Running.*"
+		Then with up to "4" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*redhat-marketplace(.*)1/1(.*)Running.*"
+		Then with up to "4" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*redhat-operators(.*)1/1(.*)Running.*"
 		When executing "oc apply -f pipeline-sub.yaml" succeeds
 		Then with up to "10" retries with wait period of "30s" command "oc get csv" output matches ".*pipelines-operator(.*)Succeeded$"
 		Then with up to "20" retries with wait period of "30s" command "oc get pods -n openshift-pipelines" output matches ".*tekton-pipelines-webhook(.*)1/1(.*)Running.*"


### PR DESCRIPTION
Since 4.15, user provisioned infra (UPI) is used for creating the
bundle, kubelet-serving signer csr request also need to be approved
manually as per docs. This PR watch kubelet-serving signer and check if
it pending then approve it.

- https://docs.openshift.com/container-platform/4.15/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.html