### PR TITLE
update image to centos:stream9 used for testing rpm build on ci

### DIFF
--- a/images/rpmbuild/Containerfile.in
+++ b/images/rpmbuild/Containerfile.in
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 WORKDIR $APP_ROOT/src
 RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)' \
         https://github.com/crc-org/admin-helper/releases/download/v0.5.2/crc-admin-helper-0.5.2-1.el8.x86_64.rpm \
@@ -6,6 +6,6 @@ RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)' \
 COPY . .
 RUN mkdir -p ~/rpmbuild/SOURCES/ && \
     git archive --format=tar --prefix=crc-__VERSION__-__OPENSHIFT_VERSION__/ HEAD | gzip >~/rpmbuild/SOURCES/crc-__VERSION__.tar.gz
-RUN yum config-manager --set-enabled powertools && \
+RUN yum config-manager --set-enabled crb && \
     yum -y builddep packaging/rpm/crc.spec && \
     rpmbuild -bb -v packaging/rpm/crc.spec


### PR DESCRIPTION
centos:stream8 has reached EOL as per:
https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/

fixes #4204 