### PR TITLE
fix (daemon) : Add logging to provide additional information for non-200 status codes (#3766)

### DIFF
--- a/cmd/crc/cmd/custom_response_writer.go
+++ b/cmd/crc/cmd/custom_response_writer.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// CustomResponseWriter wraps the standard http.ResponseWriter and captures the response body
+type CustomResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	body       *bytes.Buffer
+}
+
+// NewCustomResponseWriter creates a new CustomResponseWriter
+func NewCustomResponseWriter(w http.ResponseWriter) *CustomResponseWriter {
+	return &CustomResponseWriter{
+		ResponseWriter: w,
+		statusCode:     http.StatusOK,
+		body:           &bytes.Buffer{},
+	}
+}
+
+// WriteHeader allows capturing and modifying the status code
+func (rw *CustomResponseWriter) WriteHeader(statusCode int) {
+	rw.statusCode = statusCode
+	rw.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Write captures the response body and logs it
+func (rw *CustomResponseWriter) Write(p []byte) (int, error) {
+	bufferLen, err := rw.body.Write(p)
+	if err != nil {
+		return bufferLen, err
+	}
+
+	return rw.ResponseWriter.Write(p)
+}
+
+// interceptResponseBodyMiddleware injects the custom bodyConsumer function (received as second argument) into
+// http.HandleFunc logic that allows users to intercept response body as per their requirements (e.g. logging)
+// and returns updated http.Handler
+func interceptResponseBodyMiddleware(next http.Handler, bodyConsumer func(statusCode int, buffer *bytes.Buffer, r *http.Request)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		responseWriter := NewCustomResponseWriter(w)
+		next.ServeHTTP(responseWriter, r)
+		bodyConsumer(responseWriter.statusCode, responseWriter.body, r)
+	})
+}

--- a/cmd/crc/cmd/custom_response_writer_test.go
+++ b/cmd/crc/cmd/custom_response_writer_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestHandler struct {
+}
+
+func (t *TestHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	_, err := fmt.Fprint(w, "Testing!")
+	if err != nil {
+		return
+	}
+}
+
+func TestLogResponseBodyMiddlewareCapturesResponseAsExpected(t *testing.T) {
+	// Given
+	interceptedResponseStatusCode := -1
+	interceptedResponseBody := ""
+	responseBodyConsumer := func(statusCode int, buffer *bytes.Buffer, _ *http.Request) {
+		interceptedResponseStatusCode = statusCode
+		interceptedResponseBody = buffer.String()
+	}
+	testHandler := &TestHandler{}
+	server := httptest.NewServer(interceptResponseBodyMiddleware(http.StripPrefix("/", testHandler), responseBodyConsumer))
+	defer server.Close()
+	// When
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Then
+	responseBody := new(bytes.Buffer)
+	bytesRead, err := responseBody.ReadFrom(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 200, interceptedResponseStatusCode)
+	assert.Equal(t, int64(8), bytesRead)
+	assert.Equal(t, "Testing!", responseBody.String())
+	assert.Equal(t, "Testing!", interceptedResponseBody)
+}

--- a/cmd/crc/cmd/daemon_test.go
+++ b/cmd/crc/cmd/daemon_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogResponseBodyLogsResponseBodyForFailedResponseCodes(t *testing.T) {
+	// Given
+	var logBuffer bytes.Buffer
+	var responseBuffer bytes.Buffer
+	responseBuffer.WriteString("{\"status\": \"FAILURE\"}")
+	logrus.SetOutput(&logBuffer)
+	defer logrus.SetOutput(os.Stdout)
+	requestURL, err := url.Parse("http://127.0.0.1/log")
+	assert.NoError(t, err)
+	httpRequest := &http.Request{
+		Method: "GET",
+		URL:    requestURL,
+	}
+
+	// When
+	logResponseBodyConditionally(500, &responseBuffer, httpRequest)
+
+	// Then
+	assert.Greater(t, logBuffer.Len(), 0)
+	assert.Contains(t, logBuffer.String(), ("\\\"GET /log\\\" Response Body: {\\\"status\\\": \\\"FAILURE\\\"}"))
+}
+
+func TestLogResponseBodyLogsNothingWhenResponseSuccessful(t *testing.T) {
+	// Given
+	var logBuffer bytes.Buffer
+	var responseBuffer bytes.Buffer
+	responseBuffer.WriteString("{\"status\": \"SUCCESS\"}")
+	logrus.SetOutput(&logBuffer)
+	defer logrus.SetOutput(os.Stdout)
+	requestURL, err := url.Parse("http://127.0.0.1/log")
+	assert.NoError(t, err)
+	httpRequest := &http.Request{
+		Method: "GET",
+		URL:    requestURL,
+	}
+
+	// When
+	logResponseBodyConditionally(200, &responseBuffer, httpRequest)
+
+	// Then
+	assert.Equal(t, logBuffer.Len(), 0)
+}


### PR DESCRIPTION



**Fixes:** Issue #3766

**Relates to:** Issue #3766

## Solution/Idea

Add a custom response writer to capture the response body and status code so that we can conditionally log the response body in case of failure.

## Proposed changes

1. Add `CustomResponseWriter` object as a wrapper around `http.ResponseWriter` and override methods to capture response status code and body.
2. Add `interceptResponseBodyMiddleware` that would inject the abovementioned response writer into HTTP Handlers.
3. Use `interceptResponseBodyMiddleware` in daemon endpoint declarations and add handler for conditionally logging response body when response is not successful

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. Run `crc daemon` to start CRC daemon
2. Make some requests to the daemon API endpoints, so that they fail. You would notice that there is some additional logging whenever response code is not 200.

For example if we make requests like these
```shell
# For failed requests, there would be additional logging of response body
curl -i --unix-socket ~/.crc/crc-http.sock http://crc/api/stop
curl -i --unix-socket ~/.crc/crc-http.sock http://crc/api/start
curl -i --unix-socket ~/.crc/crc-http.sock http://crc/api/delete

# For successful requests, it won't log
curl -i --unix-socket ~/.crc/crc-http.sock http://crc/api/version
```

We see these logs (notice there is no logging in case of successful request done in the end) : 
```
ERRO [19/Nov/2024:22:11:06 +0530] "GET /api/stop" Response Body: Instance is already stopped
 
@ - - [19/Nov/2024:22:11:06 +0530] "GET /api/stop HTTP/1.1" 500 28

ERRO [19/Nov/2024:22:11:00 +0530] "GET /api/start" Response Body: lstat /home/rokumar/.crc/bin/crc: no such file or directory
 
@ - - [19/Nov/2024:22:11:00 +0530] "GET /api/start HTTP/1.1" 500 60

ERRO [19/Nov/2024:22:08:44 +0530] "GET /api/delete" Response Body: Cannot load machine: no such libmachine vm: crc
 
@ - - [19/Nov/2024:22:08:44 +0530] "GET /api/delete HTTP/1.1" 500 48

@ - - [19/Nov/2024:22:12:33 +0530] "GET /api/version HTTP/1.1" 200 101
```
