### PR TITLE
fix test suite security fails

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,3 +8,19 @@ exclude:
     # Ignore vendor/ directory since we're not (yet) concerned with scanning
     # our dependencies on each CI run.
     - 'vendor/**'
+ignore:
+    '36cd2bbf-2574-47a0-b2e8-1ff1e355a224':
+     - 'cmd/crc/cmd/console.go':
+        reason: 'basic user developer'
+    '1c87c91c-7a5b-4d00-bffe-2621128e6c08':
+     - 'pkg/crc/config/settings.go':
+        reason: 'Just a default value overrided later'
+    '94e6303b-7d14-4caa-bcff-4a3ce7cff8be':
+     - 'pkg/crc/config/settings.go':
+        reason: 'Just a default value overrided later'
+    'f3f16cec-5785-4d62-8746-fab4e9a27f17':
+     - 'cmd/crc/cmd/start.go':
+        reason: 'basic developer password'
+    'fe3fa24e-67ae-4268-9148-1563b30bf9e6':
+     - 'cmd/crc/cmd/console.go':
+        reason: 'basic developer password'

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -205,7 +205,7 @@ func unzip(archive, target string, fileFilter func(string) bool, showProgress bo
 			continue
 		}
 
-		if err := unzipFile(file, path, showProgress); err != nil {
+		if err := unzipFile(file, filepath.Clean(path), showProgress); err != nil {
 			return nil, err
 		}
 		extractedFiles = append(extractedFiles, path)

--- a/test/extended/util/prepare.go
+++ b/test/extended/util/prepare.go
@@ -97,7 +97,7 @@ func CleanTestRunDir() error {
 	}
 
 	for _, file := range files {
-		err := os.RemoveAll(filepath.Join(TestRunDir, file.Name()))
+		err := os.RemoveAll(filepath.Clean(filepath.Join(TestRunDir, file.Name())))
 		if err != nil {
 			return err
 		}

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -54,7 +54,7 @@ func CopyResourcesFromPath(resourcesPath string) error {
 		sFileName := filepath.Join(resourcesPath, file.Name())
 		fmt.Printf("Copying %s to %s\n", sFileName, destLoc)
 
-		sFile, err := os.Open(sFileName)
+		sFile, err := os.Open(filepath.Clean(sFileName))
 		if err != nil {
 			fmt.Printf("Error occurred opening file: %s", err)
 			return err


### PR DESCRIPTION
Fixing test suite for warnings on vulnerabilities

Based on https://www.stackhawk.com/blog/golang-path-traversal-guide-examples-and-prevention/

from failed test detected on https://github.com/crc-org/crc/pull/4369