### PR TITLE
Ignore virtualization check for arm64 for Linux platform

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -45,6 +46,10 @@ func checkRunningInsideWSL2() error {
 }
 
 func checkVirtualizationEnabled() error {
+	if runtime.GOARCH == "arm64" {
+		logging.Debug("Ignoring virtualization check for arm64")
+		return nil
+	}
 	logging.Debug("Checking if the vmx/svm flags are present in /proc/cpuinfo")
 	// Check if the cpu flags vmx or svm is present
 	flags, err := getCPUFlags()


### PR DESCRIPTION
Looks like for arm64 hardware there is no `vmx|svm` flag which point out if virtualization is enabled from bios or not. There is another way to handle it using `virt-host-validate` command but that do more test which we might not required. As of now this pr is going to ignore the virtualization check on arm64 to unblock CI for arm.


**Fixes:** Issue #4433 
