### PR TITLE
test (e2e) : Add E2E test for java app deploy workflow using Eclipse JKube (#4397)

### DIFF
--- a/test/e2e/features/application_deployment.feature
+++ b/test/e2e/features/application_deployment.feature
@@ -1,0 +1,37 @@
+@story_application_deployment
+Feature: Application Deployment Test
+
+    User deploys a basic java application onto CRC cluster and expects that it's
+    deployed successfully and is accessible via route
+
+    Background:
+        Given ensuring CRC cluster is running
+        And ensuring oc command is available
+        And ensuring user is logged in succeeds
+
+    @testdata @linux @windows @darwin @cleanup @needs_namespace
+    Scenario: Deploy a java application using Eclipse JKube in pod and then verify it's health
+        When executing "oc new-project testproj" succeeds
+        And executing "oc create -f jkube-kubernetes-build-resources.yaml" succeeds
+        And executing "oc start-build jkube-application-deploy-buildconfig --follow" succeeds
+        And executing "oc rollout status -w dc/jkube-application-deploy-test --timeout=600s" succeeds
+        Then stdout should contain "successfully rolled out"
+        And executing "oc logs -lapp=jkube-application-deploy-test -f" succeeds
+        And executing "oc rollout status -w dc/quarkus --timeout=600s" succeeds
+        Then stdout should contain "successfully rolled out"
+        And executing "oc get build -lapp=quarkus" succeeds
+        Then stdout should contain "quarkus-s2i"
+        And executing "oc get buildconfig -lapp=quarkus" succeeds
+        Then stdout should contain "quarkus-s2i"
+        And executing "oc get imagestream -lapp=quarkus" succeeds
+        Then stdout should contain "quarkus"
+        And executing "oc get pods -lapp=quarkus" succeeds
+        Then stdout should contain "quarkus"
+        And stdout should contain "1/1     Running"
+        And executing "oc get svc -lapp=quarkus" succeeds
+        Then stdout should contain "quarkus"
+        And executing "oc get routes -lapp=quarkus" succeeds
+        Then stdout should contain "quarkus"
+        And with up to "4" retries with wait period of "1m" http response from "http://quarkus-testproj.apps-crc.testing" has status code "200"
+        Then executing "curl -s http://quarkus-testproj.apps-crc.testing" succeeds
+        And stdout should contain "{"applicationName":"JKube","message":"Subatomic JKube really whips the llama's ass!"}"

--- a/test/testdata/jkube-kubernetes-build-resources.yaml
+++ b/test/testdata/jkube-kubernetes-build-resources.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: jkube-application-deploy-role
+      labels:
+        app: jkube-application-deploy-test
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+          - pods
+          - pods/log
+          - services
+          - events
+        verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+          - patch
+      - apiGroups:
+          - apps.openshift.io
+        resources:
+          - deploymentconfigs
+        verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+      - apiGroups:
+          - build.openshift.io
+        resources:
+          - buildconfigs
+          - buildconfigs/instantiatebinary
+          - builds
+        verbs: ["*"]
+      - apiGroups:
+          - image.openshift.io
+        resources:
+          - imagestreams
+        verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+      - apiGroups:
+          - route.openshift.io
+        resources:
+          - routes
+        verbs:
+          - create
+          - get
+          - list
+          - update
+          - patch
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: jkube-application-deploy-binding
+      labels:
+        app: jkube-application-deploy-test
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: jkube-application-deploy-role
+    subjects:
+      - kind: ServiceAccount
+        name: jkube-application-deploy-sa
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: jkube-application-deploy-sa
+      labels:
+        app: jkube-application-deploy-test
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      labels:
+        app: jkube-application-deploy-test
+      name: jkube-application-deploy-is
+  - apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      name: jkube-application-deploy-buildconfig
+      labels:
+        app: jkube-application-deploy-test
+    spec:
+      output:
+        to:
+          kind: ImageStreamTag
+          name: jkube-application-deploy-is:latest
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM registry.access.redhat.com/ubi9/openjdk-17:1.20-2.1726695177
+          LABEL org.opencontainers.image.authors="CRCQE <devtools-crc-qe@redhat.com>"
+          USER root
+          # Install Git
+          RUN microdnf install -y git
+          RUN git clone https://github.com/eclipse-jkube/jkube.git
+          RUN chmod -R 775 /home/default/jkube
+          WORKDIR /home/default/jkube/quickstarts/maven/quarkus
+          RUN mkdir foo
+          ENTRYPOINT ["mvn", "package", "oc:build", "oc:resource", "oc:apply"]
+      strategy:
+        type: Docker
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: jkube-application-deploy-test
+      name: jkube-application-deploy-test
+    spec:
+      replicas: 1
+      selector:
+        app: jkube-application-deploy-test
+      template:
+        metadata:
+          labels:
+            app: jkube-application-deploy-test
+          name: jkube-application-deploy-test
+        spec:
+          containers:
+            - image: jkube-application-deploy-is:latest
+              imagePullPolicy: IfNotPresent
+              name: maven-pod
+              securityContext:
+                privileged: false
+          serviceAccount: jkube-application-deploy-sa
+      triggers:
+        - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - maven-pod
+            from:
+              kind: ImageStreamTag
+              name: jkube-application-deploy-is:latest
+          type: ImageChange


### PR DESCRIPTION
## Description

Fix #4397  

+ Added new test `application_deployment.feature` that would deploy a simple Quarkus application onto existing CRC cluster and verify that application is accessible via endpoint.
+ Test would be performing a java maven based build inside a container within a pod inside CRC VM. At the moment, we're building the container image and running the pod at the same time.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I tested my code on specified platforms
   - [x] Linux
   - [ ] Windows
   - [ ] MacOS


**Fixes:** Issue #4397

**Relates to:** Issue #4397, Issue https://github.com/eclipse-jkube/team/issues/32

## Solution/Idea

I added an E2E test that would clone the Eclipse JKube repository and deploy one of the quickstart [jkube@quickstarts/maven/quarkus](https://github.com/eclipse-jkube/jkube/tree/master/quickstarts/maven/quarkus) onto the deployed CRC cluster. I've used a simple Quarkus REST application, but it can be changed to something else as well.

## Proposed changes

Add a new E2E test that would verify deployment workflow of a simple Java application using Eclipse JKube

## Testing

This PR only adds an E2E test, in order to run it. Use the following command:
```shell
# Modify BUNDLE_LOCATION, PULL_SECRET_PATH and CRC_BINARY variables as per your environment
make e2e GODOG_OPTS="--godog.tags='@story_application_deployment'" BUNDLE_LOCATION="--bundle-location=xxxx" PULL_SECRET_PATH="--pull-secret-path=xxxx" CRC_BINARY="--crc-binary=xxxx"
```

```
Running e2e test in: /home/rokumar/go/src/github.com/crc-org/crc/test/e2e/out/test-run
Working directory set to: /home/rokumar/go/src/github.com/crc-org/crc/test/e2e/out/test-run
Expecting the bundle provided by the user
Using existing bundle: /home/rokumar/.crc/cache/crc_libvirt_4.17.0_amd64.crcbundle
Feature: Application Deployment Test
  User deploys a basic java application onto CRC cluster and expects that it's
  deployed successfully and is accessible via route

  Background:
    Given ensuring CRC cluster is running                                                                                                                             # testsuite.go:792 -> github.com/crc-org/crc/v2/test/e2e/testsuite.EnsureCRCIsRunning
    And ensuring oc command is available                                                                                                                              # testsuite.go:875 -> github.com/crc-org/crc/v2/test/e2e/testsuite.EnsureOCCommandIsAvailable
    And ensuring user is logged in succeeds                                                                                                                           # testsuite.go:842 -> github.com/crc-org/crc/v2/test/e2e/testsuite.EnsureUserIsLoggedIntoClusterSucceedsOrFails

  Scenario: Deploy a java application using Eclipse JKube in pod and then verify it's health                                                                          # features/application_deployment.feature:13
    When executing "oc new-project jkube-quarkus-app-deploy-flow-test" succeeds                                                                                       # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    And executing "oc create -f ../../../testdata/jkube-kubernetes-build-resources.yaml" succeeds                                                                     # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    And executing "oc start-build jkube-application-deploy-buildconfig --follow" succeeds                                                                             # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    And executing "oc rollout status -w dc/jkube-application-deploy-test --timeout=600s" succeeds                                                                     # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    Then stdout should contain "successfully rolled out"                                                                                                              # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And executing "oc logs -lapp=jkube-application-deploy-test -f" succeeds                                                                                           # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    And executing "oc rollout status -w dc/quarkus --namespace jkube-quarkus-app-deploy-flow-test --timeout=600s" succeeds                                            # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    Then stdout should contain "successfully rolled out"                                                                                                              # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And executing "oc get build -lapp=quarkus --namespace jkube-quarkus-app-deploy-flow-test" succeeds                                                                # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    Then stdout should contain "quarkus-s2i"                                                                                                                          # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And executing "oc get buildconfig -lapp=quarkus --namespace jkube-quarkus-app-deploy-flow-test" succeeds                                                          # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    Then stdout should contain "quarkus-s2i"                                                                                                                          # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And executing "oc get imagestream -lapp=quarkus --namespace jkube-quarkus-app-deploy-flow-test" succeeds                                                          # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    Then stdout should contain "quarkus"                                                                                                                              # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And executing "oc get pods -lapp=quarkus --namespace jkube-quarkus-app-deploy-flow-test" succeeds                                                                 # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    Then stdout should contain "quarkus"                                                                                                                              # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And stdout should contain "1/1     Running"                                                                                                                       # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And executing "oc get svc -lapp=quarkus --namespace jkube-quarkus-app-deploy-flow-test" succeeds                                                                  # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    Then stdout should contain "quarkus"                                                                                                                              # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And executing "oc get routes -lapp=quarkus --namespace jkube-quarkus-app-deploy-flow-test" succeeds                                                               # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    Then stdout should contain "quarkus"                                                                                                                              # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    And with up to "4" retries with wait period of "1m" http response from "http://quarkus-jkube-quarkus-app-deploy-flow-test.apps-crc.testing" has status code "200" # testsuite.go:560 -> github.com/crc-org/crc/v2/test/e2e/testsuite.CheckHTTPResponseWithRetry
    Then executing "curl -s http://quarkus-jkube-quarkus-app-deploy-flow-test.apps-crc.testing" succeeds                                                              # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
    And stdout should contain "{"applicationName":"JKube","message":"Subatomic JKube really whips the llama's ass!"}"                                                 # shell.go:301 -> github.com/crc-org/crc/v2/test/extended/util.CommandReturnShouldContain
    When executing "oc delete project jkube-quarkus-app-deploy-flow-test" succeeds                                                                                    # shell.go:245 -> github.com/crc-org/crc/v2/test/extended/util.ExecuteCommandSucceedsOrFails
Deleted CRC instance (if one existed).

1 scenarios (1 passed)
28 steps (28 passed)
33m33.762301105s
ok      github.com/crc-org/crc/v2/test/e2e      2013.779s

```

