### PR TITLE
fix (crc/machine) : KubeContext left in invalid state after crc stop (#1569)

### DIFF
--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -50,7 +50,7 @@ func updateClientCrtAndKeyToKubeconfig(clientKey, clientCrt []byte, srcKubeconfi
 }
 
 func writeKubeconfig(ip string, clusterConfig *types.ClusterConfig, ingressHTTPSPort uint) error {
-	kubeconfig, cfg, err := getGlobalKubeConfig()
+	kubeconfig, cfg, err := GetGlobalKubeConfig()
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func writeKubeconfig(ip string, clusterConfig *types.ClusterConfig, ingressHTTPS
 	return clientcmd.WriteToFile(*cfg, kubeconfig)
 }
 
-func getGlobalKubeConfig() (string, *api.Config, error) {
+func GetGlobalKubeConfig() (string, *api.Config, error) {
 	kubeconfig := getGlobalKubeConfigPath()
 	return getKubeConfigFromFile(kubeconfig)
 }

--- a/pkg/crc/machine/kubeconfig_test.go
+++ b/pkg/crc/machine/kubeconfig_test.go
@@ -52,6 +52,32 @@ func TestCleanKubeconfig(t *testing.T) {
 	assert.YAMLEq(t, string(expected), string(actual))
 }
 
+func TestCleanKubeConfigIdempotency(t *testing.T) {
+	// Given
+	dir := t.TempDir()
+	// When
+	assert.NoError(t, cleanKubeconfig(filepath.Join("testdata", "kubeconfig.out"), filepath.Join(dir, "kubeconfig")))
+	actual, err := os.ReadFile(filepath.Join(dir, "kubeconfig"))
+	// Then
+	assert.NoError(t, err)
+	expected, err := os.ReadFile(filepath.Join("testdata", "kubeconfig.out"))
+	assert.NoError(t, err)
+	assert.YAMLEq(t, string(expected), string(actual))
+}
+
+func TestCleanKubeConfigShouldDoNothingWhenClusterDomainIsNotEqualToCrcTesting(t *testing.T) {
+	// Given
+	dir := t.TempDir()
+	// When
+	assert.NoError(t, cleanKubeconfig(filepath.Join("testdata", "kubeconfig-without-api-crc-testing-cluster-domain"), filepath.Join(dir, "kubeconfig")))
+	actual, err := os.ReadFile(filepath.Join(dir, "kubeconfig"))
+	// Then
+	assert.NoError(t, err)
+	expected, err := os.ReadFile(filepath.Join("testdata", "kubeconfig-without-api-crc-testing-cluster-domain"))
+	assert.NoError(t, err)
+	assert.YAMLEq(t, string(expected), string(actual))
+}
+
 func TestUpdateUserCaAndKeyToKubeconfig(t *testing.T) {
 	f, err := os.CreateTemp("", "kubeconfig")
 	assert.NoError(t, err, "")

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -1,6 +1,8 @@
 package machine
 
 import (
+	"os"
+
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
 	crcPreset "github.com/crc-org/crc/v2/pkg/crc/preset"
@@ -9,6 +11,12 @@ import (
 )
 
 func (client *client) Stop() (state.State, error) {
+	defer func(input, output string) {
+		err := cleanKubeconfig(input, output)
+		if !errors.Is(err, os.ErrNotExist) {
+			logging.Warnf("Failed to remove crc contexts from kubeconfig: %v", err)
+		}
+	}(getGlobalKubeConfigPath(), getGlobalKubeConfigPath())
 	if running, _ := client.IsRunning(); !running {
 		return state.Error, errors.New("Instance is already stopped")
 	}

--- a/pkg/crc/machine/stop_test.go
+++ b/pkg/crc/machine/stop_test.go
@@ -1,0 +1,76 @@
+package machine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	crcConfig "github.com/crc-org/crc/v2/pkg/crc/config"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
+	crcOs "github.com/crc-org/crc/v2/pkg/os"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_WhenStopInvokedWithNonExistentVM_ThenThrowError(t *testing.T) {
+	// Given
+	dir := t.TempDir()
+	oldKubeConfigEnvVarValue := os.Getenv("KUBECONFIG")
+	kubeConfigPath := filepath.Join(dir, "kubeconfig")
+	err := crcOs.CopyFile(filepath.Join("testdata", "kubeconfig.in"), kubeConfigPath)
+	assert.NoError(t, err)
+	err = os.Setenv("KUBECONFIG", kubeConfigPath)
+	assert.NoError(t, err)
+	crcConfigStorage := crcConfig.New(crcConfig.NewEmptyInMemoryStorage(), crcConfig.NewEmptyInMemorySecretStorage())
+	client := NewClient("i-dont-exist", false, crcConfigStorage)
+
+	// When
+	clusterState, stopErr := client.Stop()
+
+	// Then
+	assert.EqualError(t, stopErr, "Instance is already stopped")
+	assert.Equal(t, clusterState, state.Error)
+	err = os.Setenv("KUBECONFIG", oldKubeConfigEnvVarValue)
+	assert.NoError(t, err)
+}
+
+var testArguments = map[string]struct {
+	inputKubeConfigPath    string
+	expectedKubeConfigPath string
+}{
+	"When KubeConfig contains crc context, then cleanup KubeConfig": {
+		"kubeconfig.in", "kubeconfig.out",
+	},
+	"When KubeConfig does not contain crc context, then KubeConfig remains unchanged": {
+		"kubeconfig.out", "kubeconfig.out",
+	},
+}
+
+func TestClient_WhenStopInvoked_ThenKubeConfigUpdatedIfRequired(t *testing.T) {
+	for name, test := range testArguments {
+		t.Run(name, func(t *testing.T) {
+			// Given
+			dir := t.TempDir()
+			oldKubeConfigEnvVarValue := os.Getenv("KUBECONFIG")
+			kubeConfigPath := filepath.Join(dir, "kubeconfig")
+			err := crcOs.CopyFile(filepath.Join("testdata", test.inputKubeConfigPath), kubeConfigPath)
+			assert.NoError(t, err)
+			err = os.Setenv("KUBECONFIG", kubeConfigPath)
+			assert.NoError(t, err)
+			crcConfigStorage := crcConfig.New(crcConfig.NewEmptyInMemoryStorage(), crcConfig.NewEmptyInMemorySecretStorage())
+			client := NewClient("test-client", false, crcConfigStorage)
+
+			// When
+			clusterState, _ := client.Stop()
+
+			// Then
+			actualKubeConfigFile, err := os.ReadFile(kubeConfigPath)
+			assert.NoError(t, err)
+			expectedKubeConfigPath, err := os.ReadFile(filepath.Join("testdata", test.expectedKubeConfigPath))
+			assert.NoError(t, err)
+			assert.YAMLEq(t, string(expectedKubeConfigPath), string(actualKubeConfigFile))
+			assert.Equal(t, clusterState, state.Error)
+			err = os.Setenv("KUBECONFIG", oldKubeConfigEnvVarValue)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/crc/machine/testdata/kubeconfig-without-api-crc-testing-cluster-domain
+++ b/pkg/crc/machine/testdata/kubeconfig-without-api-crc-testing-cluster-domain
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://api.unknown.testing:6443
+  name: api-crc-testing:6443
+contexts:
+- context:
+    cluster: api-crc-testing:6443
+    namespace: default
+    user: kubeadmin/api-crc-testing:6443
+  name: default/api-crc-testing:6443/kubeadmin
+current-context: default/api-crc-testing:6443/kubeadmin
+kind: Config
+preferences: {}
+users:
+- name: kubeadmin/api-crc-testing:6443
+  user:
+    token: sha256~secret

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -60,6 +60,7 @@ Feature: Basic test
         When executing "crc stop"
         Then stdout should match "(.*)[Ss]topped the instance"
         And executing "oc whoami" fails
+        And kubeconfig is cleaned up
         # status check
         When checking that CRC is stopped
         And stdout should not contain "Running"
@@ -69,5 +70,6 @@ Feature: Basic test
         # delete
         When executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the instance"
+        And kubeconfig is cleaned up
         # cleanup
         When executing crc cleanup command succeeds


### PR DESCRIPTION
## Description

Fix #1569

At the moment, we are only cleaning up crc context from kubeconfig during `crc delete`. This can be problematic if user tries to run any cluster related command after running `crc stop` as kubeconfig still points to CRC cluster that is not active.

I checked minikube's behavior and noticed it's cleaning up kube config in case of both stop and delete commands. Make crc behavior consistent with minikube and perform kubeconfig cleanup in both sub commands.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I tested my code on specified platforms
   - [x] Linux
   - [ ] Windows
   - [ ] MacOS

**Fixes:** Issue #1569

**Relates to:** Issue #1569

## Solution/Idea

Clean up `.kube/config` file while doing `crc stop` in order to not leave kubeconfig in an inconsistent state.

Currently after crc stop `.kube/config` file is left pointing to an outdated kube-context : 
```yaml
  current-context: default/api-crc-testing:6443/kubeadmin
```

This results in timeouts on the client side when user tries to access cluster using any kube client `oc`/`kubectl`:
```
crc : $ time oc get pods
E1015 15:46:38.452130   72163 memcache.go:265] couldn't get current server API group list: Get "https://api.crc.testing:6443/api?timeout=32s": context deadline exceeded - error from a previous attempt: read tcp 127.0.0.1:35058->127.0.0.1:6443: read: connection reset by peer
E1015 15:47:10.615173   72163 memcache.go:265] couldn't get current server API group list: client rate limiter Wait returned an error: context deadline exceeded - error from a previous attempt: read tcp 127.0.0.1:38388->127.0.0.1:6443: read: connection reset by peer
E1015 15:47:43.548507   72163 memcache.go:265] couldn't get current server API group list: client rate limiter Wait returned an error: context deadline exceeded - error from a previous attempt: read tcp 127.0.0.1:55098->127.0.0.1:6443: read: connection reset by peer
E1015 15:48:15.549643   72163 memcache.go:265] couldn't get current server API group list: Get "https://api.crc.testing:6443/api?timeout=32s": context deadline exceeded - error from a previous attempt: read tcp 127.0.0.1:35854->127.0.0.1:6443: read: connection reset by peer
E1015 15:48:47.550725   72163 memcache.go:265] couldn't get current server API group list: Get "https://api.crc.testing:6443/api?timeout=32s": context deadline exceeded - error from a previous attempt: read tcp 127.0.0.1:44620->127.0.0.1:6443: read: connection reset by peer
error: Get "https://api.crc.testing:6443/api?timeout=32s": context deadline exceeded - error from a previous attempt: read tcp 127.0.0.1:44620->127.0.0.1:6443: read: connection reset by peer

real    2m41.162s
user    0m0.150s
sys     0m0.059s

```
This pull request would clean up `.kube/config` to align crc behavior with minikube so that it fails fast now:
Trying to access cluster after crc stop
```
crc : $ time oc get pods
error: Missing or incomplete configuration info.  Please point to an existing, complete config file:


  1. Via the command-line flag --kubeconfig
  2. Via the KUBECONFIG environment variable
  3. In your home directory as ~/.kube/config

To view or setup config directly use the 'config' command.

real    0m0.126s
user    0m0.062s
sys     0m0.051s
```

## Proposed changes

Add a call to `cleanKubeconfig` in `stop.go` to clean up kubeconfig while stopping cluster. 

## Testing

In order to test this branch you need to follow these steps:
1. `make cross` to build `crc` binary
2. Set up a new cluster with created crc binary
    - `./out/linux-amd64/crc setup`
    - `./out/linux-amd64/crc start`
    - `./out/linux-amd64/crc stop`
3. Verify whether `.kube/config` is cleaned up after `crc stop`
```bash
crc : $ ./out/linux-amdcat ~/.kube/config 
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users: null
```
5. Verify whether when accessing stopped cluster with `kubectl` / `oc` it fails fast:
```
crc : $ ./out/linux-amd./out/linux-amd64/crc stop
INFO Stopping the instance, this may take a few minutes... 
Stopped the instance
crc : $ kubectl get opds
E1015 14:29:44.984352   64932 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E1015 14:29:44.984593   64932 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E1015 14:29:44.985937   64932 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E1015 14:29:44.986265   64932 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E1015 14:29:44.987715   64932 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
The connection to the server localhost:8080 was refused - did you specify the right host or port?

```
