### PR TITLE
[WIP] bundle: Parallel download and decompression

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -163,7 +163,7 @@ func downloadDataFiles(goos string, components []string, destDir string) ([]stri
 		if !shouldDownload(components, componentName) {
 			continue
 		}
-		filename, err := download.Download(context.TODO(), dl.url, destDir, dl.permissions, nil)
+		_, filename, err := download.Download(context.TODO(), dl.url, destDir, dl.permissions, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -154,7 +154,8 @@ func (c *Cache) getExecutable(destDir string) (string, error) {
 	destPath := filepath.Join(destDir, archiveName)
 	err := embed.Extract(archiveName, destPath)
 	if err != nil {
-		return download.Download(context.TODO(), c.archiveURL, destDir, 0600, nil)
+		_, filename, err := download.Download(context.TODO(), c.archiveURL, destDir, 0600, nil)
+		return filename, err
 	}
 
 	return destPath, err

--- a/pkg/crc/image/image.go
+++ b/pkg/crc/image/image.go
@@ -74,6 +74,7 @@ func (img *imageHandler) copyImage(ctx context.Context, destPath string, reportW
 	if ctx == nil {
 		panic("ctx is nil, this should not happen")
 	}
+
 	manifestData, err := copy.Image(ctx, policyContext,
 		destRef, srcRef, &copy.Options{
 			ReportWriter: reportWriter,

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -48,13 +48,15 @@ func getCrcBundleInfo(ctx context.Context, preset crcPreset.Preset, bundleName, 
 		return bundleInfo, nil
 	}
 	logging.Debugf("Failed to load bundle %s: %v", bundleName, err)
+
 	logging.Infof("Downloading bundle: %s...", bundleName)
-	bundlePath, err = bundle.Download(ctx, preset, bundlePath, enableBundleQuayFallback)
+	reader, bundlePath, err := bundle.Download(ctx, preset, bundlePath, enableBundleQuayFallback)
 	if err != nil {
 		return nil, err
 	}
+
 	logging.Infof("Extracting bundle: %s...", bundleName)
-	if _, err := bundle.Extract(ctx, bundlePath); err != nil {
+	if _, err := bundle.Extract(ctx, reader, bundlePath); err != nil {
 		return nil, err
 	}
 	return bundle.Use(bundleName)

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -3,6 +3,7 @@ package preflight
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -116,13 +117,14 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset, enableBundle
 			return fmt.Errorf("Cannot create directory %s: %v", bundleDir, err)
 		}
 		var err error
+		var reader io.Reader
 		logging.Infof("Downloading bundle: %s...", bundlePath)
-		if bundlePath, err = bundle.Download(context.TODO(), preset, bundlePath, enableBundleQuayFallback); err != nil {
+		if reader, bundlePath, err = bundle.Download(context.TODO(), preset, bundlePath, enableBundleQuayFallback); err != nil {
 			return err
 		}
 
 		logging.Infof("Uncompressing %s", bundlePath)
-		if _, err := bundle.Extract(context.TODO(), bundlePath); err != nil {
+		if _, err := bundle.Extract(context.TODO(), reader, bundlePath); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return errors.Wrap(err, "Use `crc setup -b <bundle-path>`")
 			}

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -32,6 +32,20 @@ func Uncompress(ctx context.Context, tarball, targetDir string) ([]string, error
 	return uncompress(ctx, tarball, targetDir, nil, terminal.IsShowTerminalOutput())
 }
 
+func UncompressWithReader(ctx context.Context, reader io.Reader, targetDir string) ([]string, error) {
+	return uncompressWithReader(ctx, reader, targetDir, nil, terminal.IsShowTerminalOutput())
+}
+
+func uncompressWithReader(ctx context.Context, reader io.Reader, targetDir string, fileFilter func(string) bool, showProgress bool) ([]string, error) {
+	logging.Debugf("Uncompressing from reader to %s", targetDir)
+
+	reader, err := zstd.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	return untar(ctx, reader, targetDir, fileFilter, showProgress)
+}
+
 func uncompress(ctx context.Context, tarball, targetDir string, fileFilter func(string) bool, showProgress bool) ([]string, error) {
 	logging.Debugf("Uncompressing %s to %s", tarball, targetDir)
 

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -125,7 +125,7 @@ func DownloadBundle(bundleLocation string, bundleDestination string, bundleName 
 		return bundleDestination, err
 	}
 
-	filename, err := download.Download(context.TODO(), bundleLocation, bundleDestination, 0644, nil)
+	_, filename, err := download.Download(context.TODO(), bundleLocation, bundleDestination, 0644, nil)
 	fmt.Printf("Downloading bundle from %s to %s.\n", bundleLocation, bundleDestination)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

This pull request does the following:
- Return a reader from the bundle Download function.
- Use the reader to stream the bytes to Extract function.

This commit replaces grab client with the net/http client to ensure that the bytes are streamed come in correct order to the Extract func. Currently, only zst decompression is being used in the UncompressWithReader function as it is the primary compression algorithm being used in crc.

The download progress bar has been removed temporarily and will be added back as part of refactoring the code.


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4336 


<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
- Return a reader from the bundle Download function.
- Use the reader to stream the bytes to Extract function.
## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
- [x] My code follows the style guidelines of this project
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I tested my code on specified platforms <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS