### PR TITLE
bundle validation: check for bundle preset mismatch during setup

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -284,7 +284,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Error getting bundle metadata")
 	}
 
-	if err := bundleMismatchWithPreset(startConfig.Preset, crcBundleMetadata); err != nil {
+	if err := validation.BundleMismatchWithPresetMetadata(startConfig.Preset, crcBundleMetadata); err != nil {
 		return nil, err
 	}
 
@@ -850,13 +850,6 @@ func updateKubeconfig(ctx context.Context, ocConfig oc.Config, sshRunner *crcssh
 	}
 	if err := cluster.EnsureGeneratedClientCAPresentInTheCluster(ctx, ocConfig, sshRunner, selfSignedCACert, adminClientCA); err != nil {
 		return errors.Wrap(err, "Failed to update user CA to cluster")
-	}
-	return nil
-}
-
-func bundleMismatchWithPreset(preset crcPreset.Preset, bundleMetadata *bundle.CrcBundleInfo) error {
-	if preset != bundleMetadata.GetBundleType() {
-		return errors.Errorf("Preset %s is used but bundle is provided for %s preset", preset, bundleMetadata.GetBundleType())
 	}
 	return nil
 }


### PR DESCRIPTION
**Fixes:** Issue #3615 

Added a check for bundle type mismatch with preset in function `ValidateBundle`.

https://github.com/crc-org/crc/blob/7b04ce547692b44e2f12c41ecd07639303473a8f/pkg/crc/validation/validation.go#L91-L107

The check is performed before checking for custom bundle (and potentially displaying a warning).

Function `BundleMismatchWithPreset` was moved from `machine/start.go` to `validation/validation.go` and is used during start as well.

## Testing

1. Download bundle for a preset (i.e. microshift).
2. Change preset to some other value `crc config set preset openshift`
3. `crc setup --bundle <path_to_bundle>`
Output:
`FATA Preset openshift is used but bundle is provided for microshift preset`