### PR TITLE
fix (machine) : crc daemon `/status` api should return correct preset value for `okd` cluster (#4478)

### DIFF
--- a/pkg/crc/machine/status_test.go
+++ b/pkg/crc/machine/status_test.go
@@ -1,0 +1,252 @@
+package machine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/types"
+	"github.com/crc-org/crc/v2/pkg/crc/preset"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateClusterStatusResultShouldSetOpenShiftStatusAsExpected(t *testing.T) {
+	tests := []struct {
+		name                  string
+		vmStatus              state.State
+		vmBundleType          preset.Preset
+		expectedClusterStatus types.ClusterStatusResult
+	}{
+		{
+			"MicroShift cluster running", state.Running, preset.Microshift, types.ClusterStatusResult{
+				CrcStatus:            "Running",
+				OpenshiftStatus:      "Running",
+				OpenshiftVersion:     "v4.5.1",
+				DiskUse:              int64(16),
+				DiskSize:             int64(32),
+				RAMUse:               int64(8),
+				RAMSize:              int64(12),
+				PersistentVolumeUse:  16,
+				PersistentVolumeSize: 32,
+				Preset:               preset.Microshift,
+			},
+		},
+		{
+			"MicroShift cluster stopped", state.Stopped, preset.Microshift, types.ClusterStatusResult{
+				CrcStatus:            "Stopped",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.Microshift,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"MicroShift cluster error state", state.Error, preset.Microshift, types.ClusterStatusResult{
+				CrcStatus:            "Error",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.Microshift,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"MicroShift cluster stopping state", state.Stopping, preset.Microshift, types.ClusterStatusResult{
+				CrcStatus:            "Stopping",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.Microshift,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"MicroShift cluster starting state", state.Starting, preset.Microshift, types.ClusterStatusResult{
+				CrcStatus:            "Starting",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.Microshift,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift cluster running", state.Running, preset.OpenShift, types.ClusterStatusResult{
+				CrcStatus:            "Running",
+				OpenshiftStatus:      "Running",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OpenShift,
+				DiskUse:              int64(16),
+				DiskSize:             int64(32),
+				RAMUse:               int64(8),
+				RAMSize:              int64(12),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift cluster stopped", state.Stopped, preset.OpenShift, types.ClusterStatusResult{
+				CrcStatus:            "Stopped",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OpenShift,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift cluster errored", state.Error, preset.OpenShift, types.ClusterStatusResult{
+				CrcStatus:            "Error",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OpenShift,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift cluster stopping state", state.Stopping, preset.OpenShift, types.ClusterStatusResult{
+				CrcStatus:            "Stopping",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OpenShift,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift cluster starting state", state.Starting, preset.OpenShift, types.ClusterStatusResult{
+				CrcStatus:            "Starting",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OpenShift,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift/OKD cluster running", state.Running, preset.OKD, types.ClusterStatusResult{
+				CrcStatus:            "Running",
+				OpenshiftStatus:      "Running",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OKD,
+				DiskUse:              int64(16),
+				DiskSize:             int64(32),
+				RAMUse:               int64(8),
+				RAMSize:              int64(12),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift/OKD cluster stopped", state.Stopped, preset.OKD, types.ClusterStatusResult{
+				CrcStatus:            "Stopped",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OKD,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift/OKD cluster errored", state.Error, preset.OKD, types.ClusterStatusResult{
+				CrcStatus:            "Error",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OKD,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift/OKD cluster stopping state", state.Stopping, preset.OKD, types.ClusterStatusResult{
+				CrcStatus:            "Stopping",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OKD,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+		{
+			"OpenShift/OKD cluster starting state", state.Starting, preset.OKD, types.ClusterStatusResult{
+				CrcStatus:            "Starting",
+				OpenshiftStatus:      "Stopped",
+				OpenshiftVersion:     "v4.5.1",
+				Preset:               preset.OKD,
+				DiskUse:              int64(0),
+				DiskSize:             int64(0),
+				RAMUse:               int64(0),
+				RAMSize:              int64(0),
+				PersistentVolumeUse:  0,
+				PersistentVolumeSize: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			// When
+			actualClusterStatusResult, err := createClusterStatusResult(tt.vmStatus, tt.vmBundleType, "v4.5.1", "127.0.0.1", 32, 16, 12, 8, 16, 32, func(context.Context, string) types.OpenshiftStatus { return types.OpenshiftRunning })
+
+			// Then
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedClusterStatus.CrcStatus, actualClusterStatusResult.CrcStatus)
+			assert.Equal(t, tt.expectedClusterStatus.OpenshiftStatus, actualClusterStatusResult.OpenshiftStatus)
+			assert.Equal(t, tt.expectedClusterStatus.Preset, actualClusterStatusResult.Preset)
+			assert.Equal(t, tt.expectedClusterStatus.OpenshiftVersion, actualClusterStatusResult.OpenshiftVersion)
+			assert.Equal(t, tt.expectedClusterStatus.RAMSize, actualClusterStatusResult.RAMSize)
+			assert.Equal(t, tt.expectedClusterStatus.RAMUse, actualClusterStatusResult.RAMUse)
+			assert.Equal(t, tt.expectedClusterStatus.DiskSize, actualClusterStatusResult.DiskSize)
+			assert.Equal(t, tt.expectedClusterStatus.DiskUse, actualClusterStatusResult.DiskUse)
+			assert.Equal(t, tt.expectedClusterStatus.PersistentVolumeSize, actualClusterStatusResult.PersistentVolumeSize)
+			assert.Equal(t, tt.expectedClusterStatus.PersistentVolumeUse, actualClusterStatusResult.PersistentVolumeUse)
+		})
+	}
+}


### PR DESCRIPTION
Fix #4478

**Relates to:** Issue #4478  #4479

## Solution/Idea

CRC daemon's `/api/status` API endpoint should return correct value of preset when running CRC cluster configured with `crc` preset. At the moment it only returns correct value for `microshift` and `openshift` presets.


## Proposed changes

+ Refactor `Status()` method to move ClusterStatusResult object creation logic to a separate method for easier testing
+ Add case for OKD preset while setting preset value in cluster preset


## Testing
Build a development version of CRC and create a cluster configured with okd preset. Then query status endpoint to see what preset is returned by API server.

1. `crc config set preset okd`
2. `crc setup`
3. `crc start`
4. `curl -i --unix-socket ~/.crc/crc-http.sock http://crc/api/status | jq .Preset` should return `"okd"`


### Old Behavior
Old Response of `/api/status` on OKD based cluster:
```json
{
  "CrcStatus": "Running",
  "OpenshiftStatus": "Unreachable",
  "OpenshiftVersion": "4.14.0-0.okd-scos-2024-01-10-151818",
  "DiskUse": 16885141504,
  "DiskSize": 32680947712,
  "RAMUse": 1958576128,
  "RAMSize": 9371365376,
  "Preset": "openshift" // Not OK, should be okd
}
```

### New Behavior (with this PR)
New Response of `/api/status` on OKD based cluster:
```json
{
  "CrcStatus": "Running",
  "OpenshiftStatus": "Unreachable",
  "OpenshiftVersion": "4.15.0-0.okd-2024-02-23-163410",
  "DiskUse": 521195520,
  "DiskSize": 10947768320,
  "RAMUse": 21496344576,
  "RAMSize": 32680947712,
  "Preset": "okd"
}
```

I have tested by cherry-picking this commit on top of #4479 , it's now displaying OKD value in `crc status` as expected.
