### PR TITLE
fix 'sed -i' failure in Makefile for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,8 +289,8 @@ cross-lint: $(TOOLS_BINDIR)/golangci-lint
 .PHONY: gen_release_info
 gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/$(CRC_VERSION)/ > $(RELEASE_INFO)
-	@sed -i s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
-	@sed -i s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
+	@sed -i'' -e s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
+	@sed -i'' -e s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
 
 check-release-info: gen_release_info
 	cat $(RELEASE_INFO) |jq .

--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ linux-release: clean lint linux-release-binary embed_crc_helpers gen_release_inf
 	@cp LICENSE $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
 	tar cJSf $(RELEASE_DIR)/crc-linux-amd64.tar.xz -C $(BUILD_DIR) crc-linux-$(CRC_VERSION)-amd64 --owner=0 --group=0
 
-	@mv $(RELEASE_INFO) $(RELEASE_DIR)/$(RELEASE_INFO)
+	@cp $(RELEASE_INFO) $(RELEASE_DIR)/$(RELEASE_INFO)
 
 	cd $(RELEASE_DIR) && sha256sum * > sha256sum.txt
 


### PR DESCRIPTION
`make release` fail with error message:
> cat: release-info.json: No such file or directory

The file `release-info.json` was moved to folder release. Thus `check-release-info` can't find the file

`sed -i` failed in Makefile when running in MacOS