### PR TITLE
Fix cert expiration issue for aggregator client

### DIFF
--- a/pkg/crc/cluster/cert_renewal.go
+++ b/pkg/crc/cluster/cert_renewal.go
@@ -43,7 +43,7 @@ func approvePendingCSRs(ctx context.Context, ocConfig oc.Config, expectedSignerN
 	}, time.Second*5)
 }
 
-func ApproveCSRAndWaitForCertsRenewal(ctx context.Context, sshRunner *ssh.Runner, ocConfig oc.Config, client, server bool) error {
+func ApproveCSRAndWaitForCertsRenewal(ctx context.Context, sshRunner *ssh.Runner, ocConfig oc.Config, client, server, aggregratorClient bool) error {
 	const (
 		kubeletClientSignerName  = "kubernetes.io/kube-apiserver-client-kubelet"
 		kubeletServingSignerName = "kubernetes.io/kubelet-serving"
@@ -76,6 +76,10 @@ func ApproveCSRAndWaitForCertsRenewal(ctx context.Context, sshRunner *ssh.Runner
 	if server {
 		logging.Info("Kubelet serving certificate has expired, waiting for automatic renewal... [will take up to 5 minutes]")
 		return crcerrors.Retry(ctx, 5*time.Minute, waitForCertRenewal(sshRunner, KubeletServerCert), time.Second*5)
+	}
+	if aggregratorClient {
+		logging.Info("Kube API server certificate has expired, waiting for automatic renewal... [will take up to 8 minutes]")
+		return crcerrors.Retry(ctx, 8*time.Minute, waitForCertRenewal(sshRunner, AggregatorClientCert), time.Second*5)
 	}
 	return nil
 }

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -32,7 +32,7 @@ const (
 	KubeletServerCert = "/var/lib/kubelet/pki/kubelet-server-current.pem"
 	KubeletClientCert = "/var/lib/kubelet/pki/kubelet-client-current.pem"
 
-	AggregatorClientCert = "/etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/aggregator-client-ca/ca-bundle.crt"
+	AggregatorClientCert = "/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/aggregator-client/tls.crt"
 )
 
 func CheckCertsValidity(sshRunner *ssh.Runner) (map[string]bool, error) {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -552,7 +552,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 
 	ocConfig := oc.UseOCWithSSH(sshRunner)
 
-	if err := cluster.ApproveCSRAndWaitForCertsRenewal(ctx, sshRunner, ocConfig, certsExpired[cluster.KubeletClientCert], certsExpired[cluster.KubeletServerCert]); err != nil {
+	if err := cluster.ApproveCSRAndWaitForCertsRenewal(ctx, sshRunner, ocConfig, certsExpired[cluster.KubeletClientCert], certsExpired[cluster.KubeletServerCert], certsExpired[cluster.AggregatorClientCert]); err != nil {
 		logBundleDate(vm.bundle)
 		return nil, errors.Wrap(err, "Failed to renew TLS certificates: please check if a newer CRC release is available")
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -602,29 +602,6 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		}
 	}
 
-	// In Openshift 4.3, when cluster comes up, the following happens
-	// 1. After the openshift-apiserver pod is started, its log contains multiple occurrences of `certificate has expired or is not yet valid`
-	// 2. Initially there is no request-header's client-ca crt available to `extension-apiserver-authentication` configmap
-	// 3. In the pod logs `missing content for CA bundle "client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file"`
-	// 4. After ~1 min /etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/aggregator-client-ca/ca-bundle.crt is regenerated
-	// 5. It is now also appear to `extension-apiserver-authentication` configmap as part of request-header's client-ca content
-	// 6. Openshift-apiserver is able to load the CA which was regenerated
-	// 7. Now apiserver pod log contains multiple occurrences of `error x509: certificate signed by unknown authority`
-	// When the openshift-apiserver is in this state, the cluster is non functional.
-	// A restart of the openshift-apiserver pod is enough to clear that error and get a working cluster.
-	// This is a work-around while the root cause is being identified.
-	// More info: https://bugzilla.redhat.com/show_bug.cgi?id=1795163
-	if certsExpired[cluster.AggregatorClientCert] {
-		logging.Debug("Waiting for the renewal of the request header client ca...")
-		if err := cluster.WaitForRequestHeaderClientCaFile(ctx, sshRunner); err != nil {
-			return nil, errors.Wrap(err, "Failed to wait for aggregator client ca renewal")
-		}
-
-		if err := cluster.DeleteOpenshiftAPIServerPods(ctx, ocConfig); err != nil {
-			return nil, errors.Wrap(err, "Cannot delete OpenShift API Server pods")
-		}
-	}
-
 	if err := updateKubeconfig(ctx, ocConfig, sshRunner, vm.bundle.GetKubeConfigPath()); err != nil {
 		return nil, errors.Wrap(err, "Failed to update kubeconfig file")
 	}


### PR DESCRIPTION
During 4.17.0-ec.1 testing we found out that it might be possible that
kubelet certs are not expired but aggregator one is and due to that our
apiserver not able to get the node info and fails with following error.

```
INFO Verifying validity of the kubelet certificates...
DEBU Running SSH command: date --date="$(sudo openssl x509 -in /var/lib/kubelet/pki/kubelet-client-current.pem -noout -enddate | cut -d= -f 2)" --iso-8601=seconds
DEBU SSH command results: err: <nil>, output: 2025-07-05T03:48:39+00:00
DEBU Running SSH command: date --date="$(sudo openssl x509 -in /var/lib/kubelet/pki/kubelet-server-current.pem -noout -enddate | cut -d= -f 2)" --iso-8601=seconds
DEBU SSH command results: err: <nil>, output: 2025-07-05T03:49:24+00:00
DEBU Running SSH command: date --date="$(sudo openssl x509 -in /etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/aggregator-client-ca/ca-bundle.crt -noout -enddate | cut -d= -f 2)" --iso-8601=seconds
DEBU SSH command results: err: <nil>, output: 2024-07-11T05:50:37+00:00
DEBU Certs have expired, they were valid till: 11 Jul 24 05:50 +0000
```

This PR make sure we also wait to recover the api server related certs
before checking the apiserver is responding.