### PR TITLE
fix (config) : Display helpful message when user tries to set `okd` preset on arm (#3389)

### DIFF
--- a/pkg/crc/config/validations_test.go
+++ b/pkg/crc/config/validations_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePresetWithVariousPresetValues(t *testing.T) {
+	tests := []struct {
+		presetValue       string
+		validationPassed  bool
+		validationMessage string
+	}{
+		{"openshift", true, ""},
+		{"microshift", true, ""},
+		{"unknown", false, "Unknown preset"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.presetValue, func(t *testing.T) {
+			// When
+			validationPass, validationMessage := validatePreset(tt.presetValue)
+
+			// Then
+			assert.Equal(t, tt.validationPassed, validationPass)
+			assert.Contains(t, validationMessage, tt.validationMessage)
+		})
+	}
+}
+
+func TestValidationPreset_WhenOKDProvidedOnNonArmArchitecture_thenValidationSuccessful(t *testing.T) {
+	// Given
+	if runtime.GOARCH == "arm" || runtime.GOARCH == "arm64" {
+		t.Skip("Skipping test; running on ARM architecture")
+	}
+	// When
+	validationPass, validationMessage := validatePreset("okd")
+	// Then
+	assert.Equal(t, true, validationPass)
+	assert.Equal(t, "", validationMessage)
+}
+
+func TestValidationPreset_WhenOKDProvidedOnArmArchitecture_thenValidationFailure(t *testing.T) {
+	// Given
+	if runtime.GOARCH != "arm" && runtime.GOARCH != "arm64" {
+		t.Skip("Skipping test; not running on ARM architecture")
+	}
+	// When
+	validationPass, validationMessage := validatePreset("okd")
+	// Then
+	assert.Equal(t, false, validationPass)
+	assert.Equal(t, fmt.Sprintf("preset 'okd' is not supported on %s architecture, please use different preset value", runtime.GOARCH), validationMessage)
+}


### PR DESCRIPTION

**Fixes:** Issue #3389

**Relates to:** Issue #3389

## Solution/Idea

Fix #3389

Add additional handling in `validatePreset` method for failing the validation when `okd` preset is provided on arm architecture. Validation would fail with message directing user to use other preset values.

## Proposed changes

- Update `validationPreset` method with an additional check to fail when `okd` value is provided on `arm` architecture. It now checks for two conditions 
  -  whether provided preset value is valid (already existing validation)
  - whether `okd` is not provided on `arm` or `arm64` architecture

## Testing
:warning: A machine with `arm` architecture is required to test these changes

- `crc delete`
- `crc config set preset okd` (should fail with invalid value error)


### Old behavior
When user tried setting `okd` preset on `arm` architecture, CRC allowed doing this:
```bash
crc : $ crc config set preset okd
To confirm your system is ready, and you have the needed system bundle, please run 'crc setup' before 'crc start'.
crc : $ cat ~/.crc/crc.json 
{
  "consent-telemetry": "yes",
  "preset": "okd"
}
```

### New behavior 
Once these changes are merged, user would get error when he tries above action on `arm` architecture:
```bash
crc : $ crc config set preset okd
Value 'okd' for configuration property 'preset' is invalid, reason: preset 'okd' is not supported on amd64 architecture, please use different preset value
crc : $ cat ~/.crc/crc.json # Config file is not updated
{
  "consent-telemetry": "yes"
}
```