### PR TITLE
cache: Add condition to check binary name with arch suffix

### DIFF
--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
@@ -44,6 +45,10 @@ func (c *Cache) GetExecutablePath() string {
 
 func (c *Cache) GetExecutableName() string {
 	return filepath.Base(c.executablePath)
+}
+
+func (c *Cache) GetExecutableNameWithArch() string {
+	return fmt.Sprintf("%s-%s", c.GetExecutableName(), runtime.GOARCH)
 }
 
 /* getVersionGeneric runs the cached executable with 'args', and assumes the version string
@@ -128,7 +133,7 @@ func (c *Cache) cacheExecutable() error {
 		}
 	} else {
 		extractedFiles = append(extractedFiles, assetTmpFile)
-		if filepath.Base(assetTmpFile) != c.GetExecutableName() && !c.ignoreNameMismatch {
+		if (filepath.Base(assetTmpFile) != c.GetExecutableName() && filepath.Base(assetTmpFile) != c.GetExecutableNameWithArch()) && !c.ignoreNameMismatch {
 			logging.Warnf("Executable name is %s but extracted file name is %s", c.GetExecutableName(), filepath.Base(assetTmpFile))
 		}
 	}


### PR DESCRIPTION
As part of 926c78, libvirt driver download url change to have arch info and keeping the binary name as it is but as part of `cmd/embeded.go` it get the list using basename of uri and match with binary name which causing the following warning when crc binary have embedded driver and admin helper bit.

```
WARN Executable name is crc-driver-libvirt but extracted file name is crc-driver-libvirt-amd64
```

With this PR we are adding the condition where filelist and expected binary name match even it have arch info as suffix.


## Testing
- Run `make release` without this PR and remove libvirt and admin helper binary from `$HOME/.crc/bin` folder
-  use the binary which built using `make release` command and run `crc setup` and you will get this warning message

Try same with this PR and you shouldn't see this warning message.