### PR TITLE
[qe] fix check for condition for a starting cluster behind proxy

### DIFF
--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -63,6 +63,10 @@ var _ = BeforeSuite(func() {
 	err = util.RemoveCRCConfig()
 	Expect(err).NotTo(HaveOccurred())
 
+	// start shell instance
+	err = util.StartHostShellInstance("")
+	Expect(err).NotTo(HaveOccurred())
+
 	// set credPath
 	credPath = filepath.Join(userHome, ".crc", "machines", "crc", "id_rsa")
 


### PR DESCRIPTION
A condition to ensure the state of the cluster after starting it behind a proxy was introduce in https://github.com/crc-org/crc/commit/4a9a35bb1e3f954560d59dce7736606ec29bd320 that check is using a function which relies on the shell instance but that instance is not initialize anywhere as so the check is failing with an error showing shell instance is not initialize. This commit initialize the instance and now the check is working as expected

Fixes #4095 