### PR TITLE
kubeconfig.write: update the issuer with ingressPort

### DIFF
--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -198,11 +198,22 @@ func getTokenForUser(username, password, ip string, ca []byte, clusterConfig *ty
 		},
 	}
 	challengeHandler := challengehandlers.NewBasicChallengeHandler(restConfig.Host, "" /* webconsoleURL */, nil /* in */, nil /* out */, nil /* passwordPrompter */, username, password)
-	token, err := tokenrequest.RequestTokenWithChallengeHandlers(restConfig, challengeHandler)
+	token, err := requestTokenWithChallengeHandlers(restConfig, challengeHandler, ingressHTTPSPort)
 	if err != nil {
 		return "", err
 	}
 	return token, nil
+}
+
+func requestTokenWithChallengeHandlers(clientCfg *restclient.Config, handler *challengehandlers.BasicChallengeHandler, port uint) (string, error) {
+	o, err := tokenrequest.NewRequestTokenOptions(clientCfg, false).WithChallengeHandlers(handler)
+	if err != nil {
+		return "", err
+	}
+
+	portStr := strconv.Itoa(int(port))
+	o.Issuer = net.JoinHostPort(o.Issuer, portStr)
+	return o.RequestToken()
 }
 
 // getGlobalKubeConfigPath returns the path to the first entry in the KUBECONFIG environment variable


### PR DESCRIPTION
**Fixes:** Issue #4124 

**Relates to:** Issue #4177 (_Maybe_)

## Solution/Idea

This is a workaround to explicitly set the `ingressPortNumber` in the `Issuer` field when requesting token. By default, the OpenShift library uses the URL from `/.well-known/oauth-authorization-server` without including the custom port set by the user on CRC. This omission causes errors when writing new contexts to kubeconfig, as the token request fails due to the missing port number. Since users configure this custom port for their CRC instance, this commit ensures the issuer field includes the ingress-https-port before making the token request.
## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Wrote a new equivalent local function to perform the port setting.

## Testing

1. `crc config set ingress-https-port 7443`
2. `crc setup`
3. `crc start`

