### PR TITLE
add crc config set/get/unset preset test cases

### DIFF
--- a/test/e2e/features/config.feature
+++ b/test/e2e/features/config.feature
@@ -152,3 +152,39 @@ Feature: Test configuration settings
         And executing crc setup command succeeds
         Then stderr should not contain "Skipping above check"
 
+    @linux @darwin @windows 
+    Scenario: CRC config set and get preset property (default cases) 
+        When setting config property "preset" to value "openshift" succeeds
+        And "JSON" config file "crc.json" in CRC home folder does not contain key "preset"
+        When getting config property "preset" succeeds
+        And stdout should contain "Configuration property 'preset' is not set"
+        And stdout should contain "openshift"
+        When unsetting config property "preset" succeeds
+        And stdout should contain "Successfully unset configuration property 'preset'"
+        And "JSON" config file "crc.json" in CRC home folder does not contain key "preset"
+        
+
+    Scenario: CRC config set and get preset property (positive cases) 
+        When setting config property "preset" to value "<preset-value>" succeeds
+        And "JSON" config file "crc.json" in CRC home folder contains key "preset" with value matching "<preset-value>" 
+        When getting config property "preset" succeeds
+        And stdout should contain "<preset-value>"
+        When unsetting config property "preset" succeeds
+        And stdout should contain "Successfully unset configuration property 'preset'"
+        And "JSON" config file "crc.json" in CRC home folder does not contain key "preset"
+        
+        @linux @darwin @windows 
+        Examples: Config property preset setting positive
+            | preset-value  |
+            | microshift    | 
+            | okd           | 
+            
+    Scenario: CRC config set preset (negtive cases) 
+        When setting config property "preset" to value "<preset-value>" fails
+        And stderr should contain "reason: Unknown preset" 
+
+        @linux @darwin @windows 
+        Examples: Config property getting
+            | preset-value | 
+            | podman       | 
+            | others       |

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -472,6 +472,8 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		StartCRCWithDefaultBundleAndNameServerSucceedsOrFails)
 	s.Step(`^setting config property "(.*)" to value "(.*)" (succeeds|fails)$`,
 		SetConfigPropertyToValueSucceedsOrFails)
+	s.Step(`^getting config property "(.*)" (succeeds|fails)$`,
+		crcCmd.GetConfigPropertySucceedsOrFails)
 	s.Step(`^unsetting config property "(.*)" (succeeds|fails)$`,
 		crcCmd.UnsetConfigPropertySucceedsOrFails)
 	s.Step(`^login to the oc cluster (succeeds|fails)$`,

--- a/test/extended/crc/cmd/cmd.go
+++ b/test/extended/crc/cmd/cmd.go
@@ -125,6 +125,11 @@ func UnsetConfigPropertySucceedsOrFails(property string, expected string) error 
 	return util.ExecuteCommandSucceedsOrFails(cmd, expected)
 }
 
+func GetConfigPropertySucceedsOrFails(property string, expected string) error {
+	cmd := "crc config get " + property
+	return util.ExecuteCommandSucceedsOrFails(cmd, expected)
+}
+
 func WaitForClusterInState(state string) error {
 	return util.MatchRepetitionsWithRetry(state, CheckCRCStatus, clusterStateRepetition,
 		clusterStateRetryCount, clusterStateTimeout)


### PR DESCRIPTION
**Fixes:** Issue #N

**Relates to:** PR #4167

## Solution/Idea

Add test cases of setting, getting, and unsettling the preset property. 

## Proposed changes

List the main as well as consequential changes you introduced or had to introduce.

1. Add positive cases for setting, getting, and unsettling the preset property.
2. Add negative cases for setting preset property.

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. e2e test cases
