### PR TITLE
[QE] Misc fixes for the QE e2e images

### DIFF
--- a/images/build-e2e/Containerfile
+++ b/images/build-e2e/Containerfile
@@ -1,5 +1,5 @@
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS builder
 
 USER root
 

--- a/images/build-e2e/lib/darwin/run.sh
+++ b/images/build-e2e/lib/darwin/run.sh
@@ -1,1 +1,60 @@
-./../linux/run.sh
+#!/bin/bash
+
+# Parameters
+bundleLocation=""
+e2eTagExpression=""
+crcMemory=""
+targetFolder="crc-e2e"
+junitFilename="e2e-junit.xml"
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -bundleLocation)
+        bundleLocation="$2"
+        shift 
+        shift 
+        ;;
+        -e2eTagExpression)
+        e2eTagExpression="$2"
+        shift 
+        shift 
+        ;;
+        -targetFolder)
+        targetFolder="$2"
+        shift 
+        shift 
+        ;;
+        -junitFilename)
+        junitFilename="$2"
+        shift 
+        shift 
+        ;;
+        -crcMemory)
+        crcMemory="$2"
+        shift 
+        shift 
+        ;;
+        *)    # unknown option
+        shift 
+        ;;
+    esac
+done
+
+# Prepare resuslts folder
+mkdir -p $targetFolder/results
+
+# Run tests
+tags="darwin"
+if [ ! -z "$e2eTagExpression" ]
+then
+    tags="$tags && $e2eTagExpression"
+fi
+cd $targetFolder/bin
+./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --cleanup-home=false --crc-memory=$crcMemory --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
+
+# Transform results to junit
+cd ..
+init_line=$(grep -n '<?xml version="1.0" encoding="UTF-8"?>' results/e2e.results | awk '{split($0,n,":"); print n[1]}')
+tail -n +$init_line results/e2e.results > results/$junitFilename
+# Copy logs and diagnose
+cp -r bin/out/test-results/* results

--- a/images/build-e2e/lib/linux/run.sh
+++ b/images/build-e2e/lib/linux/run.sh
@@ -34,7 +34,7 @@ while [[ $# -gt 0 ]]; do
         shift 
         shift 
         ;;
-        *)
+        *)    # unknown option
         shift 
         ;;
     esac
@@ -44,7 +44,7 @@ done
 mkdir -p $targetFolder/results
 
 # Run tests
-tags="${OS}"
+tags="linux"
 if [ ! -z "$e2eTagExpression" ]
 then
     tags="$tags && $e2eTagExpression"

--- a/images/build-integration/Containerfile
+++ b/images/build-integration/Containerfile
@@ -1,5 +1,5 @@
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS builder
 
 USER root
 

--- a/images/build-integration/lib/darwin/run.sh
+++ b/images/build-integration/lib/darwin/run.sh
@@ -1,1 +1,63 @@
-./../linux/run.sh
+#!/bin/bash
+
+# Parameters
+bundleLocation=""
+targetFolder="crc-integration"
+junitFilename="integration-junit.xml"
+suiteTimeout="90m"
+labelFilter=""
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -bundleLocation)
+        bundleLocation="$2"
+        shift 
+        shift 
+        ;;
+        -targetFolder)
+        targetFolder="$2"
+        shift 
+        shift 
+        ;;
+        -junitFilename)
+        junitFilename="$2"
+        shift 
+        shift 
+        ;;
+        -suiteTimeout)
+        suiteTimeout="$2"
+        shift 
+        shift 
+        ;;
+        -labelFilter)
+        labelFilter="$2"
+        shift 
+        shift 
+        *)    # unknown option
+        shift 
+        ;;
+    esac
+done
+
+# Prepare resuslts folder
+mkdir -p $targetFolder/results
+
+# Run tests
+export PATH="$PATH:${HOME}/$targetFolder/bin"
+export PULL_SECRET_PATH="${HOME}/$targetFolder/pull-secret"
+if [ ! -z "$bundleLocation" ]
+then
+    export BUNDLE_PATH="$bundleLocation"
+fi
+cd $targetFolder/bin
+if [ ! -z "$labelFilter" ]
+then
+    ./integration.test --ginkgo.timeout $suiteTimeout --ginkgo.label-filter $labelFilter > integration.results
+else
+    ./integration.test --ginkgo.timeout $suiteTimeout > integration.results
+fi
+
+# Copy results
+cd ..
+cp bin/integration.results results/integration.results
+cp bin/out/integration.xml results/$junitFilename

--- a/images/build-integration/lib/linux/run.sh
+++ b/images/build-integration/lib/linux/run.sh
@@ -34,7 +34,7 @@ while [[ $# -gt 0 ]]; do
         shift 
         shift 
         ;;
-        *)
+        *)    # unknown option
         shift 
         ;;
     esac

--- a/update-go-version.sh
+++ b/update-go-version.sh
@@ -14,6 +14,7 @@ go mod edit -go ${golang_base_version} tools/go.mod
 sed -i "s,^GOVERSION = 1.[0-9]\+,GOVERSION = ${golang_base_version}," Makefile
 sed -i "s,^\(FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-\)1.[0-9]\+,\1${golang_base_version}," images/*/Dockerfile
 sed -i "s,^FROM registry.access.redhat.com/ubi8/go-toolset:[.0-9]\+,FROM registry.access.redhat.com/ubi8/go-toolset:${golang_base_version}," images/*/Dockerfile
+sed -i "s,^FROM registry.access.redhat.com/ubi8/go-toolset:[.0-9]\+,FROM registry.access.redhat.com/ubi8/go-toolset:${golang_base_version}," images/*/Containerfile
 for f in .github/workflows/*.yml; do
     if [ $(yq  eval '.jobs.build.strategy.matrix | has("go")' "$f") == "true" ]; then
       yq eval --inplace ".jobs.build.strategy.matrix.go[0] = ${golang_base_version} | .jobs.build.strategy.matrix.go[0] style=\"single\"" "$f";


### PR DESCRIPTION
- In the run.sh script the `${OS}` variable referred to on the scripts is only present when
running inside the container, we'll have to figure out a different
way to get the OS information when running on the host

- update base images to `go-toolset:1.21`