### PR TITLE
Fix invalid release-info.json.sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ vendorcheck:
 	./verify-vendor.sh
 
 .PHONY: check
-check: cross build_e2e_all $(HOST_BUILD_DIR)/crc-embedder test cross-lint vendorcheck build_integration_all
+check: cross build_e2e_all $(HOST_BUILD_DIR)/crc-embedder test cross-lint check-release-info vendorcheck build_integration_all
 
 # Start of the actual build targets
 
@@ -291,6 +291,9 @@ gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/$(CRC_VERSION)/ > $(RELEASE_INFO)
 	@sed -i s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
 	@sed -i s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
+
+check-release-info: gen_release_info
+	cat $(RELEASE_INFO) |jq .
 
 .PHONY: linux-release-binary macos-release-binary windows-release-binary
 linux-release-binary: LDFLAGS+= $(RELEASE_VERSION_VARIABLES)

--- a/release-info.json.sample
+++ b/release-info.json.sample
@@ -2,7 +2,7 @@
 	"version": {
 		"crcVersion": "@CRC_VERSION@",
 		"gitSha": "@GIT_COMMIT_SHA@",
-		"openshiftVersion": "@OPENSHIFT_VERSION@",
+		"openshiftVersion": "@OPENSHIFT_VERSION@"
 	},
 	"links": {
 	    "linux": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/@CRC_VERSION@/crc-linux-amd64.tar.xz",


### PR DESCRIPTION
An extra ',' causes it to fail validation

$ curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/release-info.json | jq .
parse error: Expected another key-value pair at line 6, column 2