### PR TITLE
Add `nvram` option for undefine vm

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -604,7 +604,7 @@ func removeCrcVM() error {
 			return fmt.Errorf("Failed to destroy 'crc' VM")
 		}
 	}
-	_, stderr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "undefine", constants.DefaultName)
+	_, stderr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "undefine", "--nvram", constants.DefaultName)
 	if err != nil {
 		logging.Debugf("%v : %s", err, stderr)
 		return fmt.Errorf("Failed to undefine 'crc' VM")


### PR DESCRIPTION
With https://github.com/crc-org/machine-driver-libvirt/commit/a130898ad92b7e4a9d5cefb853dd63a0480e38e3 now `nvram` is added to domain template and as part of undefine it we need to use this flag otherwise following error occur during `crc cleanup` if domain is present.

```
Code=55, Domain=10, Message='Requested operation is not valid: cannot undefine domain with nvram'
```

This pr even work with current template where no `<nvram />` present.


**Fixes:** Issue #4228 