### PR TITLE
doc : Add info about hypervisor log file locations for troubleshooting (#3688)

### DIFF
--- a/docs/modules/getting_started/partials/proc_troubleshooting-unknown-issues.adoc
+++ b/docs/modules/getting_started/partials/proc_troubleshooting-unknown-issues.adoc
@@ -61,4 +61,12 @@ If your issue is not resolved by this procedure, perform the following steps:
 
 . link:https://github.com/crc-org/crc/issues[Search open issues] for the issue that you are encountering.
 . If no existing issue addresses the encountered issue, link:https://github.com/crc-org/crc/issues/new[create an issue] and link:https://help.github.com/en/articles/file-attachments-on-issues-and-pull-requests[attach the [filename]*_~/.crc/crc.log_* file] to the created issue.
-The [filename]*_~/.crc/crc.log_* file has detailed debugging and troubleshooting information which can help diagnose the problem that you are experiencing.
+The [filename]*_~/.crc/crc.log_* file has detailed debugging and troubleshooting information which can help diagnose the problem that you are experiencing. In case you're looking for more detailed information about virtual machine startup, state transitions and errors you can
+look into serial console logs created by virtual machine hypervisors. Here are the locations where you can find these logs:
+  - **libvirt**: In case of https://libvirt.org/kbase/debuglogs.html[libvirt], you can find the log file in `/var/log/libvirt/qemu/crc.log`
+  - **vfkit**: In case of https://github.com/crc-org/vfkit[vfkit], you can find log file in `~/.crc/vfkit.log`
+  - **hyper-v**: In case of Hyper-V, there are several options to get logs:
+    * **Event Logs for Hyper-V**: Go to start and open `Event Viewer`, then navigate to `Applications and Services Logs` → `Microsoft` → `Windows`. Here you should be able to find some options for `Hyper-V`,
+      click on `Hyper-V-VMMS` for Hyper-V Virtual Machine Management logs and `Hyper-V-Worker` for Hyper-V Worker logs.
+    * **VM Configuration Logs**: Each VM has a set of logs that can be found in the VM configuration folder. By default, this is located in the `C:\ProgramData\Microsoft\Windows\Hyper-V` folder. For each VM, there is a file called Virtual Machine Log File (`vmname.evtx`)
+      that records the events related to that particular VM.


### PR DESCRIPTION
## Description

Fixes: #3688

Relates to: #3688

Add information about hyper-v, vfkit and libvirt virtual machine specific logs to help users find more information while troubleshooting issues.

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
Add documentation for checking hypervisor log details while troubleshooting

## Testing
N/A

## Contribution Checklist
- [X] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
- [X] My code follows the style guidelines of this project
- [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I tested my code on specified platforms <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS