### PR TITLE
build: Fix binaries not being rebuilt even when there are source changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ORG := github.com/crc-org
 MODULEPATH = $(ORG)/crc/v2
 PACKAGE_DIR := packaging/$(GOOS)
 
-SOURCES := $(shell git ls-files  *.go ":^vendor")
+SOURCES := $(shell git ls-files '*.go' ":^vendor")
 
 RELEASE_INFO := release-info.json
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ MODULEPATH = $(ORG)/crc/v2
 PACKAGE_DIR := packaging/$(GOOS)
 
 SOURCES := $(shell git ls-files '*.go' ":^vendor")
+SOURCES := $(SOURCES) go.mod go.sum Makefile
 
 RELEASE_INFO := release-info.json
 

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ install: $(SOURCES)
 	go install -tags "$(BUILDTAGS)"  -ldflags="$(LDFLAGS)" $(GO_EXTRA_BUILDFLAGS) ./cmd/crc
 
 $(BUILD_DIR)/macos-amd64/crc: $(SOURCES)
-	GOARCH=amd64 GOOS=darwin go build -tags "$(BUILDTAGS)" -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/macos-amd64/crc $(GO_EXTRA_BUILDFLAGS) ./cmd/crc
+	GOARCH=amd64 GOOS=darwin go build -tags "$(BUILDTAGS)" -ldflags="$(LDFLAGS)" -o $@ $(GO_EXTRA_BUILDFLAGS) ./cmd/crc
 
 $(BUILD_DIR)/macos-arm64/crc: $(SOURCES)
 	GOARCH=arm64 GOOS=darwin go build -tags "$(BUILDTAGS)" -ldflags="$(LDFLAGS)" -o $@ $(GO_EXTRA_BUILDFLAGS) ./cmd/crc


### PR DESCRIPTION
The Makefile has a `SOURCES` variable which contains a list of all go source
files used by crc. It's used as a dependency for the targets building binaries
so that the binaries are rebuilt on any source changes.

This broke in 1d104598 when a release_info_test.go file was added to the top
level directory. Since `SOURCES` is set to `git ls-files *.go ":^vendor"` shell
expansion will happen before `git ls-files` runs, so we'll be running `git
ls-files release_info_test.go ":^vendor"`, the `SOURCES` variable will only
contain `release_info_test.go` instead of the list of all source files, and
binaries won't get rebuilt when one of the go files change.

This commit adds quoting around `*.go` so that this works properly.