### PR TITLE
release-info: Test its format as part of 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,8 +289,8 @@ cross-lint: $(TOOLS_BINDIR)/golangci-lint gen_release_info
 .PHONY: gen_release_info
 gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/$(CRC_VERSION)/ > $(RELEASE_INFO)
-	@sed -i s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
-	@sed -i s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
+	@sed -i'' -e s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
+	@sed -i'' -e s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
 
 .PHONY: linux-release-binary macos-release-binary windows-release-binary
 linux-release-binary: LDFLAGS+= $(RELEASE_VERSION_VARIABLES)

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ linux-release: clean lint linux-release-binary embed_crc_helpers gen_release_inf
 	@cp LICENSE $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
 	tar cJSf $(RELEASE_DIR)/crc-linux-amd64.tar.xz -C $(BUILD_DIR) crc-linux-$(CRC_VERSION)-amd64 --owner=0 --group=0
 
-	@mv $(RELEASE_INFO) $(RELEASE_DIR)/$(RELEASE_INFO)
+	@cp $(RELEASE_INFO) $(RELEASE_DIR)/$(RELEASE_INFO)
 
 	cd $(RELEASE_DIR) && sha256sum * > sha256sum.txt
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ vendorcheck:
 	./verify-vendor.sh
 
 .PHONY: check
-check: cross build_e2e_all $(HOST_BUILD_DIR)/crc-embedder test cross-lint check-release-info vendorcheck build_integration_all
+check: cross build_e2e_all $(HOST_BUILD_DIR)/crc-embedder test cross-lint vendorcheck build_integration_all
 
 # Start of the actual build targets
 
@@ -291,9 +291,6 @@ gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/$(CRC_VERSION)/ > $(RELEASE_INFO)
 	@sed -i s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
 	@sed -i s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
-
-check-release-info: gen_release_info
-	cat $(RELEASE_INFO) |jq .
 
 .PHONY: linux-release-binary macos-release-binary windows-release-binary
 linux-release-binary: LDFLAGS+= $(RELEASE_VERSION_VARIABLES)

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,8 @@ generate_mocks: $(TOOLS_BINDIR)/mockery
 	$(TOOLS_BINDIR)/mockery --srcpkg ./pkg/crc/api/client --name Client --output test/mocks/api  --filename client.go
 
 .PHONY: test
-test:
-	go test -race --tags "build $(BUILDTAGS)" -v -ldflags="$(VERSION_VARIABLES)" ./pkg/... ./cmd/...
+test: gen_release_info
+	go test -race --tags "build $(BUILDTAGS)" -v -ldflags="$(VERSION_VARIABLES)" . ./pkg/... ./cmd/...
 
 .PHONY: spec test-rpmbuild
 
@@ -277,10 +277,10 @@ fmt: $(TOOLS_BINDIR)/goimports
 
 # Run golangci-lint against code
 .PHONY: lint cross-lint
-lint: $(TOOLS_BINDIR)/golangci-lint
+lint: $(TOOLS_BINDIR)/golangci-lint gen_release_info
 	"$(TOOLS_BINDIR)"/golangci-lint run
 
-cross-lint: $(TOOLS_BINDIR)/golangci-lint
+cross-lint: $(TOOLS_BINDIR)/golangci-lint gen_release_info
 	GOARCH=amd64 GOOS=darwin "$(TOOLS_BINDIR)"/golangci-lint run
 	GOARCH=arm64 GOOS=darwin "$(TOOLS_BINDIR)"/golangci-lint run
 	GOARCH=amd64 GOOS=linux "$(TOOLS_BINDIR)"/golangci-lint run

--- a/release_info_test.go
+++ b/release_info_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"testing"
+)
+
+//go:embed release-info.json
+var releaseInfo []byte
+
+func TestReleaseInfo(t *testing.T) {
+	if !json.Valid(releaseInfo) {
+		t.Fatal("release-info.json is not a valid json file")
+	}
+}


### PR DESCRIPTION
This commit makes use of `//go:embed` to run the content of
`release-info.json` through golang `json.Valid` to check if it's valid 
JSON.

This is better/simpler than using `jq` as we don't have to change all our
container images/CI envs/... to make sure `jq` is installed, and
`json.Valid` uses the same json parser as crc so this avoids possible 
differences of behaviour between json parsers.