### PR TITLE
feat (dns) : Add `host.crc.testing` to `/etc/hosts` (#4410)

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -108,8 +108,12 @@ func (bundle *CrcBundleInfo) GetBundleName() string {
 	return bundle.Name
 }
 
+func (bundle *CrcBundleInfo) GetFQDN(shortName string) string {
+	return fmt.Sprintf("%s.%s.%s", shortName, bundle.ClusterInfo.ClusterName, bundle.ClusterInfo.BaseDomain)
+}
+
 func (bundle *CrcBundleInfo) GetAPIHostname() string {
-	return fmt.Sprintf("api.%s.%s", bundle.ClusterInfo.ClusterName, bundle.ClusterInfo.BaseDomain)
+	return bundle.GetFQDN("api")
 }
 
 func (bundle *CrcBundleInfo) GetAppHostname(appName string) string {

--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -289,3 +289,25 @@ func TestGetBundleInfoFromNameInvalid(t *testing.T) {
 	_, err = GetBundleInfoFromName("crc_nanoshift_libvirt_4.16.7_amd64_232.crcbundle")
 	assert.Error(t, err)
 }
+
+func TestGetFQDN(t *testing.T) {
+	tests := []struct {
+		name               string
+		shortName          string
+		expectedDomainName string
+	}{
+		{"api host name", "api", "api.crc.testing"},
+		{"vm host name", "host", "host.crc.testing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			// When
+			hostName := parsedReference.GetFQDN(tt.shortName)
+
+			// Then
+			assert.Equal(t, tt.expectedDomainName, hostName)
+		})
+	}
+}

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -205,10 +205,18 @@ func matchIP(ips []net.IP, expectedIP string) bool {
 }
 
 func addOpenShiftHosts(serviceConfig services.ServicePostStartConfig) error {
-	return adminhelper.UpdateHostsFile(serviceConfig.IP, serviceConfig.BundleMetadata.GetAPIHostname(),
+	hostnames := getApplicableHostnames(serviceConfig)
+	return adminhelper.UpdateHostsFile(serviceConfig.IP, hostnames...)
+}
+
+func getApplicableHostnames(serviceConfig services.ServicePostStartConfig) []string {
+	return []string{
+		serviceConfig.BundleMetadata.GetAPIHostname(),
+		serviceConfig.BundleMetadata.GetFQDN("host"),
 		serviceConfig.BundleMetadata.GetAppHostname("oauth-openshift"),
 		serviceConfig.BundleMetadata.GetAppHostname("console-openshift-console"),
 		serviceConfig.BundleMetadata.GetAppHostname("downloads-openshift-console"),
 		serviceConfig.BundleMetadata.GetAppHostname("canary-openshift-ingress-canary"),
-		serviceConfig.BundleMetadata.GetAppHostname("default-route-openshift-image-registry"))
+		serviceConfig.BundleMetadata.GetAppHostname("default-route-openshift-image-registry"),
+	}
 }

--- a/pkg/crc/services/dns/dns_test.go
+++ b/pkg/crc/services/dns/dns_test.go
@@ -1,0 +1,38 @@
+package dns
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/bundle"
+	"github.com/crc-org/crc/v2/pkg/crc/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetApplicableHostnames(t *testing.T) {
+	// Given
+	bundleMetadata := services.ServicePostStartConfig{
+		BundleMetadata: bundle.CrcBundleInfo{
+			ClusterInfo: bundle.ClusterInfo{
+				OpenShiftVersion:  semver.MustParse("4.6.1"),
+				ClusterName:       "crc",
+				BaseDomain:        "testing",
+				AppsDomain:        "apps.crc.testing",
+				SSHPrivateKeyFile: "id_ecdsa_crc",
+				KubeConfig:        "kubeconfig",
+			},
+		},
+	}
+	// When
+	hostnames := getApplicableHostnames(bundleMetadata)
+	// Then
+	assert.Equal(t, []string{
+		"api.crc.testing",
+		"host.crc.testing",
+		"oauth-openshift.apps.crc.testing",
+		"console-openshift-console.apps.crc.testing",
+		"downloads-openshift-console.apps.crc.testing",
+		"canary-openshift-ingress-canary.apps.crc.testing",
+		"default-route-openshift-image-registry.apps.crc.testing",
+	}, hostnames)
+}


### PR DESCRIPTION
Fixes: #4410
**Relates to:** Issue #4410

## Solution/Idea

Add another entry in `/etc/hosts/` for `host.crc.testing` domain as suggested in https://github.com/crc-org/crc/issues/4410#issuecomment-2431907547

## Proposed changes

+ Add another method `GetFQDN(string)` to CrcBundleInfo struct in order to provide host domain
+ Use abovementioned method in `dns.addOpenShiftHosts` in order to add another dns entry for `host.crc.testing`

## Testing

After doing `crc start` you'd notice an additional entry in `/etc/hosts` for `host.crc.testing`

Old state of `/etc/hosts`
```
# Added by CRC
192.168.130.11   api.crc.testing canary-openshift-ingress-canary.apps.crc.testing console-openshift-console.apps.crc.testing default-ro
ute-openshift-image-registry.apps.crc.testing downloads-openshift-console.apps.crc.testing oauth-openshift.apps.crc.testing
# End of CRC section
```

New state of `/etc/hosts` (after these changes):
```
# Added by CRC
192.168.130.11   api.crc.testing canary-openshift-ingress-canary.apps.crc.testing console-openshift-console.apps.crc.testing default-route-openshift-image-registry.apps.crc.testing downloads-openshift-console.apps.crc.testing host.crc.testing oauth-openshift.apps.crc.testing
# End of CRC section
```
