### PR TITLE
CI: update macOS-12 to macOS-14

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os:
           - macOS-13
-          - macOS-12
+          - macOS-14
         go:
           - '1.22'
     steps:

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os:
           - macOS-13
-          - macOS-12
+          - macOS-14
           - ubuntu-latest
           - ubuntu-20.04
         go:


### PR DESCRIPTION
We are not supporting macOS-12 anymore so better to switch to 14.
