### PR TITLE
ssh: Use ed25519 algorithm instead ECDSA

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -174,11 +174,11 @@ func EnsureBaseDirectoriesExist() error {
 }
 
 func GetPublicKeyPath() string {
-	return filepath.Join(MachineInstanceDir, DefaultName, "id_ecdsa.pub")
+	return filepath.Join(MachineInstanceDir, DefaultName, "id_ed25519.pub")
 }
 
 func GetPrivateKeyPath() string {
-	return filepath.Join(MachineInstanceDir, DefaultName, "id_ecdsa")
+	return filepath.Join(MachineInstanceDir, DefaultName, "id_ed25519")
 }
 
 func GetHostDockerSocketPath() string {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -185,9 +185,9 @@ func GetHostDockerSocketPath() string {
 	return filepath.Join(MachineInstanceDir, DefaultName, "docker.sock")
 }
 
-// For backward compatibility to v 1.20.0
-func GetRsaPrivateKeyPath() string {
-	return filepath.Join(MachineInstanceDir, DefaultName, "id_rsa")
+// For backward compatibility to v 2.40.0
+func GetECDSAPrivateKeyPath() string {
+	return filepath.Join(MachineInstanceDir, DefaultName, "id_ecdsa")
 }
 
 func GetKubeAdminPasswordPath() string {

--- a/pkg/crc/machine/ip.go
+++ b/pkg/crc/machine/ip.go
@@ -21,6 +21,6 @@ func (client *client) ConnectionDetails() (*types.ConnectionDetails, error) {
 		IP:          ip,
 		SSHPort:     vm.SSHPort(),
 		SSHUsername: constants.DefaultSSHUser,
-		SSHKeys:     []string{constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath(), vm.bundle.GetSSHKeyPath()},
+		SSHKeys:     []string{constants.GetPrivateKeyPath(), constants.GetECDSAPrivateKeyPath(), vm.bundle.GetSSHKeyPath()},
 	}, nil
 }

--- a/pkg/crc/machine/virtualmachine.go
+++ b/pkg/crc/machine/virtualmachine.go
@@ -106,5 +106,5 @@ func (vm *virtualMachine) SSHRunner() (*ssh.Runner, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ssh.CreateRunner(ip, vm.SSHPort(), constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath(), vm.bundle.GetSSHKeyPath())
+	return ssh.CreateRunner(ip, vm.SSHPort(), constants.GetPrivateKeyPath(), constants.GetECDSAPrivateKeyPath(), vm.bundle.GetSSHKeyPath())
 }

--- a/pkg/crc/ssh/client.go
+++ b/pkg/crc/ssh/client.go
@@ -50,6 +50,7 @@ func clientConfig(user string, keys []string) (*ssh.ClientConfig, error) {
 
 		privateKey, err := ssh.ParsePrivateKey(key)
 		if err != nil {
+			log.Debugf("Failed to parse private key: %v\n", err)
 			return nil, err
 		}
 

--- a/pkg/crc/ssh/keys_test.go
+++ b/pkg/crc/ssh/keys_test.go
@@ -11,7 +11,7 @@ func TestNewKeyPair(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if privPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Headers: nil, Bytes: pair.PrivateKey}); len(privPem) == 0 {
+	if privPem := pem.EncodeToMemory(&pem.Block{Type: "OPENSSH PRIVATE KEY", Headers: nil, Bytes: pair.PrivateKey}); len(privPem) == 0 {
 		t.Fatal("No PEM returned")
 	}
 }

--- a/pkg/crc/ssh/keys_unix.go
+++ b/pkg/crc/ssh/keys_unix.go
@@ -4,7 +4,6 @@
 package ssh
 
 import (
-	"encoding/pem"
 	"os"
 )
 
@@ -17,7 +16,7 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 	}{
 		{
 			File:  privateKeyPath,
-			Value: pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Headers: nil, Bytes: kp.PrivateKey}),
+			Value: kp.PrivateKey,
 		},
 		{
 			File:  publicKeyPath,

--- a/pkg/crc/ssh/keys_windows.go
+++ b/pkg/crc/ssh/keys_windows.go
@@ -1,7 +1,6 @@
 package ssh
 
 import (
-	"encoding/pem"
 	"os"
 
 	"github.com/hectane/go-acl"
@@ -35,7 +34,7 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 	}{
 		{
 			File:  privateKeyPath,
-			Value: pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Headers: nil, Bytes: kp.PrivateKey}),
+			Value: kp.PrivateKey,
 		},
 		{
 			File:  publicKeyPath,


### PR DESCRIPTION
Key generated using ecdsa algorithm is causing issue for podman remote
connection on podman desktop side because the library they consume
doesn't have support for this algorithm. This PR is switching the ecdsa
to ed25519 which is supported by the library consumed in podman desktop.

[0] https://github.com/containers/podman-desktop/issues/8351
[1] https://github.com/mscdex/ssh2/issues/1375


how to test
=========

- Use artifact from this PR to install crc (windows and mac)
- Install the podman-desktop
- No need to start podman machine or even enable the openshift-local plugin
- from the PD, `Setting => preference => Extension: podman => Enable the Remote`
- start crc with microshift preset
```
$ podman system connection add crc-root --identity "C:\Users\<username>\.crc\machines\crc\id_ed25519"  "ssh://core@127.0.0.1:2222/run/podman/podman.sock"
```
- on the PD check if images and pods are now listed.