### PR TITLE
feat : Add support to customize the developer account password (#2359)

### DIFF
--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -128,7 +128,7 @@ func toConsoleClusterConfig(result *client.ConsoleResult) *clusterConfig {
 		},
 		DeveloperCredentials: credentials{
 			Username: "developer",
-			Password: "developer",
+			Password: result.ClusterConfig.DeveloperPass,
 		},
 	}
 }

--- a/cmd/crc/cmd/console_test.go
+++ b/cmd/crc/cmd/console_test.go
@@ -41,6 +41,7 @@ func createDummyClusterConfig(preset preset.Preset) types.ClusterConfig {
 		ClusterCACert: "MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ",
 		KubeConfig:    "/tmp/kubeconfig",
 		KubeAdminPass: "foobar",
+		DeveloperPass: "foobar",
 		ClusterAPI:    "https://foo.testing:6443",
 		WebConsoleURL: "https://console.foo.testing:6443",
 		ProxyConfig:   nil,
@@ -69,9 +70,9 @@ func TestConsolePlainError(t *testing.T) {
 }
 
 func TestConsoleWithPrintCredentialsPlainSuccess(t *testing.T) {
-	expectedOut := fmt.Sprintf(`To login as a regular user, run 'oc login -u developer -p developer %s'.
+	expectedOut := fmt.Sprintf(`To login as a regular user, run 'oc login -u developer -p %s %s'.
 To login as an admin, run 'oc login -u kubeadmin -p %s %s'
-`, fakemachine.DummyClusterConfig.ClusterAPI, fakemachine.DummyClusterConfig.KubeAdminPass, fakemachine.DummyClusterConfig.ClusterAPI)
+`, fakemachine.DummyClusterConfig.DeveloperPass, fakemachine.DummyClusterConfig.ClusterAPI, fakemachine.DummyClusterConfig.KubeAdminPass, fakemachine.DummyClusterConfig.ClusterAPI)
 	out := new(bytes.Buffer)
 	assert.NoError(t, runConsole(out, setUpClientForConsole(t), false, true, ""))
 	assert.Equal(t, expectedOut, out.String())
@@ -79,9 +80,9 @@ To login as an admin, run 'oc login -u kubeadmin -p %s %s'
 
 func TestConsoleWithPrintCredentialsAndURLPlainSuccess(t *testing.T) {
 	expectedOut := fmt.Sprintf(`%s
-To login as a regular user, run 'oc login -u developer -p developer %s'.
+To login as a regular user, run 'oc login -u developer -p %s %s'.
 To login as an admin, run 'oc login -u kubeadmin -p %s %s'
-`, fakemachine.DummyClusterConfig.WebConsoleURL, fakemachine.DummyClusterConfig.ClusterAPI, fakemachine.DummyClusterConfig.KubeAdminPass, fakemachine.DummyClusterConfig.ClusterAPI)
+`, fakemachine.DummyClusterConfig.WebConsoleURL, fakemachine.DummyClusterConfig.DeveloperPass, fakemachine.DummyClusterConfig.ClusterAPI, fakemachine.DummyClusterConfig.KubeAdminPass, fakemachine.DummyClusterConfig.ClusterAPI)
 	out := new(bytes.Buffer)
 	assert.NoError(t, runConsole(out, setUpClientForConsole(t), true, true, ""))
 	assert.Equal(t, expectedOut, out.String())
@@ -89,22 +90,22 @@ To login as an admin, run 'oc login -u kubeadmin -p %s %s'
 
 func TestConsoleJSONSuccess(t *testing.T) {
 	expectedJSONOut := fmt.Sprintf(`{
-  "success": true,
-  "clusterConfig": {
-    "clusterType": "openshift",
-    "cacert": "%s",
-    "webConsoleUrl": "%s",
-    "url": "%s",
-    "adminCredentials": {
-      "username": "kubeadmin",
-      "password": "%s"
-    },
-    "developerCredentials": {
-      "username": "developer",
-      "password": "developer"
-    }
-  }
-}`, fakemachine.DummyClusterConfig.ClusterCACert, fakemachine.DummyClusterConfig.WebConsoleURL, fakemachine.DummyClusterConfig.ClusterAPI, fakemachine.DummyClusterConfig.KubeAdminPass)
+	 "success": true,
+	 "clusterConfig": {
+	   "clusterType": "openshift",
+	   "cacert": "%s",
+	   "webConsoleUrl": "%s",
+	   "url": "%s",
+	   "adminCredentials": {
+	     "username": "kubeadmin",
+	     "password": "%s"
+	   },
+	   "developerCredentials": {
+	     "username": "developer",
+	     "password": "%s"
+	   }
+	 }
+	}`, fakemachine.DummyClusterConfig.ClusterCACert, fakemachine.DummyClusterConfig.WebConsoleURL, fakemachine.DummyClusterConfig.ClusterAPI, fakemachine.DummyClusterConfig.KubeAdminPass, fakemachine.DummyClusterConfig.DeveloperPass)
 	out := new(bytes.Buffer)
 	assert.NoError(t, runConsole(out, setUpClientForConsole(t), false, false, jsonFormat))
 	assert.JSONEq(t, expectedJSONOut, out.String())

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -142,7 +142,7 @@ func toClusterConfig(result *types.StartResult) *clusterConfig {
 		},
 		DeveloperCredentials: credentials{
 			Username: "developer",
-			Password: "developer",
+			Password: result.ClusterConfig.DeveloperPass,
 		},
 	}
 }

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -77,6 +77,7 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		NameServer:        config.Get(crcConfig.NameServer).AsString(),
 		PullSecret:        cluster.NewInteractivePullSecretLoader(config),
 		KubeAdminPassword: config.Get(crcConfig.KubeAdminPassword).AsString(),
+		DeveloperPassword: config.Get(crcConfig.DeveloperPassword).AsString(),
 		Preset:            crcConfig.GetPreset(config),
 		IngressHTTPPort:   config.Get(crcConfig.IngressHTTPPort).AsUInt(),
 		IngressHTTPSPort:  config.Get(crcConfig.IngressHTTPSPort).AsUInt(),

--- a/cmd/crc/cmd/start_test.go
+++ b/cmd/crc/cmd/start_test.go
@@ -32,7 +32,7 @@ func TestRenderActionPlainSuccess(t *testing.T) {
 			},
 			DeveloperCredentials: credentials{
 				Username: "developer",
-				Password: "developer",
+				Password: "secret",
 			},
 		},
 	}, out, ""))
@@ -118,7 +118,7 @@ Log in as administrator:
 
 Log in as user:
   Username: developer
-  Password: developer
+  Password: secret
 
 Use the 'oc' command line interface:
   $ eval $(crc oc-env)
@@ -136,7 +136,7 @@ Log in as administrator:
 
 Log in as user:
   Username: developer
-  Password: developer
+  Password: secret
 
 Use the 'oc' command line interface:
   PS> & crc oc-env | Invoke-Expression
@@ -154,7 +154,7 @@ Log in as administrator:
 
 Log in as user:
   Username: developer
-  Password: developer
+  Password: secret
 
 Use the 'oc' command line interface:
   > @FOR /f "tokens=*" %i IN ('crc oc-env') DO @call %i

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -96,6 +96,7 @@ func TestStart(t *testing.T) {
 				ClusterCACert: "MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ",
 				KubeConfig:    "/tmp/kubeconfig",
 				KubeAdminPass: "foobar",
+				DeveloperPass: "foobar",
 				ClusterAPI:    "https://foo.testing:6443",
 				WebConsoleURL: "https://console.foo.testing:6443",
 				ProxyConfig:   nil,

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -167,11 +167,11 @@ var testCases = []testCase{
 	// start
 	{
 		request:  post("start"),
-		response: jSon(`{"Status":"","ClusterConfig":{"ClusterType":"openshift","ClusterCACert":"MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ","KubeConfig":"/tmp/kubeconfig","KubeAdminPass":"foobar","ClusterAPI":"https://foo.testing:6443","WebConsoleURL":"https://console.foo.testing:6443","ProxyConfig":null},"KubeletStarted":true}`),
+		response: jSon(`{"Status":"","ClusterConfig":{"ClusterType":"openshift","ClusterCACert":"MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ","KubeConfig":"/tmp/kubeconfig","KubeAdminPass":"foobar","DeveloperPass":"foobar","ClusterAPI":"https://foo.testing:6443","WebConsoleURL":"https://console.foo.testing:6443","ProxyConfig":null},"KubeletStarted":true}`),
 	},
 	{
 		request:  get("start"),
-		response: jSon(`{"Status":"","ClusterConfig":{"ClusterType":"openshift","ClusterCACert":"MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ","KubeConfig":"/tmp/kubeconfig","KubeAdminPass":"foobar","ClusterAPI":"https://foo.testing:6443","WebConsoleURL":"https://console.foo.testing:6443","ProxyConfig":null},"KubeletStarted":true}`),
+		response: jSon(`{"Status":"","ClusterConfig":{"ClusterType":"openshift","ClusterCACert":"MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ","KubeConfig":"/tmp/kubeconfig","KubeAdminPass":"foobar","DeveloperPass":"foobar","ClusterAPI":"https://foo.testing:6443","WebConsoleURL":"https://console.foo.testing:6443","ProxyConfig":null},"KubeletStarted":true}`),
 	},
 
 	// start with failure
@@ -273,7 +273,7 @@ var testCases = []testCase{
 	// webconsoleurl
 	{
 		request:  get("webconsoleurl"),
-		response: jSon(`{"ClusterConfig":{"ClusterType":"openshift","ClusterCACert":"MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ","KubeConfig":"/tmp/kubeconfig","KubeAdminPass":"foobar","ClusterAPI":"https://foo.testing:6443","WebConsoleURL":"https://console.foo.testing:6443","ProxyConfig":null},"State":"Running"}`),
+		response: jSon(`{"ClusterConfig":{"ClusterType":"openshift","ClusterCACert":"MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ","KubeConfig":"/tmp/kubeconfig","KubeAdminPass":"foobar","DeveloperPass":"foobar","ClusterAPI":"https://foo.testing:6443","WebConsoleURL":"https://console.foo.testing:6443","ProxyConfig":null},"State":"Running"}`),
 	},
 
 	// webconsoleurl with failure

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -129,6 +129,7 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 		NameServer:               cfg.Get(crcConfig.NameServer).AsString(),
 		PullSecret:               cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
 		KubeAdminPassword:        cfg.Get(crcConfig.KubeAdminPassword).AsString(),
+		DeveloperPassword:        cfg.Get(crcConfig.DeveloperPassword).AsString(),
 		IngressHTTPPort:          cfg.Get(crcConfig.IngressHTTPPort).AsUInt(),
 		IngressHTTPSPort:         cfg.Get(crcConfig.IngressHTTPSPort).AsUInt(),
 		Preset:                   crcConfig.GetPreset(cfg),

--- a/pkg/crc/cluster/kubeadmin_password_test.go
+++ b/pkg/crc/cluster/kubeadmin_password_test.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +57,59 @@ func TestCompareFalseWithCustomEntries(t *testing.T) {
 	ok, _, err = compareHtpasswd(htpasswd, map[string]string{"username": "password", "external1": "external1", "external2": "external2"})
 	assert.NoError(t, err)
 	assert.True(t, ok)
+}
+
+func TestGenerateUserPassword_WhenValidFileProvided_ThenWritePasswordToFile(t *testing.T) {
+	// Given
+	dir := t.TempDir()
+	userPasswordPath := filepath.Join(dir, "test-user-password")
+	// When
+	err := GenerateUserPassword(userPasswordPath, "test-user")
+	// Then
+	assert.NoError(t, err)
+	actualPasswordFileContents, err := os.ReadFile(userPasswordPath)
+	assert.NoError(t, err)
+	assert.Equal(t, 23, len(actualPasswordFileContents))
+}
+
+var testResolveUserPasswordArguments = map[string]struct {
+	kubeAdminPasswordViaConfig string
+	developerPasswordViaConfig string
+	expectedKubeAdminPassword  string
+	expectedDeveloperPassword  string
+}{
+	"When no password configured in config, then read kubeadmin and developer passwords from password files": {
+		"", "", "kubeadmin-password-via-file", "developer-password-via-file",
+	},
+	"When developer password configured in config, then use developer password from config": {
+		"", "developer-password-via-config", "kubeadmin-password-via-file", "developer-password-via-config",
+	},
+	"When kube admin password configured in config, then use kube admin password from config": {
+		"kubeadmin-password-via-config", "", "kubeadmin-password-via-config", "developer-password-via-file",
+	},
+	"When kube admin and developer password configured in config, then use kube admin and developer passwords from config": {
+		"kubeadmin-password-via-config", "developer-password-via-config", "kubeadmin-password-via-config", "developer-password-via-config",
+	},
+}
+
+func TestResolveUserPassword_WhenNothingProvided_ThenUsePasswordFromFiles(t *testing.T) {
+	for name, test := range testResolveUserPasswordArguments {
+		t.Run(name, func(t *testing.T) {
+			// Given
+			dir := t.TempDir()
+			kubeAdminPasswordPath := filepath.Join(dir, "kubeadmin-password")
+			err := os.WriteFile(kubeAdminPasswordPath, []byte("kubeadmin-password-via-file"), 0600)
+			assert.NoError(t, err)
+			developerPasswordPath := filepath.Join(dir, "developer-password")
+			err = os.WriteFile(developerPasswordPath, []byte("developer-password-via-file"), 0600)
+			assert.NoError(t, err)
+
+			// When
+			credentials, err := resolveUserPasswords(test.kubeAdminPasswordViaConfig, test.developerPasswordViaConfig, kubeAdminPasswordPath, developerPasswordPath)
+
+			// Then
+			assert.NoError(t, err)
+			assert.Equal(t, map[string]string{"developer": test.expectedDeveloperPassword, "kubeadmin": test.expectedKubeAdminPassword}, credentials)
+		})
+	}
 }

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -29,6 +29,7 @@ const (
 	ConsentTelemetry         = "consent-telemetry"
 	EnableClusterMonitoring  = "enable-cluster-monitoring"
 	KubeAdminPassword        = "kubeadmin-password"
+	DeveloperPassword        = "developer-password"
 	Preset                   = "preset"
 	EnableSharedDirs         = "enable-shared-dirs"
 	SharedDirPassword        = "shared-dir-password" // #nosec G101
@@ -134,6 +135,8 @@ func RegisterSettings(cfg *Config) {
 
 	cfg.AddSetting(KubeAdminPassword, "", validateString, SuccessfullyApplied,
 		"User defined kubeadmin password")
+	cfg.AddSetting(DeveloperPassword, constants.DefaultDeveloperPassword, validateString, SuccessfullyApplied,
+		"User defined developer password")
 	cfg.AddSetting(IngressHTTPPort, constants.OpenShiftIngressHTTPPort, validatePort, RequiresHTTPPortChangeWarning,
 		fmt.Sprintf("HTTP port to use for OpenShift ingress/routes on the host (1024-65535, default: %d)", constants.OpenShiftIngressHTTPPort))
 	cfg.AddSetting(IngressHTTPSPort, constants.OpenShiftIngressHTTPSPort, validatePort, RequiresHTTPSPortChangeWarning,

--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -204,6 +204,9 @@ var configDefaultValuesTestArguments = []struct {
 		KubeAdminPassword, "",
 	},
 	{
+		DeveloperPassword, "developer",
+	},
+	{
 		CPUs, uint(4),
 	},
 	{
@@ -288,6 +291,9 @@ var configProvidedValuesTestArguments = []struct {
 }{
 	{
 		KubeAdminPassword, "kubeadmin-secret-password",
+	},
+	{
+		DeveloperPassword, "developer-secret-password",
 	},
 	{
 		CPUs, uint(8),

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -197,6 +197,10 @@ func GetKubeAdminPasswordPath() string {
 	return filepath.Join(MachineInstanceDir, DefaultName, "kubeadmin-password")
 }
 
+func GetDeveloperPasswordPath() string {
+	return filepath.Join(MachineInstanceDir, DefaultName, "developer-password")
+}
+
 func GetWin32BackgroundLauncherDownloadURL() string {
 	return fmt.Sprintf(BackgroundLauncherURL,
 		version.GetWin32BackgroundLauncherVersion())

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -32,6 +32,7 @@ const (
 	BackgroundLauncherURL     = "https://github.com/crc-org/win32-background-launcher/releases/download/v%s/win32-background-launcher.exe"
 	DefaultBundleURLBase      = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/%s/%s/%s"
 	DefaultContext            = "admin"
+	DefaultDeveloperPassword  = "developer"
 	DaemonHTTPEndpoint        = "http://unix/api"
 	DaemonVsockPort           = 1024
 	DefaultPodmanNamedPipe    = `\\.\pipe\crc-podman`

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -29,6 +29,7 @@ var DummyClusterConfig = types.ClusterConfig{
 	ClusterCACert: "MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ",
 	KubeConfig:    "/tmp/kubeconfig",
 	KubeAdminPass: "foobar",
+	DeveloperPass: "foobar",
 	ClusterAPI:    "https://foo.testing:6443",
 	WebConsoleURL: "https://console.foo.testing:6443",
 	ProxyConfig:   nil,

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -21,9 +21,13 @@ func getClusterConfig(bundleInfo *bundle.CrcBundleInfo) (*types.ClusterConfig, e
 		}, nil
 	}
 
-	kubeadminPassword, err := cluster.GetKubeadminPassword()
+	kubeadminPassword, err := cluster.GetUserPassword(constants.GetKubeAdminPasswordPath())
 	if err != nil {
 		return nil, fmt.Errorf("Error reading kubeadmin password from bundle %v", err)
+	}
+	developerPassword, err := cluster.GetUserPassword(constants.GetDeveloperPasswordPath())
+	if err != nil {
+		return nil, fmt.Errorf("error reading developer password from bundle %v", err)
 	}
 	proxyConfig, err := getProxyConfig(bundleInfo)
 	if err != nil {
@@ -38,6 +42,7 @@ func getClusterConfig(bundleInfo *bundle.CrcBundleInfo) (*types.ClusterConfig, e
 		ClusterCACert: base64.StdEncoding.EncodeToString(clusterCACert),
 		KubeConfig:    bundleInfo.GetKubeConfigPath(),
 		KubeAdminPass: kubeadminPassword,
+		DeveloperPass: developerPassword,
 		WebConsoleURL: fmt.Sprintf("https://%s", bundleInfo.GetAppHostname("console-openshift-console")),
 		ClusterAPI:    fmt.Sprintf("https://%s:6443", bundleInfo.GetAPIHostname()),
 		ProxyConfig:   proxyConfig,

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -584,7 +584,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Failed to update pull secret on the disk")
 	}
 
-	if err := cluster.UpdateKubeAdminUserPassword(ctx, ocConfig, startConfig.KubeAdminPassword); err != nil {
+	if err := cluster.UpdateUserPasswords(ctx, ocConfig, startConfig.KubeAdminPassword, startConfig.DeveloperPassword); err != nil {
 		return nil, errors.Wrap(err, "Failed to update kubeadmin user password")
 	}
 
@@ -691,8 +691,11 @@ func createHost(machineConfig config.MachineConfig, preset crcPreset.Preset) err
 		return fmt.Errorf("Error generating ssh key pair: %v", err)
 	}
 	if preset == crcPreset.OpenShift || preset == crcPreset.OKD {
-		if err := cluster.GenerateKubeAdminUserPassword(); err != nil {
+		if err := cluster.GenerateUserPassword(constants.GetKubeAdminPasswordPath(), "kubeadmin"); err != nil {
 			return errors.Wrap(err, "Error generating new kubeadmin password")
+		}
+		if err = os.WriteFile(constants.GetDeveloperPasswordPath(), []byte(constants.DefaultDeveloperPassword), 0600); err != nil {
+			return errors.Wrap(err, "Error writing developer password")
 		}
 	}
 	if err := api.SetExists(vm.Name); err != nil {

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -26,6 +26,9 @@ type StartConfig struct {
 	// User defined kubeadmin password
 	KubeAdminPassword string
 
+	// User defined developer password
+	DeveloperPassword string
+
 	// Preset
 	Preset crcpreset.Preset
 

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -53,6 +53,7 @@ type ClusterConfig struct {
 	ClusterCACert string
 	KubeConfig    string
 	KubeAdminPass string
+	DeveloperPass string
 	ClusterAPI    string
 	WebConsoleURL string
 	ProxyConfig   *httpproxy.ProxyConfig

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -30,12 +30,18 @@ Feature: Basic test
     @darwin @linux @windows @cleanup
     Scenario: CRC start usecase
         Given executing "crc setup --check-only" fails
+        And unsetting config property "developer-password" succeeds
         # Request start with monitoring stack
         * setting config property "enable-cluster-monitoring" to value "true" succeeds
         * setting config property "memory" to value "16000" succeeds
         Given executing single crc setup command succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
+        And stdout should contain "Log in as administrator:"
+        And stdout should contain "  Username: kubeadmin"
+        And stdout should contain "Log in as user:"
+        And stdout should contain "  Username: developer"
+        And stdout should contain "  Password: developer"
         # Check if user can copy-paste login details for developer and kubeadmin users
         * stdout should match "(?s)(.*)oc login -u developer https:\/\/api\.crc\.testing:6443(.*)$"
         * stdout should match "(?s)(.*)https:\/\/console-openshift-console\.apps-crc\.testing(.*)$"

--- a/test/e2e/features/config.feature
+++ b/test/e2e/features/config.feature
@@ -17,27 +17,30 @@ Feature: Test configuration settings
         # always return to default values
         @darwin
         Examples: Config settings on Mac
-            | property         | value1    | value2            |
-            | cpus             | 5         | 3                 |
-            | memory           | 10753     | 4096              |
-            | nameserver       | 120.0.0.1 | 999.999.999.999   |
-            | pull-secret-file | /etc      | /nonexistent-file |
+            | property           | value1    | value2            |
+            | cpus               | 5         | 3                 |
+            | memory             | 10753     | 4096              |
+            | nameserver         | 120.0.0.1 | 999.999.999.999   |
+            | pull-secret-file   | /etc      | /nonexistent-file |
+            | developer-password | secret1   |                   |
 
         @linux
         Examples: Config settings on Linux
-            | property         | value1    | value2            |
-            | cpus             | 5         | 3                 |
-            | memory           | 10753     | 4096              |
-            | nameserver       | 120.0.0.1 | 999.999.999.999   |
-            | pull-secret-file | /etc      | /nonexistent-file |
+            | property           | value1    | value2            |
+            | cpus               | 5         | 3                 |
+            | memory             | 10753     | 4096              |
+            | nameserver         | 120.0.0.1 | 999.999.999.999   |
+            | pull-secret-file   | /etc      | /nonexistent-file |
+            | developer-password | secret1   |                   |
 
         @windows
         Examples: Config settings on Windows
-            | property         | value1    | value2            |
-            | cpus             | 5         | 3                 |
-            | memory           | 10753     | 4096              |
-            | nameserver       | 120.0.0.1 | 999.999.999.999   |
-            | pull-secret-file | /Users    | /nonexistent-file |
+            | property           | value1    | value2            |
+            | cpus               | 5         | 3                 |
+            | memory             | 10753     | 4096              |
+            | nameserver         | 120.0.0.1 | 999.999.999.999   |
+            | pull-secret-file   | /Users    | /nonexistent-file |
+            | developer-password | secret1   |                   |
 
     @linux @darwin @windows
     Scenario: CRC config checks (bundle version)
@@ -182,7 +185,7 @@ Feature: Test configuration settings
             | preset-value  |
             | microshift    | 
             
-    Scenario: CRC config set preset (negtive cases) 
+    Scenario: CRC config set preset (negative cases)
         When setting config property "preset" to value "<preset-value>" fails
         And stderr should contain "reason: Unknown preset" 
 

--- a/test/e2e/features/custom_developer_password.feature
+++ b/test/e2e/features/custom_developer_password.feature
@@ -1,0 +1,19 @@
+@story_custom_developer_password
+Feature: Custom Developer Password Test
+
+    User provides configuration property to override default developer user password
+
+    Background:
+        Given ensuring CRC cluster is running
+
+    @linux @windows @darwin @cleanup
+    Scenario: Override default developer password should be reflected during crc start
+        Given executing "crc stop" succeeds
+        And setting config property "developer-password" to value "secret-dev" succeeds
+        When starting CRC with default bundle succeeds
+        Then stdout should contain "Started the OpenShift cluster"
+        And stdout should contain "Log in as administrator:"
+        And stdout should contain "  Username: kubeadmin"
+        And stdout should contain "Log in as user:"
+        And stdout should contain "  Username: developer"
+        And stdout should contain "  Password: secret-dev"


### PR DESCRIPTION
Fix #2539

**Relates to:** Issue #2539

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I tested my code on specified platforms
   - [x] Linux
   - [ ] Windows
   - [ ] MacOS

## Solution/Idea

+ Generate developer password instead of hardcoded `developer` string as password
+ Add config option to set developer password for cluster `developer-password`

## Proposed changes
crc would no longer have `developer` as user password. It would be generated each time cluster is created (just like kubeadmin password). If user wants to override it, they can use `developer-password` configuration option in CRC config.

## Testing

- After starting CRC cluster user would see a random string as password value instead of `developer
- If user has specified `developer-password` configuration option in CRC config, then that value is used in developer password:
```sh
    $ crc config set developer-password mypassword
    $ crc start
    [...]
    INFO Adding crc-admin and crc-developer contexts to kubeconfig...
    Started the OpenShift cluster.
    
    The server is accessible via web console at:
      https://console-openshift-console.apps-crc.testing
    
    Log in as user:
      Username: developer
      Password: mypassword
```
