### PR TITLE
nameservers: Use nmcli to update the nameserver and search info

### DIFF
--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -33,7 +33,7 @@ func GetResolvValuesFromInstance(sshRunner *ssh.Runner) (*ResolvFileValues, erro
 	return parseResolveConfFile(out)
 }
 
-func CreateResolvFileOnInstance(sshRunner *ssh.Runner, resolvFileValues ResolvFileValues) error {
+func UpdateResolvFileOnInstance(sshRunner *ssh.Runner, resolvFileValues ResolvFileValues) error {
 	sd := systemd.NewInstanceSystemdCommander(sshRunner)
 	// Check if ovs-configuration.service exist and if not then it is old bundle and use the same way to
 	// update resolve.conf file

--- a/pkg/crc/network/types.go
+++ b/pkg/crc/network/types.go
@@ -20,6 +20,22 @@ type ResolvFileValues struct {
 	NameServers   []NameServer
 }
 
+func (vals *ResolvFileValues) GetNameServer() []string {
+	var nameservers []string
+	for _, ns := range vals.NameServers {
+		nameservers = append(nameservers, ns.IPAddress)
+	}
+	return nameservers
+}
+
+func (vals *ResolvFileValues) GetSearchDomains() []string {
+	var searchDomains []string
+	for _, sd := range vals.SearchDomains {
+		searchDomains = append(searchDomains, sd.Domain)
+	}
+	return searchDomains
+}
+
 type Mode string
 
 func (m Mode) String() string {

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -41,7 +41,7 @@ func RunPostStart(serviceConfig services.ServicePostStartConfig) error {
 		return err
 	}
 	// override resolv.conf file
-	return network.CreateResolvFileOnInstance(serviceConfig.SSHRunner, resolvFileValues)
+	return network.UpdateResolvFileOnInstance(serviceConfig.SSHRunner, resolvFileValues)
 }
 
 func setupDnsmasq(serviceConfig services.ServicePostStartConfig) error {


### PR DESCRIPTION
From 4.15, because of ovn-kubernetes the info around nameserver and
search option in the `/etc/resolv.conf` not match with user expectation.
`ovs-configuration` service is run on this node which is a dependency
for kubelet and this make changes in the networking by creating bridge
network and restarting the NetworkManager. As soon as NM restart happen,
changes which are done as part of crc vm post start are vanished.

This PR is going to make sure that changes are done using `nmcli` and
shouldn't removed when NM restart happen. Following steps are done in
this PR
- Start the `ovs-configuration` service, even it is enabled it doesn't
  autostart because it only required by `kubelet-dependencies.target`.
- `ovs-configuration` service always create the network named as
  `ovs-if-br-ex` so we run the nmcli command to update this connection
  and add the nameserver and search option
- Restart the NM to update the /etc/resolv.conf

**Fixes:** Issue #4144 


