### PR TITLE
Chocolatey: Update project url for crc spec

### DIFF
--- a/packaging/chocolatey/crc/crc.nuspec.in
+++ b/packaging/chocolatey/crc/crc.nuspec.in
@@ -6,7 +6,7 @@
     <owners>anjannath</owners>
     <title>CRC - Runs Containers</title>
     <authors>https://github.com/crc-org</authors>
-    <projectUrl>https://crc.dev/blog/about</projectUrl>
+    <projectUrl>https://crc.dev/blog</projectUrl>
     <bugTrackerUrl>https://github.com/crc-org/crc/issues</bugTrackerUrl>
     <iconUrl>https://cdn.statically.io/gh/crc-org/blog/main/static/crc-upstream-logo.png</iconUrl>
     <licenseUrl>https://github.com/crc-org/crc/blob/main/LICENSE</licenseUrl>


### PR DESCRIPTION
https://crc.dev/blog/about is no longer works and `about` section is removed, this pr update to latest valid url

It will also fix the issue which described in
https://community.chocolatey.org/packages/crc/2.34.1#dependencies one.


