### PR TITLE
fix (status) : Log info in CRC status for OKD preset (#3626)

### DIFF
--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -195,12 +195,7 @@ func (s *status) prettyPrintTo(writer io.Writer) error {
 		{"CRC VM", s.CrcStatus},
 	}
 
-	if s.Preset == preset.OpenShift {
-		lines = append(lines, line{"OpenShift", openshiftStatus(s)})
-	}
-	if s.Preset == preset.Microshift {
-		lines = append(lines, line{"MicroShift", openshiftStatus(s)})
-	}
+	lines = append(lines, line{s.Preset.ForDisplay(), openshiftStatus(s)})
 
 	if s.RAMSize != -1 && s.RAMUsage != -1 {
 		lines = append(lines, line{"RAM Usage", fmt.Sprintf(


### PR DESCRIPTION
~:warning: This currently doesn't work as expected due to https://github.com/crc-org/crc/issues/4478 . It requires #4480 to me merged first~

**Fixes:** Issue #3626

**Relates to:** Issue #3626 

## Solution/Idea

Currently, `crc status` logs information only for OpenShift and MicroShift presets. We should also log cluster information for the OKD preset.


## Proposed changes

This PR only changes the way `crc status` logs information for `okd` preset. 

Old behavior of `crc status` on OKD preset (Nothing is logged for OpenShift version as there is no handling for `okd` preset): 
``` 
CRC VM:          Running
RAM Usage:       647.2MB of 10.95GB
Disk Usage:      21.48GB of 32.68GB (Inside the CRC VM)
Cache Usage:     67.13GB
Cache Directory: /home/rokumar/.crc/cache
```

Expected New behavior of `crc status` on OKD preset: 
```
CRC VM:          Running
OpenShift/OKD:       Running (v4.15.0-0.okd-2024-02-23-163410)
RAM Usage:       647.2MB of 10.95GB
Disk Usage:      21.48GB of 32.68GB (Inside the CRC VM)
Cache Usage:     67.13GB
Cache Directory: /home/rokumar/.crc/cache
```

## Testing
- Set up crc cluster
  - `crc config set preset okd`
  - `crc setup`
  - `crc start`
- Run `crc status` (should see `OpenShift/OKD` in status logs)
