### PR TITLE
kubeconfig: Don't use JoinHostPort with URI

### DIFF
--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -211,8 +211,7 @@ func requestTokenWithChallengeHandlers(clientCfg *restclient.Config, handler *ch
 		return "", err
 	}
 
-	portStr := strconv.Itoa(int(port))
-	o.Issuer = net.JoinHostPort(o.Issuer, portStr)
+	o.Issuer = fmt.Sprintf("%s:%d", o.Issuer, port)
 	return o.RequestToken()
 }
 


### PR DESCRIPTION
As part of 4f83f71654f84c9c9dafb85e0178139607f07dd4 we used JoinHostPort but o.Issuer is uri string not the hostname so when it is used with JoinHostPort it thinks it is a ipv6 and return the value as following
```
[https://oauth-openshift.apps-crc.testing]:443
```

This failed to parse so better to avoid it.

This would fix following error
```
INFO Adding crc-admin and crc-developer contexts to kubeconfig...
ERRO Cannot update kubeconfig: parse "[https://oauth-openshift.apps-crc.testing]:443": first path segment in URL cannot contain colon
Started the OpenShift cluster.
```


