### PR TITLE
fix: Download bundle without specifying tag

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -243,17 +243,19 @@ func GetCustomBundleName(bundleFilename string) string {
 	return fmt.Sprintf("%s_%d%s", baseName, time.Now().Unix(), bundleExtension)
 }
 
-func GetBundleNameFromURI(bundleURI string) string {
-	// the URI is expected to have been validated by validation.ValidateBundlePath first
+func GetBundleNameFromURI(bundleURI string) (string, error) {
 	switch {
 	case strings.HasPrefix(bundleURI, "docker://"):
 		imageAndTag := strings.Split(path.Base(bundleURI), ":")
-		return constants.BundleForPreset(image.GetPresetName(imageAndTag[0]), imageAndTag[1])
+		if len(imageAndTag) < 2 {
+			return "", fmt.Errorf("No tag found in bundle URI")
+		}
+		return constants.BundleForPreset(image.GetPresetName(imageAndTag[0]), imageAndTag[1]), nil
 	case strings.HasPrefix(bundleURI, "http://"), strings.HasPrefix(bundleURI, "https://"):
-		return path.Base(bundleURI)
+		return path.Base(bundleURI), nil
 	default:
 		// local path
-		return filepath.Base(bundleURI)
+		return filepath.Base(bundleURI), nil
 	}
 }
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -278,7 +278,11 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Cannot determine if VM exists")
 	}
 
-	bundleName := bundle.GetBundleNameWithoutExtension(bundle.GetBundleNameFromURI(startConfig.BundlePath))
+	bundleNameFromURI, err := bundle.GetBundleNameFromURI(startConfig.BundlePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error getting bundle name")
+	}
+	bundleName := bundle.GetBundleNameWithoutExtension(bundleNameFromURI)
 	crcBundleMetadata, err := getCrcBundleInfo(ctx, startConfig.Preset, bundleName, startConfig.BundlePath, startConfig.EnableBundleQuayFallback)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting bundle metadata")

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -87,7 +87,11 @@ var genericCleanupChecks = []Check{
 func checkBundleExtracted(bundlePath string) func() error {
 	return func() error {
 		logging.Infof("Checking if %s exists", bundlePath)
-		bundleName := bundle.GetBundleNameFromURI(bundlePath)
+		bundleName, err := bundle.GetBundleNameFromURI(bundlePath)
+		if err != nil {
+			logging.Debugf("error getting bundle name from path %s: %v", bundlePath, err)
+			return err
+		}
 		if _, err := bundle.Get(bundleName); err != nil {
 			logging.Debugf("error getting bundle info for %s: %v", bundleName, err)
 			return err

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -83,13 +83,19 @@ func ValidateBundlePath(bundlePath string, preset crcpreset.Preset) error {
 		}
 	}
 
-	userProvidedBundle := bundle.GetBundleNameFromURI(bundlePath)
+	userProvidedBundle, err := bundle.GetBundleNameFromURI(bundlePath)
+	if err != nil {
+		return err
+	}
 	bundleMismatchWarning(userProvidedBundle, preset)
 	return nil
 }
 
 func ValidateBundle(bundlePath string, preset crcpreset.Preset) error {
-	bundleName := bundle.GetBundleNameFromURI(bundlePath)
+	bundleName, err := bundle.GetBundleNameFromURI(bundlePath)
+	if err != nil {
+		return err
+	}
 	bundleMetadata, err := bundle.Get(bundleName)
 	if err != nil {
 		if bundlePath == constants.GetDefaultBundlePath(preset) {


### PR DESCRIPTION
The "latest" tag is not supported, therefore it is necessary to stop with an error in case it is not provided when using the -b flag command line flag.

Add unit tests to reproduce the bug and verify the fix.

Closes issue #4470


**Fixes:** Issue #4470 


## Solution/Idea

Before, in the `GetBundleNameFromURI` function, the `imageAndTag` array was trying to access its second element without ensuring that the length is at least 2 causing a crash in case the `-b` command line option was used to specify a bundle from a container image repository (using the `docker://` scheme) without a tag. I have added a check to prevent the program from crashing, returning an error to the user since the "latest" tag is not an option.

## Proposed changes

In `GetBundleNameFromURI` function:

1. Check the lenght of `imageAndTag` array
  1. if it is greater or equal to 2, then obtain image name and tag as `imageAndTag[0]` and `imageAndTag[1]` respectively
  2. otherwise, bail out with an error
2. Change all the use in the codebase, since now the function returns also an error in case of failure

## Testing

Added unit tests to reproduce the bug and validate the fix proposed.
Check the `TestGetBundleNameFromURI` function in the `pkg/crc/machine/bundle/metadata_test.go` file.
Running `crc setup -b docker://quay.io/crcont/openshift-bundle` should now return an error message instead of crashing.

