### PR TITLE
clusteroperator: Ignore EvaluationConditionsDetected condition

### DIFF
--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -128,6 +128,8 @@ func getStatus(ctx context.Context, lister operatorLister, selector []string) (*
 				}
 			case openshiftapi.OperatorUpgradeable:
 				continue
+			case openshiftapi.EvaluationConditionsDetected:
+				continue
 			case "Disabled": // non official status, used by insights and cluster baremetal operators
 				if con.Status == openshiftapi.ConditionTrue {
 					logging.Debug(c.ObjectMeta.Name, " operator is disabled, Reason: ", con.Reason)


### PR DESCRIPTION
As per godoc of cluster operator type
```
EvaluationConditionsDetected is used to indicate the result of the detection
logic that was added to a component to evaluate the introduction of an
invasive change that could potentially result in highly visible alerts,
breakages or upgrade failures. You can concatenate multiple Reason using
the "::" delimiter if you need to evaluate the introduction of multiple changes.
```

which is not required in our usecase to check cluster operator availability so ignoring that state. This will also fix the debug logs of start command which have following message

```
DEBU Unexpected operator status for authentication: EvaluationConditionsDetected
DEBU Unexpected operator status for config-operator: EvaluationConditionsDetected
DEBU Unexpected operator status for console: EvaluationConditionsDetected
DEBU Unexpected operator status for etcd: EvaluationConditionsDetected
DEBU Unexpected operator status for ingress: EvaluationConditionsDetected
DEBU Unexpected operator status for kube-apiserver: EvaluationConditionsDetected
DEBU Unexpected operator status for kube-controller-manager: EvaluationConditionsDetected
DEBU Unexpected operator status for kube-scheduler: EvaluationConditionsDetected
DEBU Unexpected operator status for machine-config: EvaluationConditionsDetected
DEBU Unexpected operator status for openshift-apiserver: EvaluationConditionsDetected
DEBU Unexpected operator status for openshift-controller-manager: EvaluationConditionsDetected
```