### PR TITLE
fix (test/extended/util) : shell doesn't parse command output ending without newline (#4416)

### DIFF
--- a/test/extended/util/shell.go
+++ b/test/extended/util/shell.go
@@ -92,9 +92,19 @@ func (shell *ShellInstance) ScanPipe(scanner *bufio.Scanner, buffer *bytes.Buffe
 		}
 
 		if strings.Contains(str, exitCodeIdentifier) && !strings.Contains(str, shell.checkExitCodeCmd) {
-			exitCode := strings.Split(str, "=")[1]
+			lastCommandExitCodeStr := str
+			exitCodeIdentifierIndex := strings.Index(lastCommandExitCodeStr, exitCodeIdentifier)
+			if exitCodeIdentifierIndex > 0 {
+				lastCommandExitCodeStr = lastCommandExitCodeStr[exitCodeIdentifierIndex:]
+				str = str[0:exitCodeIdentifierIndex]
+			} else {
+				str = ""
+			}
+
+			exitCode := strings.Split(lastCommandExitCodeStr, "=")[1]
 			shell.exitCodeChannel <- exitCode
-		} else {
+		}
+		if len(str) > 0 {
 			buffer.WriteString(str + "\n")
 		}
 	}

--- a/test/extended/util/shell_test.go
+++ b/test/extended/util/shell_test.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testArguments = map[string]struct {
+	commandOutput          string
+	expectedParsedOutput   string
+	expectedParsedExitCode string
+}{
+	"When command output line contains additional output along with exit code, then parse output and exit code": {
+		"remainderOutputexitCodeOfLastCommandInShell=0", "remainderOutput\n", "0",
+	},
+	"When command output line contains only exit code, then parse exit code": {
+		"exitCodeOfLastCommandInShell=1", "", "1",
+	},
+}
+
+func TestScanPipeShouldCorrectlyParseOutputNotEndingWithNewLine(t *testing.T) {
+	for name, test := range testArguments {
+		t.Run(name, func(t *testing.T) {
+			// Given
+			shell.ConfigureTypeOfShell("bash")
+			shell.exitCodeChannel = make(chan string, 2)
+			scanner := bufio.NewScanner(strings.NewReader(test.commandOutput))
+			b := &bytes.Buffer{}
+			// When
+			shell.ScanPipe(scanner, b, "stdout")
+			// Then
+			assert.Equal(t, test.expectedParsedOutput, b.String())
+			assert.Equal(t, test.expectedParsedExitCode, <-shell.exitCodeChannel)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fix #4416 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I tested my code on specified platforms
   - [x] Linux
   - [ ] Windows
   - [ ] MacOS


**Fixes:** Issue #4416 
**Relates to:** Issue #4397

## Solution/Idea

ScanPipe should not assume that the entire line contains only the exit code token. It should extract the exit code token and write the remainder of the output to the output buffer.

## Proposed changes

Do not assume that the entire output line contains only the exit code token. Extract any prefix and write it to the output buffer.

## Testing

The test added in https://github.com/crc-org/crc/pull/4414 should pass once these changes get merged.
