### PR TITLE
windows-artifacts: run yq --inplace to windows-artifacts.yml 

### DIFF
--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-2022']
-        go: ['1.20']
+        go: ['1.21']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -12,11 +12,9 @@ on:
       - 'docs/**'
       - 'images/docs-builder/**'
       - '*.adoc'
-
 env:
   IMAGE_NAME_E2E: crc-e2e
   IMAGE_NAME_INTEGRATION: crc-integration
-
 jobs:
   build-installer:
     runs-on: ${{ matrix.os }}
@@ -26,80 +24,68 @@ jobs:
         os: ['windows-2022']
         go: ['1.20']
     steps:
-    - name: Check out repository code
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go }}
-
-    - name: Set path for heat.exe and light.exe
-      shell: bash
-      run: echo "$WIX\\bin" >>$GITHUB_PATH
-      
-    - name: Build Windows installer
-      run: make out/windows-amd64/crc-windows-installer.zip
-      
-    - name: Upload windows installer artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: windows-installer
-        path: "./out/windows-amd64/crc-windows-installer.zip"
-
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Set path for heat.exe and light.exe
+        shell: bash
+        run: echo "$WIX\\bin" >>$GITHUB_PATH
+      - name: Build Windows installer
+        run: make out/windows-amd64/crc-windows-installer.zip
+      - name: Upload windows installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: "./out/windows-amd64/crc-windows-installer.zip"
   build-qe:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: ['darwin','windows', 'linux']
+        os: ['darwin', 'windows', 'linux']
         arch: ['amd64', 'arm64']
         exclude:
-        - arch: 'arm64'
-          os: 'windows'
-        - arch: 'arm64'
-          os: 'linux'
-      
+          - arch: 'arm64'
+            os: 'windows'
+          - arch: 'arm64'
+            os: 'linux'
     steps:
-    - name: Check out repository code
-      uses: actions/checkout@v4
-    
-    - name: Build qe oci images ${{matrix.os}}-${{matrix.arch}}
-      run: |
-        # e2e
-        CRC_E2E_IMG_VERSION=gh ARCH=${{matrix.arch}} OS=${{matrix.os}} make containerized_e2e
-        podman save -o ${{ env.IMAGE_NAME_E2E }}-${{matrix.os}}-${{matrix.arch}}.tar \
-          quay.io/crcont/${{ env.IMAGE_NAME_E2E}}:gh-${{matrix.os}}-${{matrix.arch}}
-        # integration
-        CRC_INTEGRATION_IMG_VERSION=gh ARCH=${{matrix.arch}} OS=${{matrix.os}} make containerized_integration
-        podman save -o ${{ env.IMAGE_NAME_INTEGRATION }}-${{matrix.os}}-${{matrix.arch}}.tar \
-          quay.io/crcont/${{ env.IMAGE_NAME_INTEGRATION}}:gh-${{matrix.os}}-${{matrix.arch}}
-
-    - name: Upload e2e ${{matrix.os}}-${{matrix.arch}}
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.IMAGE_NAME_E2E }}-${{matrix.os}}-${{matrix.arch}}
-        path: ${{ env.IMAGE_NAME_E2E }}-${{matrix.os}}-${{matrix.arch}}.tar
-
-    - name: Upload integration ${{matrix.os}}-${{matrix.arch}}
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.IMAGE_NAME_INTEGRATION }}-${{matrix.os}}-${{matrix.arch}}
-        path: ${{ env.IMAGE_NAME_INTEGRATION }}-${{matrix.os}}-${{matrix.arch}}.tar
-
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Build qe oci images ${{matrix.os}}-${{matrix.arch}}
+        run: |
+          # e2e
+          CRC_E2E_IMG_VERSION=gh ARCH=${{matrix.arch}} OS=${{matrix.os}} make containerized_e2e
+          podman save -o ${{ env.IMAGE_NAME_E2E }}-${{matrix.os}}-${{matrix.arch}}.tar \
+            quay.io/crcont/${{ env.IMAGE_NAME_E2E}}:gh-${{matrix.os}}-${{matrix.arch}}
+          # integration
+          CRC_INTEGRATION_IMG_VERSION=gh ARCH=${{matrix.arch}} OS=${{matrix.os}} make containerized_integration
+          podman save -o ${{ env.IMAGE_NAME_INTEGRATION }}-${{matrix.os}}-${{matrix.arch}}.tar \
+            quay.io/crcont/${{ env.IMAGE_NAME_INTEGRATION}}:gh-${{matrix.os}}-${{matrix.arch}}
+      - name: Upload e2e ${{matrix.os}}-${{matrix.arch}}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.IMAGE_NAME_E2E }}-${{matrix.os}}-${{matrix.arch}}
+          path: ${{ env.IMAGE_NAME_E2E }}-${{matrix.os}}-${{matrix.arch}}.tar
+      - name: Upload integration ${{matrix.os}}-${{matrix.arch}}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.IMAGE_NAME_INTEGRATION }}-${{matrix.os}}-${{matrix.arch}}
+          path: ${{ env.IMAGE_NAME_INTEGRATION }}-${{matrix.os}}-${{matrix.arch}}.tar
   save-gh-context:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-
     steps:
-    - name: Save the GH context in an artifact 
-      env:
-        GH_CONTEXT: ${{ toJSON(github) }}
-      run: echo $GH_CONTEXT > gh_context.json
-
-    - name: Upload the GH context artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: gh-context
-        path: gh_context.json
+      - name: Save the GH context in an artifact
+        env:
+          GH_CONTEXT: ${{ toJSON(github) }}
+        run: echo $GH_CONTEXT > gh_context.json
+      - name: Upload the GH context artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gh-context
+          path: gh_context.json

--- a/update-go-version.sh
+++ b/update-go-version.sh
@@ -18,4 +18,7 @@ for f in .github/workflows/*.yml; do
     if [ $(yq  eval '.jobs.build.strategy.matrix | has("go")' "$f") == "true" ]; then
       yq eval --inplace ".jobs.build.strategy.matrix.go[0] = ${golang_base_version} | .jobs.build.strategy.matrix.go[0] style=\"single\"" "$f";
     fi
+    if [ $(yq  eval '.jobs.build-installer.strategy.matrix | has("go")' "$f") == "true" ]; then
+      yq eval --inplace ".jobs.build-installer.strategy.matrix.go[0] = ${golang_base_version} | .jobs.build-installer.strategy.matrix.go[0] style=\"single\"" "$f";
+    fi
 done


### PR DESCRIPTION
Looks like when yq is run on any yaml file it strip the blank like from
the output so as part of parse https://github.com/mikefarah/yq/issues/515

we use to parse this file to update the go version using the script in
next commit so this commit just to make sure the formatting is right
when it parsed with `yq`

It is generated using `yq --inplace .github/workflows/windows-artifacts.yml`