### PR TITLE
Display PersistentVolumeSize in `crc status`

### DIFF
--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -19,14 +19,16 @@ type StartResult struct {
 }
 
 type ClusterStatusResult struct {
-	CrcStatus        string
-	OpenshiftStatus  string
-	OpenshiftVersion string `json:"OpenshiftVersion,omitempty"`
-	DiskUse          int64
-	DiskSize         int64
-	RAMUse           int64
-	RAMSize          int64
-	Preset           preset.Preset
+	CrcStatus            string
+	OpenshiftStatus      string
+	OpenshiftVersion     string `json:"OpenshiftVersion,omitempty"`
+	DiskUse              int64
+	DiskSize             int64
+	RAMUse               int64
+	RAMSize              int64
+	PersistentVolumeUse  int `json:"PersistentVolumeUse,omitempty"`
+	PersistentVolumeSize int `json:"PersistentVolumeSize,omitempty"`
+	Preset               preset.Preset
 }
 
 type ConsoleResult struct {

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -63,14 +63,16 @@ func (h *Handler) Status(c *context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, client.ClusterStatusResult{
-		CrcStatus:        string(res.CrcStatus),
-		OpenshiftStatus:  string(res.OpenshiftStatus),
-		OpenshiftVersion: res.OpenshiftVersion,
-		DiskUse:          res.DiskUse,
-		DiskSize:         res.DiskSize,
-		RAMSize:          res.RAMSize,
-		RAMUse:           res.RAMUse,
-		Preset:           res.Preset,
+		CrcStatus:            string(res.CrcStatus),
+		OpenshiftStatus:      string(res.OpenshiftStatus),
+		OpenshiftVersion:     res.OpenshiftVersion,
+		DiskUse:              res.DiskUse,
+		DiskSize:             res.DiskSize,
+		RAMSize:              res.RAMSize,
+		RAMUse:               res.RAMUse,
+		PersistentVolumeUse:  res.PersistentVolumeUse,
+		PersistentVolumeSize: res.PersistentVolumeSize,
+		Preset:               res.Preset,
 	})
 }
 

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -72,14 +72,16 @@ type StopResult struct {
 }
 
 type ClusterStatusResult struct {
-	CrcStatus        state.State
-	OpenshiftStatus  OpenshiftStatus
-	OpenshiftVersion string
-	DiskUse          int64
-	DiskSize         int64
-	RAMUse           int64
-	RAMSize          int64
-	Preset           crcpreset.Preset
+	CrcStatus            state.State
+	OpenshiftStatus      OpenshiftStatus
+	OpenshiftVersion     string
+	DiskUse              int64
+	DiskSize             int64
+	RAMUse               int64
+	RAMSize              int64
+	PersistentVolumeUse  int
+	PersistentVolumeSize int
+	Preset               crcpreset.Preset
 }
 
 type ClusterLoadResult struct {


### PR DESCRIPTION
Enhance the crc status command to display the PersistentVolumeSize from the CRC configuration.

**Fixes:** Issue #4191 

## Solution/Idea
The `/status` handler should return fields specifying the PVC size and usage (allocated storage).

## Proposed changes

 - Fetch and display the PersistentVolumeSize value in the crc status output.
 - Add new fields to the ClusterStatus and CrcStatus structs to support this feature.
 - Update the CRC daemon to include these changes.

## Testing

Run `crc status`
```
gvyas-mac:~ gvyas$ crc status
CRC VM:                  Running
MicroShift:              Running (v4.15.12)
RAM Usage:               1.62GB of 3.904GB
Disk Usage:              6.824GB of 20.41GB (Inside the CRC VM)
Persistent Volume Usage: 10.67GB of 16GB (Allocated)
Cache Usage:             74.36GB
Cache Directory:         /Users/gvyas/.crc/cache
```