### PR TITLE
refactor (crc/machine) : Provide a dummy implementation for virtualMachine object for writing unit tests (#4407)

### DIFF
--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -30,21 +30,30 @@ type Client interface {
 }
 
 type client struct {
-	name   string
-	debug  bool
-	config crcConfig.Storage
+	name           string
+	debug          bool
+	config         crcConfig.Storage
+	virtualMachine VirtualMachine
 
 	diskDetails *memoize.Memoizer
 	ramDetails  *memoize.Memoizer
 }
 
 func NewClient(name string, debug bool, config crcConfig.Storage) Client {
+	return newClientWithVirtualMachine(name, debug, config, nil)
+}
+
+// newClientWithVirtualMachine creates a Client instance with an overridden VirtualMachine implementation.
+// It would not create a new VirtualMachine object. This method is primarily created for usage in tests so
+// that we can pass a fake VirtualMachine implementation.
+func newClientWithVirtualMachine(name string, debug bool, config crcConfig.Storage, vm VirtualMachine) Client {
 	return &client{
-		name:        name,
-		debug:       debug,
-		config:      config,
-		diskDetails: memoize.NewMemoizer(time.Minute, 5*time.Minute),
-		ramDetails:  memoize.NewMemoizer(30*time.Second, 2*time.Minute),
+		name:           name,
+		debug:          debug,
+		config:         config,
+		diskDetails:    memoize.NewMemoizer(time.Minute, 5*time.Minute),
+		ramDetails:     memoize.NewMemoizer(30*time.Second, 2*time.Minute),
+		virtualMachine: vm,
 	}
 }
 

--- a/pkg/crc/machine/console.go
+++ b/pkg/crc/machine/console.go
@@ -21,7 +21,7 @@ func (client *client) GetConsoleURL() (*types.ConsoleResult, error) {
 		return nil, errors.Wrap(err, "Error getting the state for virtual machine")
 	}
 
-	clusterConfig, err := getClusterConfig(vm.bundle)
+	clusterConfig, err := getClusterConfig(vm.Bundle())
 	if err != nil {
 		return nil, errors.Wrap(err, "Error loading cluster configuration")
 	}

--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -22,7 +22,7 @@ func (client *client) Delete() error {
 
 	// In case usermode networking make sure all the port bind on host should be released
 	if client.useVSock() {
-		if err := unexposePorts(); err != nil {
+		if err := vm.UnExposePorts(); err != nil {
 			return err
 		}
 	}

--- a/pkg/crc/machine/fakemachine/virtualmachine.go
+++ b/pkg/crc/machine/fakemachine/virtualmachine.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/crc-org/crc/v2/pkg/crc/machine/bundle"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
+	crcPreset "github.com/crc-org/crc/v2/pkg/crc/preset"
 	"github.com/crc-org/crc/v2/pkg/crc/ssh"
 	"github.com/crc-org/crc/v2/pkg/libmachine"
 	libmachinehost "github.com/crc-org/crc/v2/pkg/libmachine/host"
@@ -39,6 +40,7 @@ type FakeVirtualMachine struct {
 	FailingStop   bool
 	FailingState  bool
 	FakeSSHClient *FakeSSHClient
+	PortsExposed  bool
 }
 
 func (vm *FakeVirtualMachine) Close() error {
@@ -100,6 +102,16 @@ func (vm *FakeVirtualMachine) Host() *libmachinehost.Host {
 
 func (vm *FakeVirtualMachine) Kill() error {
 	panic("not implemented")
+}
+
+func (vm *FakeVirtualMachine) ExposePorts(_ crcPreset.Preset, _, _ uint) error {
+	vm.PortsExposed = true
+	return nil
+}
+
+func (vm *FakeVirtualMachine) UnExposePorts() error {
+	vm.PortsExposed = false
+	return nil
 }
 
 func NewFakeVirtualMachine(failingStop bool, failingState bool) *FakeVirtualMachine {

--- a/pkg/crc/machine/fakemachine/virtualmachine.go
+++ b/pkg/crc/machine/fakemachine/virtualmachine.go
@@ -1,0 +1,114 @@
+package fakemachine
+
+import (
+	"errors"
+
+	"github.com/crc-org/crc/v2/pkg/crc/machine/bundle"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
+	"github.com/crc-org/crc/v2/pkg/crc/ssh"
+	"github.com/crc-org/crc/v2/pkg/libmachine"
+	libmachinehost "github.com/crc-org/crc/v2/pkg/libmachine/host"
+	"github.com/crc-org/machine/libmachine/drivers"
+)
+
+type FakeSSHClient struct {
+	LastExecutedCommand string
+	IsSSHClientClosed   bool
+}
+
+func (client *FakeSSHClient) Run(command string) ([]byte, []byte, error) {
+	client.LastExecutedCommand = command
+	return []byte("test"), []byte("test"), nil
+}
+
+func (client *FakeSSHClient) Close() {
+	client.IsSSHClientClosed = true
+}
+
+func NewFakeSSHClient() *FakeSSHClient {
+	return &FakeSSHClient{
+		LastExecutedCommand: "",
+		IsSSHClientClosed:   false,
+	}
+}
+
+type FakeVirtualMachine struct {
+	IsClosed      bool
+	IsRemoved     bool
+	IsStopped     bool
+	FailingStop   bool
+	FailingState  bool
+	FakeSSHClient *FakeSSHClient
+}
+
+func (vm *FakeVirtualMachine) Close() error {
+	vm.IsClosed = true
+	return nil
+}
+
+func (vm *FakeVirtualMachine) Remove() error {
+	vm.IsRemoved = true
+	return nil
+}
+
+func (vm *FakeVirtualMachine) Stop() error {
+	if vm.FailingStop {
+		return errors.New("stopping failed")
+	}
+	vm.IsStopped = true
+	return nil
+}
+
+func (vm *FakeVirtualMachine) State() (state.State, error) {
+	if vm.FailingState {
+		return state.Error, errors.New("unable to get virtual machine state")
+	}
+	if vm.IsClosed || vm.IsStopped {
+		return state.Stopped, nil
+	}
+	return state.Running, nil
+}
+
+func (vm *FakeVirtualMachine) IP() (string, error) {
+	panic("not implemented")
+}
+
+func (vm *FakeVirtualMachine) SSHPort() int {
+	panic("not implemented")
+}
+
+func (vm *FakeVirtualMachine) SSHRunner() (*ssh.Runner, error) {
+	runner, err := ssh.CreateRunnerWithClient(vm.FakeSSHClient)
+	return runner, err
+}
+
+func (vm *FakeVirtualMachine) Bundle() *bundle.CrcBundleInfo {
+	panic("not implemented")
+}
+
+func (vm *FakeVirtualMachine) Driver() drivers.Driver {
+	panic("not implemented")
+}
+
+func (vm *FakeVirtualMachine) API() libmachine.API {
+	panic("not implemented")
+}
+
+func (vm *FakeVirtualMachine) Host() *libmachinehost.Host {
+	panic("not implemented")
+}
+
+func (vm *FakeVirtualMachine) Kill() error {
+	panic("not implemented")
+}
+
+func NewFakeVirtualMachine(failingStop bool, failingState bool) *FakeVirtualMachine {
+	return &FakeVirtualMachine{
+		FakeSSHClient: NewFakeSSHClient(),
+		IsStopped:     false,
+		IsRemoved:     false,
+		IsClosed:      false,
+		FailingStop:   failingStop,
+		FailingState:  failingState,
+	}
+}

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -111,7 +111,7 @@ func loadVM(client *client) (*bundle.CrcBundleInfo, *crcssh.Runner, error) {
 	}
 	defer vm.Close()
 
-	currentState, err := vm.Driver.GetState()
+	currentState, err := vm.Driver().GetState()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Cannot get machine state")
 	}
@@ -124,5 +124,5 @@ func loadVM(client *client) (*bundle.CrcBundleInfo, *crcssh.Runner, error) {
 		return nil, nil, errors.Wrap(err, "Error creating the ssh client")
 	}
 
-	return vm.bundle, sshRunner, nil
+	return vm.Bundle(), sshRunner, nil
 }

--- a/pkg/crc/machine/ip.go
+++ b/pkg/crc/machine/ip.go
@@ -21,6 +21,6 @@ func (client *client) ConnectionDetails() (*types.ConnectionDetails, error) {
 		IP:          ip,
 		SSHPort:     vm.SSHPort(),
 		SSHUsername: constants.DefaultSSHUser,
-		SSHKeys:     []string{constants.GetPrivateKeyPath(), constants.GetECDSAPrivateKeyPath(), vm.bundle.GetSSHKeyPath()},
+		SSHKeys:     []string{constants.GetPrivateKeyPath(), constants.GetECDSAPrivateKeyPath(), vm.Bundle().GetSSHKeyPath()},
 	}, nil
 }

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -374,7 +374,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	logging.Infof("Starting CRC VM for %s %s...", startConfig.Preset, vm.Bundle().GetVersion())
 
 	if client.useVSock() {
-		if err := exposePorts(startConfig.Preset, startConfig.IngressHTTPPort, startConfig.IngressHTTPSPort); err != nil {
+		if err := vm.ExposePorts(startConfig.Preset, startConfig.IngressHTTPPort, startConfig.IngressHTTPSPort); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -634,7 +634,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 }
 
 func (client *client) IsRunning() (bool, error) {
-	vm, err := loadVirtualMachine(client.name, client.useVSock())
+	vm, err := loadVirtualMachineLazily(client.virtualMachine, client.name, client.useVSock())
 	if err != nil {
 		return false, errors.Wrap(err, "Cannot load machine")
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -62,10 +62,10 @@ func getCrcBundleInfo(ctx context.Context, preset crcPreset.Preset, bundleName, 
 	return bundle.Use(bundleName)
 }
 
-func (client *client) updateVMConfig(startConfig types.StartConfig, vm *virtualMachine) error {
+func (client *client) updateVMConfig(startConfig types.StartConfig, vm VirtualMachine) error {
 	/* Memory */
 	logging.Debugf("Updating CRC VM configuration")
-	if err := setMemory(vm.Host, startConfig.Memory); err != nil {
+	if err := setMemory(vm.Host(), startConfig.Memory); err != nil {
 		logging.Debugf("Failed to update CRC VM configuration: %v", err)
 		if err == drivers.ErrNotImplemented {
 			logging.Warn("Memory configuration change has been ignored as the machine driver does not support it")
@@ -73,7 +73,7 @@ func (client *client) updateVMConfig(startConfig types.StartConfig, vm *virtualM
 			return err
 		}
 	}
-	if err := setVcpus(vm.Host, startConfig.CPUs); err != nil {
+	if err := setVcpus(vm.Host(), startConfig.CPUs); err != nil {
 		logging.Debugf("Failed to update CRC VM configuration: %v", err)
 		if err == drivers.ErrNotImplemented {
 			logging.Warn("CPU configuration change has been ignored as the machine driver does not support it")
@@ -81,13 +81,13 @@ func (client *client) updateVMConfig(startConfig types.StartConfig, vm *virtualM
 			return err
 		}
 	}
-	if err := vm.api.Save(vm.Host); err != nil {
+	if err := vm.API().Save(vm.Host()); err != nil {
 		return err
 	}
 
 	/* Disk size */
 	if startConfig.DiskSize != constants.DefaultDiskSize {
-		if err := setDiskSize(vm.Host, startConfig.DiskSize); err != nil {
+		if err := setDiskSize(vm.Host(), startConfig.DiskSize); err != nil {
 			logging.Debugf("Failed to update CRC disk configuration: %v", err)
 			if err == drivers.ErrNotImplemented {
 				logging.Warn("Disk size configuration change has been ignored as the machine driver does not support it")
@@ -95,7 +95,7 @@ func (client *client) updateVMConfig(startConfig types.StartConfig, vm *virtualM
 				return err
 			}
 		}
-		if err := vm.api.Save(vm.Host); err != nil {
+		if err := vm.API().Save(vm.Host()); err != nil {
 			return err
 		}
 	}
@@ -103,7 +103,7 @@ func (client *client) updateVMConfig(startConfig types.StartConfig, vm *virtualM
 	// we want to set the shared dir password on-the-fly to be used
 	// we do not want this value to be persisted to disk
 	if startConfig.SharedDirPassword != "" {
-		if err := setSharedDirPassword(vm.Host, startConfig.SharedDirPassword); err != nil {
+		if err := setSharedDirPassword(vm.Host(), startConfig.SharedDirPassword); err != nil {
 			return fmt.Errorf("Failed to set shared dir password: %w", err)
 		}
 	}
@@ -208,9 +208,9 @@ func growLVForMicroshift(sshRunner crcos.CommandRunner, lvFullName string, rootP
 	return nil
 }
 
-func configureSharedDirs(vm *virtualMachine, sshRunner *crcssh.Runner) error {
+func configureSharedDirs(vm VirtualMachine, sshRunner *crcssh.Runner) error {
 	logging.Debugf("Configuring shared directories")
-	sharedDirs, err := vm.Driver.GetSharedDirs()
+	sharedDirs, err := vm.Driver().GetSharedDirs()
 	if err != nil {
 		// the libvirt machine driver uses net/rpc, which wraps errors
 		// in rpc.ServerError, but without using golang 1.13 error
@@ -340,7 +340,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 	defer vm.Close()
 
-	currentBundleName := vm.bundle.GetBundleName()
+	currentBundleName := vm.Bundle().GetBundleName()
 	if currentBundleName != bundleName {
 		logging.Debugf("Bundle '%s' was requested, but the existing VM is using '%s'",
 			bundleName, currentBundleName)
@@ -353,8 +353,8 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Error getting the machine state")
 	}
 	if vmState == state.Running {
-		logging.Infof("A CRC VM for %s %s is already running", startConfig.Preset.ForDisplay(), vm.bundle.GetVersion())
-		clusterConfig, err := getClusterConfig(vm.bundle)
+		logging.Infof("A CRC VM for %s %s is already running", startConfig.Preset.ForDisplay(), vm.Bundle().GetVersion())
+		clusterConfig, err := getClusterConfig(vm.Bundle())
 		if err != nil {
 			return nil, errors.Wrap(err, "Cannot create cluster configuration")
 		}
@@ -371,7 +371,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, err
 	}
 
-	logging.Infof("Starting CRC VM for %s %s...", startConfig.Preset, vm.bundle.GetVersion())
+	logging.Infof("Starting CRC VM for %s %s...", startConfig.Preset, vm.Bundle().GetVersion())
 
 	if client.useVSock() {
 		if err := exposePorts(startConfig.Preset, startConfig.IngressHTTPPort, startConfig.IngressHTTPSPort); err != nil {
@@ -466,7 +466,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Failed to change permissions to root podman socket")
 	}
 
-	proxyConfig, err := getProxyConfig(vm.bundle)
+	proxyConfig, err := getProxyConfig(vm.Bundle())
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting proxy configuration")
 	}
@@ -481,7 +481,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		SSHRunner: sshRunner,
 		IP:        instanceIP,
 		// TODO: should be more finegrained
-		BundleMetadata: *vm.bundle,
+		BundleMetadata: *vm.Bundle(),
 		NetworkMode:    client.networkMode(),
 	}
 
@@ -511,7 +511,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		logging.Warn(fmt.Sprintf("Failed to query DNS from host: %v", err))
 	}
 
-	if vm.bundle.IsMicroshift() {
+	if vm.Bundle().IsMicroshift() {
 		// **************************
 		//  END OF MICROSHIFT START CODE
 		// **************************
@@ -556,7 +556,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	ocConfig := oc.UseOCWithSSH(sshRunner)
 
 	if err := cluster.ApproveCSRAndWaitForCertsRenewal(ctx, sshRunner, ocConfig, certsExpired[cluster.KubeletClientCert], certsExpired[cluster.KubeletServerCert], certsExpired[cluster.AggregatorClientCert]); err != nil {
-		logBundleDate(vm.bundle)
+		logBundleDate(vm.Bundle())
 		return nil, errors.Wrap(err, "Failed to renew TLS certificates: please check if a newer CRC release is available")
 	}
 
@@ -605,7 +605,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		}
 	}
 
-	if err := updateKubeconfig(ctx, ocConfig, sshRunner, vm.bundle.GetKubeConfigPath()); err != nil {
+	if err := updateKubeconfig(ctx, ocConfig, sshRunner, vm.Bundle().GetKubeConfigPath()); err != nil {
 		return nil, errors.Wrap(err, "Failed to update kubeconfig file")
 	}
 
@@ -616,7 +616,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 
 	waitForProxyPropagation(ctx, ocConfig, proxyConfig)
 
-	clusterConfig, err := getClusterConfig(vm.bundle)
+	clusterConfig, err := getClusterConfig(vm.Bundle())
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot get cluster configuration")
 	}
@@ -703,17 +703,17 @@ func createHost(machineConfig config.MachineConfig, preset crcPreset.Preset) err
 	return nil
 }
 
-func startHost(ctx context.Context, vm *virtualMachine) error {
-	if err := vm.Driver.Start(); err != nil {
+func startHost(ctx context.Context, vm VirtualMachine) error {
+	if err := vm.Driver().Start(); err != nil {
 		return fmt.Errorf("Error in driver during machine start: %s", err)
 	}
 
-	if err := vm.api.Save(vm.Host); err != nil {
+	if err := vm.API().Save(vm.Host()); err != nil {
 		return fmt.Errorf("Error saving virtual machine to store after attempting creation: %s", err)
 	}
 
 	logging.Debug("Waiting for machine to be running, this may take a few minutes...")
-	if err := crcerrors.Retry(ctx, 3*time.Minute, host.MachineInState(vm.Driver, libmachinestate.Running), 3*time.Second); err != nil {
+	if err := crcerrors.Retry(ctx, 3*time.Minute, host.MachineInState(vm.Driver(), libmachinestate.Running), 3*time.Second); err != nil {
 		return fmt.Errorf("Error waiting for machine to be running: %s", err)
 	}
 

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -50,11 +50,11 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	diskSize, diskUse := client.getDiskDetails(vm)
 	pvSize, pvUse := client.getPVCSize(vm)
 	var openShiftStatusSupplier = getOpenShiftStatus
-	if vm.bundle.IsMicroshift() {
+	if vm.Bundle().IsMicroshift() {
 		openShiftStatusSupplier = getMicroShiftStatus
 	}
 
-	return createClusterStatusResult(vmStatus, vm.bundle.GetBundleType(), vm.bundle.GetVersion(), ip, diskSize, diskUse, ramSize, ramUse, pvUse, pvSize, openShiftStatusSupplier)
+	return createClusterStatusResult(vmStatus, vm.Bundle().GetBundleType(), vm.Bundle().GetVersion(), ip, diskSize, diskUse, ramSize, ramUse, pvUse, pvSize, openShiftStatusSupplier)
 }
 
 func createClusterStatusResult(vmStatus state.State, bundleType preset.Preset, vmBundleVersion, vmIP string, diskSize, diskUse, ramSize, ramUse strongunits.B, pvUse, pvSize strongunits.B, openShiftStatusSupplier openShiftStatusSupplierFunc) (*types.ClusterStatusResult, error) {
@@ -127,7 +127,7 @@ func (client *client) GetClusterLoad() (*types.ClusterLoadResult, error) {
 	}, nil
 }
 
-func (client *client) getDiskDetails(vm *virtualMachine) (strongunits.B, strongunits.B) {
+func (client *client) getDiskDetails(vm VirtualMachine) (strongunits.B, strongunits.B) {
 	disk, err, _ := client.diskDetails.Memoize("disks", func() (interface{}, error) {
 		sshRunner, err := vm.SSHRunner()
 		if err != nil {
@@ -177,7 +177,7 @@ func getStatus(status *cluster.Status) types.OpenshiftStatus {
 	return types.OpenshiftStopped
 }
 
-func (client *client) getRAMStatus(vm *virtualMachine) (strongunits.B, strongunits.B) {
+func (client *client) getRAMStatus(vm VirtualMachine) (strongunits.B, strongunits.B) {
 	ram, err, _ := client.ramDetails.Memoize("ram", func() (interface{}, error) {
 		sshRunner, err := vm.SSHRunner()
 		if err != nil {
@@ -200,7 +200,7 @@ func (client *client) getRAMStatus(vm *virtualMachine) (strongunits.B, stronguni
 	return strongunits.B(used), strongunits.B(total)
 }
 
-func (client *client) getCPUStatus(vm *virtualMachine) []int64 {
+func (client *client) getCPUStatus(vm VirtualMachine) []int64 {
 	sshRunner, err := vm.SSHRunner()
 	if err != nil {
 		logging.Debugf("Cannot get SSH runner: %v", err)
@@ -218,7 +218,7 @@ func (client *client) getCPUStatus(vm *virtualMachine) []int64 {
 
 }
 
-func (client *client) getPVCSize(vm *virtualMachine) (strongunits.B, strongunits.B) {
+func (client *client) getPVCSize(vm VirtualMachine) (strongunits.B, strongunits.B) {
 	sshRunner, err := vm.SSHRunner()
 	if err != nil {
 		logging.Debugf("Cannot get SSH runner: %v", err)

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -45,7 +45,7 @@ func (client *client) Stop() (state.State, error) {
 	}
 	// In case usermode networking make sure all the port bind on host should be released
 	if client.useVSock() {
-		return status, unexposePorts()
+		return status, vm.UnExposePorts()
 	}
 	return status, nil
 }

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -20,7 +20,7 @@ func (client *client) Stop() (state.State, error) {
 	if running, _ := client.IsRunning(); !running {
 		return state.Error, errors.New("Instance is already stopped")
 	}
-	vm, err := loadVirtualMachine(client.name, client.useVSock())
+	vm, err := loadVirtualMachineLazily(client.virtualMachine, client.name, client.useVSock())
 	if err != nil {
 		return state.Error, errors.Wrap(err, "Cannot load machine")
 	}

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -54,7 +54,7 @@ func (client *client) Stop() (state.State, error) {
 // is fixed. We should also ignore the openshift specific errors because stop
 // operation shouldn't depend on the openshift side. Without this graceful shutdown
 // takes around 6-7 mins.
-func stopAllContainers(vm *virtualMachine) error {
+func stopAllContainers(vm VirtualMachine) error {
 	logging.Info("Stopping kubelet and all containers...")
 	sshRunner, err := vm.SSHRunner()
 	if err != nil {

--- a/pkg/crc/machine/stop_test.go
+++ b/pkg/crc/machine/stop_test.go
@@ -6,10 +6,70 @@ import (
 	"testing"
 
 	crcConfig "github.com/crc-org/crc/v2/pkg/crc/config"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/fakemachine"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
 	crcOs "github.com/crc-org/crc/v2/pkg/os"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestStop_WhenVMRunning_ThenShouldStopVirtualMachine(t *testing.T) {
+	// Given
+	crcConfigStorage := crcConfig.New(crcConfig.NewEmptyInMemoryStorage(), crcConfig.NewEmptyInMemorySecretStorage())
+	crcConfigStorage.AddSetting(crcConfig.NetworkMode, "user", crcConfig.ValidateBool, crcConfig.SuccessfullyApplied,
+		"network-mode")
+	_, err := crcConfigStorage.Set(crcConfig.NetworkMode, "true")
+	assert.NoError(t, err)
+	virtualMachine := fakemachine.NewFakeVirtualMachine(false, false)
+	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, virtualMachine)
+
+	// When
+	clusterState, stopErr := client.Stop()
+
+	// Then
+	assert.NoError(t, stopErr)
+	assert.Equal(t, clusterState, state.Stopped)
+	assert.Equal(t, virtualMachine.IsStopped, true)
+	assert.Equal(t, virtualMachine.FakeSSHClient.LastExecutedCommand, "sudo -- sh -c 'crictl stop $(crictl ps -q)'")
+	assert.Equal(t, virtualMachine.FakeSSHClient.IsSSHClientClosed, true)
+}
+
+func TestStop_WhenStopVmFailed_ThenErrorThrown(t *testing.T) {
+	// Given
+	crcConfigStorage := crcConfig.New(crcConfig.NewEmptyInMemoryStorage(), crcConfig.NewEmptyInMemorySecretStorage())
+	crcConfigStorage.AddSetting(crcConfig.NetworkMode, "user", crcConfig.ValidateBool, crcConfig.SuccessfullyApplied,
+		"network-mode")
+	_, err := crcConfigStorage.Set(crcConfig.NetworkMode, "true")
+	assert.NoError(t, err)
+	virtualMachine := fakemachine.NewFakeVirtualMachine(true, false)
+	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, virtualMachine)
+
+	// When
+	_, stopErr := client.Stop()
+
+	// Then
+	assert.ErrorContains(t, stopErr, "Cannot stop machine: stopping failed")
+}
+
+func TestStop_WhenVMAlreadyStopped_ThenThrowError(t *testing.T) {
+	// Given
+	crcConfigStorage := crcConfig.New(crcConfig.NewEmptyInMemoryStorage(), crcConfig.NewEmptyInMemorySecretStorage())
+	crcConfigStorage.AddSetting(crcConfig.NetworkMode, "user", crcConfig.ValidateBool, crcConfig.SuccessfullyApplied,
+		"network-mode")
+	_, err := crcConfigStorage.Set(crcConfig.NetworkMode, "true")
+	assert.NoError(t, err)
+	virtualMachine := fakemachine.NewFakeVirtualMachine(false, false)
+	err = virtualMachine.Stop()
+	assert.NoError(t, err)
+	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, virtualMachine)
+
+	// When
+	clusterState, stopErr := client.Stop()
+
+	// Then
+	assert.EqualError(t, stopErr, "Instance is already stopped")
+	assert.Equal(t, clusterState, state.Error)
+	assert.Equal(t, virtualMachine.IsStopped, true)
+}
 
 func TestClient_WhenStopInvokedWithNonExistentVM_ThenThrowError(t *testing.T) {
 	// Given

--- a/pkg/crc/machine/stop_test.go
+++ b/pkg/crc/machine/stop_test.go
@@ -19,8 +19,8 @@ func TestStop_WhenVMRunning_ThenShouldStopVirtualMachine(t *testing.T) {
 		"network-mode")
 	_, err := crcConfigStorage.Set(crcConfig.NetworkMode, "true")
 	assert.NoError(t, err)
-	virtualMachine := fakemachine.NewFakeVirtualMachine(false, false)
-	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, virtualMachine)
+	fakeVirtualMachine := fakemachine.NewFakeVirtualMachine(false, false)
+	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, fakeVirtualMachine)
 
 	// When
 	clusterState, stopErr := client.Stop()
@@ -28,9 +28,9 @@ func TestStop_WhenVMRunning_ThenShouldStopVirtualMachine(t *testing.T) {
 	// Then
 	assert.NoError(t, stopErr)
 	assert.Equal(t, clusterState, state.Stopped)
-	assert.Equal(t, virtualMachine.IsStopped, true)
-	assert.Equal(t, virtualMachine.FakeSSHClient.LastExecutedCommand, "sudo -- sh -c 'crictl stop $(crictl ps -q)'")
-	assert.Equal(t, virtualMachine.FakeSSHClient.IsSSHClientClosed, true)
+	assert.Equal(t, fakeVirtualMachine.IsStopped, true)
+	assert.Equal(t, fakeVirtualMachine.FakeSSHClient.IsSSHClientClosed, true)
+	assert.Equal(t, fakeVirtualMachine.PortsExposed, false)
 }
 
 func TestStop_WhenStopVmFailed_ThenErrorThrown(t *testing.T) {
@@ -40,8 +40,8 @@ func TestStop_WhenStopVmFailed_ThenErrorThrown(t *testing.T) {
 		"network-mode")
 	_, err := crcConfigStorage.Set(crcConfig.NetworkMode, "true")
 	assert.NoError(t, err)
-	virtualMachine := fakemachine.NewFakeVirtualMachine(true, false)
-	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, virtualMachine)
+	fakeVirtualMachine := fakemachine.NewFakeVirtualMachine(true, false)
+	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, fakeVirtualMachine)
 
 	// When
 	_, stopErr := client.Stop()
@@ -57,10 +57,10 @@ func TestStop_WhenVMAlreadyStopped_ThenThrowError(t *testing.T) {
 		"network-mode")
 	_, err := crcConfigStorage.Set(crcConfig.NetworkMode, "true")
 	assert.NoError(t, err)
-	virtualMachine := fakemachine.NewFakeVirtualMachine(false, false)
-	err = virtualMachine.Stop()
+	fakeVirtualMachine := fakemachine.NewFakeVirtualMachine(false, false)
+	err = fakeVirtualMachine.Stop()
 	assert.NoError(t, err)
-	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, virtualMachine)
+	client := newClientWithVirtualMachine("fake-virtual-machine", false, crcConfigStorage, fakeVirtualMachine)
 
 	// When
 	clusterState, stopErr := client.Stop()
@@ -68,7 +68,7 @@ func TestStop_WhenVMAlreadyStopped_ThenThrowError(t *testing.T) {
 	// Then
 	assert.EqualError(t, stopErr, "Instance is already stopped")
 	assert.Equal(t, clusterState, state.Error)
-	assert.Equal(t, virtualMachine.IsStopped, true)
+	assert.Equal(t, fakeVirtualMachine.IsStopped, true)
 }
 
 func TestClient_WhenStopInvokedWithNonExistentVM_ThenThrowError(t *testing.T) {

--- a/pkg/crc/machine/virtualmachine.go
+++ b/pkg/crc/machine/virtualmachine.go
@@ -51,6 +51,13 @@ func (err *MissingHostError) Error() string {
 
 var errInvalidBundleMetadata = errors.New("Error loading bundle metadata")
 
+func loadVirtualMachineLazily(vm VirtualMachine, name string, useVSock bool) (VirtualMachine, error) {
+	if vm != nil {
+		return vm, nil
+	}
+	return loadVirtualMachine(name, useVSock)
+}
+
 func loadVirtualMachine(name string, useVSock bool) (VirtualMachine, error) {
 	apiClient := libmachine.NewClient(constants.MachineBaseDir)
 	exists, err := apiClient.Exists(name)

--- a/pkg/crc/machine/virtualmachine.go
+++ b/pkg/crc/machine/virtualmachine.go
@@ -3,6 +3,8 @@ package machine
 import (
 	"fmt"
 
+	crcPreset "github.com/crc-org/crc/v2/pkg/crc/preset"
+
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/bundle"
@@ -27,6 +29,8 @@ type VirtualMachine interface {
 	Driver() drivers.Driver
 	API() libmachine.API
 	Host() *libmachinehost.Host
+	ExposePorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint) error
+	UnExposePorts() error
 }
 
 type virtualMachine struct {

--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func exposePorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint) error {
+func (vm *virtualMachine) ExposePorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint) error {
 	portsToExpose := vsockPorts(preset, ingressHTTPPort, ingressHTTPSPort)
 	daemonClient := daemonclient.New()
 	alreadyOpenedPorts, err := listOpenPorts(daemonClient)
@@ -47,7 +47,7 @@ func isOpened(exposed []types.ExposeRequest, port types.ExposeRequest) bool {
 	return false
 }
 
-func unexposePorts() error {
+func (vm *virtualMachine) UnExposePorts() error {
 	var mErr crcErrors.MultiError
 	daemonClient := daemonclient.New()
 	alreadyOpenedPorts, err := listOpenPorts(daemonClient)

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -27,6 +27,12 @@ func CreateRunner(ip string, port int, privateKeys ...string) (*Runner, error) {
 	}, nil
 }
 
+func CreateRunnerWithClient(client Client) (*Runner, error) {
+	return &Runner{
+		client: client,
+	}, nil
+}
+
 func (runner *Runner) Close() {
 	runner.client.Close()
 }


### PR DESCRIPTION
## Description


**Fixes:** Issue #4407

**Relates to:** Issue #4407, PR https://github.com/crc-org/crc/pull/4400

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I tested my code on specified platforms
   - [x] Linux
   - [ ] Windows
   - [ ] MacOS

## Solution/Idea

+ Add a VirtualMachine interface and make the CRC `machine` package client use the VirtualMachine interface instead of a concrete implementation. This way we can inject a dummy test FakeVirtualMachine implementation into client tests that can ease writing tests for this package.
  - Add some additional methods in VirtualMachine interface so that we can replace direct usage of struct fields with interface methods
    - `Bundle()`
    - `Driver()`
    - `API()`
    - `GetHost()`
+ Add a new field `VirtualMachine` in the client so we can avoid creating it if it's already created.
+ Introduce a new constructor method `newClientWithVirtualMachine` in machine client that would have an additional VirtualMachine argument, this would be kept package private so that it's used only by tests in the same package.
+ Add FakeVirtualMachine sturct in `fakemachine` for adding dummy implementation for `VirtualMachine` interface. Currently, I've only completed methods used by `stop_test.go`, I'll add more in small increments as I get more familiar with the project. 



## Proposed changes
- Add new `VirtualMachine` interface and make client member functions use it instead of `virtualMachine` struct.
- Add new constructor in machine client to be able to override `VirtualMachine` implementation from tests
- These files have been modified to use `VirtualMachine` interface instead of `virtualMachine` struct (these changes are only related to changing use of `virtualMachine` struct to `VirtualMachine` interface:
  - `pkg/crc/machine/ip.go`
  - `pkg/crc/machine/poweroff.go`
  - `pkg/crc/machine/start.go`
  - `pkg/crc/machine/status.go`
  - `pkg/crc/machine/stop.go`


## Testing

It's a small refactor. I've only run E2E tests locally to verify if these changes don't introduce any kind of regression.
