### PR TITLE
bundle download & decompression: added Context argument

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -162,7 +163,7 @@ func downloadDataFiles(goos string, components []string, destDir string) ([]stri
 		if !shouldDownload(components, componentName) {
 			continue
 		}
-		filename, err := download.Download(dl.url, destDir, dl.permissions, nil)
+		filename, err := download.Download(context.TODO(), dl.url, destDir, dl.permissions, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compress/compress_test.go
+++ b/pkg/compress/compress_test.go
@@ -1,6 +1,7 @@
 package compress
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ func testCompress(t *testing.T, baseDir string) {
 
 	destDir := t.TempDir()
 
-	fileList, err := extract.Uncompress(testArchiveName, destDir)
+	fileList, err := extract.Uncompress(context.TODO(), testArchiveName, destDir)
 	require.NoError(t, err)
 
 	_, d := filepath.Split(baseDir)

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -121,7 +122,7 @@ func (c *Cache) cacheExecutable() error {
 	// Check the file is tarball or not
 	if isTarball(assetTmpFile) {
 		// Extract the tarball and put it the cache directory.
-		extractedFiles, err = extract.UncompressWithFilter(assetTmpFile, tmpDir,
+		extractedFiles, err = extract.UncompressWithFilter(context.TODO(), assetTmpFile, tmpDir,
 			func(filename string) bool { return filepath.Base(filename) == c.GetExecutableName() })
 		if err != nil {
 			return errors.Wrapf(err, "Cannot uncompress '%s'", assetTmpFile)
@@ -153,7 +154,7 @@ func (c *Cache) getExecutable(destDir string) (string, error) {
 	destPath := filepath.Join(destDir, archiveName)
 	err := embed.Extract(archiveName, destPath)
 	if err != nil {
-		return download.Download(c.archiveURL, destDir, 0600, nil)
+		return download.Download(context.TODO(), c.archiveURL, destDir, 0600, nil)
 	}
 
 	return destPath, err

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -124,7 +124,7 @@ func (bundle *CrcBundleInfo) createSymlinkOrCopyPodmanRemote(binDir string) erro
 	return bundle.copyExecutableFromBundle(binDir, PodmanExecutable, constants.PodmanRemoteExecutableName)
 }
 
-func (repo *Repository) Extract(path string) error {
+func (repo *Repository) Extract(ctx context.Context, path string) error {
 	bundleName := filepath.Base(path)
 
 	tmpDir := filepath.Join(repo.CacheDir, "tmp-extract")
@@ -133,7 +133,7 @@ func (repo *Repository) Extract(path string) error {
 		_ = os.RemoveAll(tmpDir) // clean up after using it
 	}()
 
-	if _, err := extract.Uncompress(path, tmpDir); err != nil {
+	if _, err := extract.Uncompress(ctx, path, tmpDir); err != nil {
 		return err
 	}
 
@@ -198,8 +198,8 @@ func Use(bundleName string) (*CrcBundleInfo, error) {
 	return defaultRepo.Use(bundleName)
 }
 
-func Extract(path string) (*CrcBundleInfo, error) {
-	if err := defaultRepo.Extract(path); err != nil {
+func Extract(ctx context.Context, path string) (*CrcBundleInfo, error) {
+	if err := defaultRepo.Extract(ctx, path); err != nil {
 		return nil, err
 	}
 	return defaultRepo.Get(filepath.Base(path))

--- a/pkg/crc/machine/bundle/repository_test.go
+++ b/pkg/crc/machine/bundle/repository_test.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -39,7 +40,7 @@ func TestExtract(t *testing.T) {
 		OcBinDir: ocBinDir,
 	}
 
-	assert.NoError(t, repo.Extract(filepath.Join("testdata", testBundle(t))))
+	assert.NoError(t, repo.Extract(context.TODO(), filepath.Join("testdata", testBundle(t))))
 
 	bundle, err := repo.Get(testBundle(t))
 	assert.NoError(t, err)

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -14,7 +14,7 @@ import (
 	"github.com/crc-org/crc/v2/pkg/crc/cluster"
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	crcerrors "github.com/crc-org/crc/v2/pkg/crc/errors"
-	logging "github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/bundle"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/config"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
@@ -41,7 +41,7 @@ import (
 
 const minimumMemoryForMonitoring = 14336
 
-func getCrcBundleInfo(preset crcPreset.Preset, bundleName, bundlePath string, enableBundleQuayFallback bool) (*bundle.CrcBundleInfo, error) {
+func getCrcBundleInfo(ctx context.Context, preset crcPreset.Preset, bundleName, bundlePath string, enableBundleQuayFallback bool) (*bundle.CrcBundleInfo, error) {
 	bundleInfo, err := bundle.Use(bundleName)
 	if err == nil {
 		logging.Infof("Loading bundle: %s...", bundleName)
@@ -49,12 +49,12 @@ func getCrcBundleInfo(preset crcPreset.Preset, bundleName, bundlePath string, en
 	}
 	logging.Debugf("Failed to load bundle %s: %v", bundleName, err)
 	logging.Infof("Downloading bundle: %s...", bundleName)
-	bundlePath, err = bundle.Download(preset, bundlePath, enableBundleQuayFallback)
+	bundlePath, err = bundle.Download(ctx, preset, bundlePath, enableBundleQuayFallback)
 	if err != nil {
 		return nil, err
 	}
 	logging.Infof("Extracting bundle: %s...", bundleName)
-	if _, err := bundle.Extract(bundlePath); err != nil {
+	if _, err := bundle.Extract(ctx, bundlePath); err != nil {
 		return nil, err
 	}
 	return bundle.Use(bundleName)
@@ -279,7 +279,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	bundleName := bundle.GetBundleNameWithoutExtension(bundle.GetBundleNameFromURI(startConfig.BundlePath))
-	crcBundleMetadata, err := getCrcBundleInfo(startConfig.Preset, bundleName, startConfig.BundlePath, startConfig.EnableBundleQuayFallback)
+	crcBundleMetadata, err := getCrcBundleInfo(ctx, startConfig.Preset, bundleName, startConfig.BundlePath, startConfig.EnableBundleQuayFallback)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting bundle metadata")
 	}

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -1,6 +1,7 @@
 package preflight
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -112,12 +113,12 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset, enableBundle
 		}
 		var err error
 		logging.Infof("Downloading bundle: %s...", bundlePath)
-		if bundlePath, err = bundle.Download(preset, bundlePath, enableBundleQuayFallback); err != nil {
+		if bundlePath, err = bundle.Download(context.TODO(), preset, bundlePath, enableBundleQuayFallback); err != nil {
 			return err
 		}
 
 		logging.Infof("Uncompressing %s", bundlePath)
-		if _, err := bundle.Extract(bundlePath); err != nil {
+		if _, err := bundle.Extract(context.TODO(), bundlePath); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return errors.Wrap(err, "Use `crc setup -b <bundle-path>`")
 			}

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -1,6 +1,7 @@
 package extract
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,7 +60,7 @@ func TestDotSlash(t *testing.T) {
 
 func TestZipSlip(t *testing.T) {
 	archiveName := filepath.Join("testdata", "zipslip.tar.gz")
-	_, err := Uncompress(archiveName, t.TempDir())
+	_, err := Uncompress(context.TODO(), archiveName, t.TempDir())
 	logging.Infof("error: %v", err)
 	assert.ErrorContains(t, err, "illegal file path")
 }
@@ -147,9 +148,9 @@ func testUncompress(t *testing.T, archiveName string, fileFilter func(string) bo
 	var fileList []string
 	var err error
 	if fileFilter != nil {
-		fileList, err = UncompressWithFilter(archiveName, destDir, fileFilter)
+		fileList, err = UncompressWithFilter(context.TODO(), archiveName, destDir, fileFilter)
 	} else {
-		fileList, err = Uncompress(archiveName, destDir)
+		fileList, err = Uncompress(context.TODO(), archiveName, destDir)
 	}
 	if err != nil {
 		return err

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -124,7 +125,7 @@ func DownloadBundle(bundleLocation string, bundleDestination string, bundleName 
 		return bundleDestination, err
 	}
 
-	filename, err := download.Download(bundleLocation, bundleDestination, 0644, nil)
+	filename, err := download.Download(context.TODO(), bundleLocation, bundleDestination, 0644, nil)
 	fmt.Printf("Downloading bundle from %s to %s.\n", bundleLocation, bundleDestination)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**Fixes:** Issue #3998 


## Solution/Idea

Added a `context.Context` argument to functions such as `bundle.Download` and `bundle.Extract` and others, to allow them to gracefully stop (if they are running) when the `stop` command is issued through the HTTP API.

Context support was added to regular HTTP bundle downloads as well as bundle pulls from container registries (it was supported by the used libraries). However, for the bundle decompression, this had to be done manually, since there is no library used.

If there is no context available to be used, `nil` or `context.Background()` can be used.


## Testing

```
$ curl --unix-socket ~/.crc/crc-http.sock  http://unix/api/start
# the start command hangs waiting for the bundle to be downloaded/decompressed

# in another terminal
$ curl --unix-socket ~/.crc/crc-http.sock  http://unix/api/stop
Instance is already stopped
```

## Caveat

The `stop` command ends with `Instance is already stopped` error (error code 500 is returned) since it is intended to stop the machine, which is (at that moment) not running. But it stops the download/decompression, which is desired.