### PR TITLE
Fix: go-lint fixes for go tools 0.24.0 update

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -81,7 +81,7 @@ func runPrerun(cmd *cobra.Command) error {
 	logging.InitLogrus(logFile)
 
 	for _, str := range defaultVersion().lines() {
-		logging.Debugf(str)
+		logging.Debugf("%s", str)
 	}
 	return nil
 }
@@ -138,7 +138,7 @@ func setProxyDefaults() error {
 	}
 
 	if proxyConfig.IsEnabled() {
-		logging.Debugf(proxyConfig.String())
+		logging.Debugf("%s", proxyConfig.String())
 		proxyConfig.ApplyToEnvironment()
 	}
 	return nil

--- a/pkg/crc/input/input.go
+++ b/pkg/crc/input/input.go
@@ -15,7 +15,7 @@ func PromptUserForYesOrNo(message string, force bool) bool {
 		return false
 	}
 	var response string
-	fmt.Printf(message + "? [y/N]: ")
+	fmt.Printf("%s? [y/N]: ", message)
 	_, _ = fmt.Scanf("%s", &response)
 
 	return strings.ToLower(response) == "y"

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -72,7 +72,7 @@ func (check *Check) doFix() error {
 		panic(fmt.Sprintf("Should not happen, empty description for fix '%s'", check.configKeySuffix))
 	}
 	if check.flags&NoFix == NoFix {
-		return fmt.Errorf(check.fixDescription)
+		return fmt.Errorf("%s", check.fixDescription)
 	}
 
 	logging.Infof("%s", check.fixDescription)


### PR DESCRIPTION
Related PR: https://github.com/crc-org/crc/pull/4316

## Solution/Idea

Fix golint errors

## Testing
Tested with updated `golangci-lint`
