### PR TITLE
Show MicroShift version as part of 'version' command

### DIFF
--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -34,16 +34,18 @@ func runPrintVersion(writer io.Writer, version *version, outputFormat string) er
 }
 
 type version struct {
-	Version          string `json:"version"`
-	Commit           string `json:"commit"`
-	OpenshiftVersion string `json:"openshiftVersion"`
+	Version           string `json:"version"`
+	Commit            string `json:"commit"`
+	OpenshiftVersion  string `json:"openshiftVersion"`
+	MicroshiftVersion string `json:"microshiftVersion"`
 }
 
 func defaultVersion() *version {
 	return &version{
-		Version:          crcversion.GetCRCVersion(),
-		Commit:           crcversion.GetCommitSha(),
-		OpenshiftVersion: crcversion.GetBundleVersion(crcPreset.OpenShift),
+		Version:           crcversion.GetCRCVersion(),
+		Commit:            crcversion.GetCommitSha(),
+		OpenshiftVersion:  crcversion.GetBundleVersion(crcPreset.OpenShift),
+		MicroshiftVersion: crcversion.GetBundleVersion(crcPreset.Microshift),
 	}
 }
 
@@ -60,5 +62,6 @@ func (v *version) lines() []string {
 	return []string{
 		fmt.Sprintf("CRC version: %s+%s\n", v.Version, v.Commit),
 		fmt.Sprintf("OpenShift version: %s\n", v.OpenshiftVersion),
+		fmt.Sprintf("MicroShift version: %s\n", v.MicroshiftVersion),
 	}
 }

--- a/cmd/crc/cmd/version_test.go
+++ b/cmd/crc/cmd/version_test.go
@@ -10,23 +10,26 @@ import (
 func TestPlainVersion(t *testing.T) {
 	out := new(bytes.Buffer)
 	assert.NoError(t, runPrintVersion(out, &version{
-		Version:          "1.13",
-		Commit:           "aabbcc",
-		OpenshiftVersion: "4.5.4",
+		Version:           "1.13",
+		Commit:            "aabbcc",
+		OpenshiftVersion:  "4.5.4",
+		MicroshiftVersion: "4.16.0",
 	}, ""))
 	assert.Equal(t, `CRC version: 1.13+aabbcc
 OpenShift version: 4.5.4
+MicroShift version: 4.16.0
 `, out.String())
 }
 
 func TestJsonVersion(t *testing.T) {
 	out := new(bytes.Buffer)
 	assert.NoError(t, runPrintVersion(out, &version{
-		Version:          "1.13",
-		Commit:           "aabbcc",
-		OpenshiftVersion: "4.5.4",
+		Version:           "1.13",
+		Commit:            "aabbcc",
+		OpenshiftVersion:  "4.5.4",
+		MicroshiftVersion: "4.16.0",
 	}, "json"))
 
-	expected := `{"version": "1.13", "commit": "aabbcc", "openshiftVersion": "4.5.4"}`
+	expected := `{"version": "1.13", "commit": "aabbcc", "openshiftVersion": "4.5.4", "microshiftVersion": "4.16.0"}`
 	assert.JSONEq(t, expected, out.String())
 }

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -48,9 +48,10 @@ func TestVersion(t *testing.T) {
 	assert.Equal(
 		t,
 		apiClient.VersionResult{
-			CrcVersion:       version.GetCRCVersion(),
-			OpenshiftVersion: version.GetBundleVersion(preset.OpenShift),
-			CommitSha:        version.GetCommitSha(),
+			CrcVersion:        version.GetCRCVersion(),
+			OpenshiftVersion:  version.GetBundleVersion(preset.OpenShift),
+			MicroshiftVersion: version.GetBundleVersion(preset.Microshift),
+			CommitSha:         version.GetCommitSha(),
 		},
 		vr,
 	)

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -265,7 +265,7 @@ var testCases = []testCase{
 	// version
 	{
 		request:  get("version"),
-		response: jSon(fmt.Sprintf(`{"CrcVersion":"%s","CommitSha":"%s","OpenshiftVersion":"%s"}`, version.GetCRCVersion(), version.GetCommitSha(), version.GetBundleVersion(preset.OpenShift))),
+		response: jSon(fmt.Sprintf(`{"CrcVersion":"%s","CommitSha":"%s","OpenshiftVersion":"%s","MicroshiftVersion":"%s"}`, version.GetCRCVersion(), version.GetCommitSha(), version.GetBundleVersion(preset.OpenShift), version.GetBundleVersion(preset.Microshift))),
 	},
 
 	// version never fails

--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -7,9 +7,10 @@ import (
 )
 
 type VersionResult struct {
-	CrcVersion       string
-	CommitSha        string
-	OpenshiftVersion string
+	CrcVersion        string
+	CommitSha         string
+	OpenshiftVersion  string
+	MicroshiftVersion string
 }
 
 type StartResult struct {

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -136,9 +136,10 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 
 func (h *Handler) GetVersion(c *context) error {
 	return c.JSON(http.StatusOK, &client.VersionResult{
-		CrcVersion:       version.GetCRCVersion(),
-		CommitSha:        version.GetCommitSha(),
-		OpenshiftVersion: version.GetBundleVersion(preset.OpenShift),
+		CrcVersion:        version.GetCRCVersion(),
+		CommitSha:         version.GetCommitSha(),
+		OpenshiftVersion:  version.GetBundleVersion(preset.OpenShift),
+		MicroshiftVersion: version.GetBundleVersion(preset.Microshift),
 	})
 }
 

--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 type VersionAnswer struct {
-	Version          string `json:"version"`
-	Commit           string `json:"commit"`
-	OpenshiftVersion string `json:"openshiftVersion"`
+	Version           string `json:"version"`
+	Commit            string `json:"commit"`
+	OpenshiftVersion  string `json:"openshiftVersion"`
+	MicroshiftVersion string `json:"microshiftVersion"`
 }
 
 var credPath string


### PR DESCRIPTION
**Fixes:** Issue #4098

**Relates to:** Issue #4099

## Solution/Idea

Display MicroShift version as part of CRC version command output. Extend existing unit tests to verify that also this newly added field is present in the output.

## Proposed changes

1. Add `MicroshiftVersion` field to `Version` type.
2. Read the bundled version from `crcPreset`
3. Print out the value as part of the `version` command

## Testing

1. `crc` version contains Microshift version
2. if the output shows the correct Microshift version the test succeeded 
3. Extended existing unit test to verify the claim
