### PR TITLE
Update the publicDNSQueryURI in DNS Check to https://quay.io 

### DIFF
--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	dnsServicePort    = 53
-	publicDNSQueryURI = "quay.io"
+	publicDNSQueryURI = "https://quay.io"
 	dnsmasqService    = "dnsmasq.service"
 )
 


### PR DESCRIPTION
**Relates to:** Issue #4218 (error code `301` was seen in this issue)

## Solution/Idea

Change the publicDNSQueryURI to `https` to prevent `301 Moved Permanently` during DNS check.

The alternate is to add `-sSL` flags to the curl command during the check for a quiet follow to any redirects.


