### PR TITLE
pkg: remove use of sudo from the signing script

### DIFF
--- a/packaging/darwin/macos-pkg-build-and-sign.sh
+++ b/packaging/darwin/macos-pkg-build-and-sign.sh
@@ -49,7 +49,7 @@ sign "${crcBinDir}/crc"
 sign "${crcBinDir}/crc-admin-helper-darwin"
 sign "${crcBinDir}/vfkit"
 
-sudo chmod +sx "${crcBinDir}/crc-admin-helper-darwin"
+chmod +sx "${crcBinDir}/crc-admin-helper-darwin"
 
 pkgbuild --identifier com.redhat.crc --version ${version} \
   --scripts "${BASEDIR}/scripts" \


### PR DESCRIPTION
this is required as use of 'sudo' is not available in downstream build machines. while testing the built pkg with this changes crc is working as expected

