### PR TITLE
Spec: Append arch info for admin-helper and libvirt driver

### DIFF
--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -63,8 +63,8 @@ ln -fs "$(pwd)" "%{gobuilddir}/src/%{goipath}"
 %build
 export GOFLAGS="-mod=vendor"
 mkdir embed-files
-cp /usr/bin/crc-driver-libvirt embed-files
-cp /usr/bin/crc-admin-helper embed-files/crc-admin-helper-linux
+cp /usr/bin/crc-driver-libvirt embed-files/crc-driver-libvirt-%{gohostarch}
+cp /usr/bin/crc-admin-helper embed-files/crc-admin-helper-linux-%{gohostarch}
 make COMMIT_SHA=__COMMIT_SHA__ GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ release
 
 %install


### PR DESCRIPTION
After 589e1520c531c4fae95e5d6ae39f8a357d22d866 and 926c78e6bfc64ce6a5ed1771d58d637ce34aafe5, the filename detected by embedded binary also have arch info since it takes basename of url for admin-helper and libvirt and both url now have arch info. This PR copy the binary with arch info suffix to fix the following error during rpm build.
```
 > [6/6] RUN yum config-manager --set-enabled crb &&     yum -y builddep packaging/rpm/crc.spec &&     rpmbuild -bb -v packaging/rpm/crc.spec:
238.6 go build --tags="build" -ldflags="-X github.com/crc-org/crc/v2/pkg/crc/version.crcVersion=2.38.0 -X github.com/crc-org/crc/v2/pkg/crc/version.ocpVersion=4.15.17 -X github.com/crc-org/crc/v2/pkg/crc/version.okdVersion=4.15.0-0.okd-2024-02-23-163410 -X github.com/crc-org/crc/v2/pkg/crc/version.microshiftVersion=4.15.17 -X github.com/crc-org/crc/v2/pkg/crc/version.commitSha=4225c2 -B 0xc4fae8225411a1c1f9d2fbff31dff48012b372b9" -o out/linux-amd64/crc-embedder  ./cmd/crc-embedder
239.8 out/linux-amd64/crc-embedder embed --log-level debug --cache-dir=embed-files/ --no-download --goos=linux out/linux-amd64/crc
239.8 level=debug msg="Embedding embed-files/crc-driver-libvirt-amd64 in out/linux-amd64/crc"
239.8 level=fatal msg="Failed to embed data files: Failed to open embed-files/crc-driver-libvirt-amd64: open embed-files/crc-driver-libvirt-amd64: no such file or directory"
239.8 make: *** [Makefile:326: embed_crc_helpers] Error 1
239.8 error: Bad exit status from /var/tmp/rpm-tmp.Cd7dtB (%build)
```

