### PR TITLE
Fixing typo in documentation

### DIFF
--- a/docs/modules/getting_started/partials/proc_deploying-sample-application-with-odo.adoc
+++ b/docs/modules/getting_started/partials/proc_deploying-sample-application-with-odo.adoc
@@ -23,7 +23,7 @@ $ odo login -u developer -p developer
 +
 [subs="+quotes,attributes"]
 ----
-$ odo project create sample-app
+$ odo create project sample-app
 ----
 
 . Create a directory for your components:


### PR DESCRIPTION
Fixing typo. Just changing order of commands


