### PR TITLE
doc : Use GitHub recommended keywords in pull request template to automatically link related issues (#4488)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,40 @@
+## Description
 
-**Fixes:** Issue #N
+<!--
+Thank you for your pull request (PR)!
 
-**Relates to:** Issue #N, PR #N, ...
+Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
+-->
 
-## Solution/Idea
+Fixes: #N
 
-Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set-up a single-node OpenShift cluster on it with one command. It requires blablabla..._
+Relates to: #N, PR #N, ...
+
+<!--
+Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
+-->
+
+## Type of change
+<!--
+What types of changes does your code introduce? Put an `x` in all the boxes that apply
+-->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change
+- [ ] Chore (non-breaking change which doesn't affect codebase;
+  test, version modification, documentation, etc.)
 
 ## Proposed changes
-
+<!--
 List main as well as consequential changes you introduced or had to introduce.
 
 1. Add `start` command.
 2. Add `setup` as prerequisite to `start`.
 3. ...
+-->
 
 ## Testing
-
+<!--
 What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.
 
 1. `start` succeeds first time after `setup` succeeded
@@ -26,3 +44,16 @@ What is the _bottom-line_ functionality that needs testing? Describe in pseudo-c
 5. `status` returns ... if `start` failed
 6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
 7. ...
+-->
+
+## Contribution Checklist
+- [ ] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
+- [ ] My code follows the style guidelines of this project
+- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
+- [ ] I have performed a self-review of my code
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I tested my code on specified platforms <!-- Only put an `x` in applicable platforms -->
+    - [ ] Linux
+    - [ ] Windows
+    - [ ] MacOS


### PR DESCRIPTION
Fixes #4488

+ Use `Fixes #N` keyword (without any formatting) in pull request template so that GitHub links pull request with issue automatically.
+ Merge some components from [Eclipse JKube Pull Request template](https://github.com/eclipse-jkube/jkube/blob/master/.github/pull_request_template.md) . This is something that can be helpful (however, it's just my opinion, if team disagrees I'll revert this change).
+ Move pull request hints to comment blocks
   - In my opinion, they are only there to give pull request author hints about providing all the necessary information. They should be kept hidden if the pull request author isn't interested in adding information. 

## Solution/Idea

Update pull request template to use `Fixes #N` keyword as suggested in [GitHub documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)

## Proposed changes

Update GitHub pull request template to use `Fixes #N` keyword and merge some components from JKube pull request template.

## Testing

N/A
