### PR TITLE
Return user networking mode as default on macOS and linux & Remove unused flags from goproxy integration test

### DIFF
--- a/pkg/crc/network/types.go
+++ b/pkg/crc/network/types.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/spf13/cast"
@@ -61,9 +62,18 @@ func ParseMode(input string) Mode {
 	mode, err := parseMode(input)
 	if err != nil {
 		logging.Errorf("unexpected network mode %s, using default", input)
-		return SystemNetworkingMode
+		mode = getDefaultMode()
 	}
 	return mode
+}
+
+func getDefaultMode() Mode {
+	switch runtime.GOOS {
+	case "linux":
+		return SystemNetworkingMode
+	default:
+		return UserNetworkingMode
+	}
 }
 
 func ValidateMode(val interface{}) (bool, string) {

--- a/test/extended/util/proxy.go
+++ b/test/extended/util/proxy.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed" // blanks are good
-	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -70,12 +70,11 @@ func RunProxy() {
 		ipaddr = "192.168.130.1"
 	}
 
-	verbose := flag.Bool("v", true, "should every proxy request be logged to stdout")
-	addr := flag.String(ipaddr, ":8888", "proxy listen address") // using network-mode=user
-	flag.Parse()
-	proxy.Verbose = *verbose
+	addr := fmt.Sprintf("%s:8888", ipaddr)
+	proxy.Verbose = true
 	proxy.Logger = log.StandardLogger()
-	err = http.ListenAndServe(*addr, proxy) // #nosec G114
+
+	err = http.ListenAndServe(addr, proxy) // #nosec G114
 	if err != nil {
 		log.Printf("error running proxy: %s", err)
 	}


### PR DESCRIPTION
**Fixes:** Issue #4335 


## Solution/Idea

This PR addresses two issues I encountered while running integration tests on my local machine

- The default networking mode returned should be based on the OS
- goproxy test is defining and parsing unused flags which are causing a post test-run panic

## Proposed changes

1. Removed the unused flags
2. Modified the function for fetching the default networking mode

## Testing

```zsh
make GINKGO_OPTS="--ginkgo.label-filter='openshift-preset'" BUNDLE_PATH="--bundle-path=~/.crc/cache/crc_vfkit_4.16.7_arm64.crcbundle" PULL_SECRET_PATH="--pull-secret-path=~/Downloads/pull-secret.txt" integration
```