### PR TITLE
[QE]bump qe images with deliverset v0.0.7

### DIFF
--- a/images/build-e2e/Containerfile
+++ b/images/build-e2e/Containerfile
@@ -9,7 +9,7 @@ WORKDIR /workspace
 COPY . .
 RUN GOARCH=${ARCH} GOOS=${OS} make build_e2e
 
-FROM quay.io/rhqp/deliverest:v0.0.6
+FROM quay.io/rhqp/deliverest:v0.0.7
 
 LABEL org.opencontainers.image.authors="CRCQE <devtools-crc-qe@redhat.com>"
 

--- a/images/build-integration/Containerfile
+++ b/images/build-integration/Containerfile
@@ -9,7 +9,7 @@ WORKDIR /workspace
 COPY . .
 RUN GOARCH=${ARCH} GOOS=${OS} make build_integration
 
-FROM quay.io/rhqp/deliverest:v0.0.6
+FROM quay.io/rhqp/deliverest:v0.0.7
 
 LABEL org.opencontainers.image.authors="CRCQE <devtools-crc-qe@redhat.com>"
 


### PR DESCRIPTION
fix https://github.com/devtools-qe-incubator/deliverest/issues/50
Also, new deliverset image supports connection via bastion, which required for machine from Testing Farm.   