### PR TITLE
Change linux default network-mode to user

### DIFF
--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -168,10 +168,7 @@ func GetPreset(config Storage) preset.Preset {
 }
 
 func defaultNetworkMode() network.Mode {
-	if runtime.GOOS != "linux" {
-		return network.UserNetworkingMode
-	}
-	return network.SystemNetworkingMode
+	return network.UserNetworkingMode
 }
 
 func GetNetworkMode(config Storage) network.Mode {

--- a/pkg/crc/network/types.go
+++ b/pkg/crc/network/types.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/spf13/cast"
@@ -55,7 +54,7 @@ func parseMode(input string) (Mode, error) {
 	case string(SystemNetworkingMode), "default":
 		return SystemNetworkingMode, nil
 	default:
-		return SystemNetworkingMode, fmt.Errorf("Cannot parse mode '%s'", input)
+		return UserNetworkingMode, fmt.Errorf("Cannot parse mode '%s'", input)
 	}
 }
 func ParseMode(input string) Mode {
@@ -68,12 +67,7 @@ func ParseMode(input string) Mode {
 }
 
 func getDefaultMode() Mode {
-	switch runtime.GOOS {
-	case "linux":
-		return SystemNetworkingMode
-	default:
-		return UserNetworkingMode
-	}
+	return UserNetworkingMode
 }
 
 func ValidateMode(val interface{}) (bool, string) {

--- a/test/e2e/features/config.feature
+++ b/test/e2e/features/config.feature
@@ -79,18 +79,20 @@ Feature: Test configuration settings
         Examples:
             | property                             | value1 | value2 |
             | skip-check-bundle-extracted          | true   | false  |
-            | skip-check-crc-network               | true   | false  |
-            | skip-check-crc-network-active        | true   | false  |
             | skip-check-kvm-enabled               | true   | false  |
             | skip-check-libvirt-driver            | true   | false  |
             | skip-check-libvirt-installed         | true   | false  |
             | skip-check-libvirt-running           | true   | false  |
             | skip-check-libvirt-version           | true   | false  |
-            | skip-check-network-manager-installed | true   | false  |
-            | skip-check-network-manager-running   | true   | false  |
             | skip-check-root-user                 | true   | false  |
             | skip-check-user-in-libvirt-group     | true   | false  |
             | skip-check-virt-enabled              | true   | false  |
+    
+    # the following properties not suit for user notwork
+    #| skip-check-crc-network               | true   | false  | 
+    #| skip-check-crc-network-active        | true   | false  | 
+    #| skip-check-network-manager-installed | true   | false  | 
+    #| skip-check-network-manager-running   | true   | false  | 
 
         @windows
         Examples:
@@ -118,12 +120,9 @@ Feature: Test configuration settings
         When removing file "crc.json" from CRC home folder succeeds
         And executing single crc setup command succeeds
         And executing "sudo virsh net-list --name" succeeds
-        Then stdout contains "crc"
-        When executing "sudo virsh net-undefine crc && sudo virsh net-destroy crc" succeeds
-        And executing "sudo virsh net-list --name" succeeds
-        Then stdout should not contain "crc"
+        Then stdout contains "default"
 
-    @linux
+    @linux @system_network
     Scenario: Running `crc setup` with checks enabled restores destroyed network
         When setting config property "skip-check-crc-network" to value "false" succeeds
         And setting config property "skip-check-crc-network-active" to value "false" succeeds
@@ -131,7 +130,7 @@ Feature: Test configuration settings
         And executing "sudo virsh net-list --name" succeeds
         And stdout contains "crc"
 
-    @linux
+    @linux @system_network
     Scenario: Running `crc start` without `crc setup` and with checks disabled fails when network destroyed
         # Destroy network again
         When executing "sudo virsh net-undefine crc && sudo virsh net-destroy crc" succeeds

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -213,7 +213,6 @@ func InitializeScenario(s *godog.ScenarioContext) {
 			}
 
 			if tag.Name == "@proxy" {
-
 				// start container with squid proxy
 				err := util.ExecuteCommand("podman run --name squid -d -p 3128:3128 quay.io/crcont/squid")
 				if err != nil {
@@ -221,13 +220,13 @@ func InitializeScenario(s *godog.ScenarioContext) {
 					os.Exit(1)
 				}
 
-				err = util.ExecuteCommand("crc config set http-proxy http://192.168.130.1:3128")
+				err = util.ExecuteCommand("crc config set http-proxy http://host.crc.testing:3128")
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}
 
-				err = util.ExecuteCommand("crc config set https-proxy http://192.168.130.1:3128")
+				err = util.ExecuteCommand("crc config set https-proxy http://host.crc.testing:3128")
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)
@@ -239,6 +238,20 @@ func InitializeScenario(s *godog.ScenarioContext) {
 					os.Exit(1)
 				}
 
+				err = util.ExecuteCommand("crc config set host-network-access true")
+				if err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+
+			}
+
+			if tag.Name == "@system_network" {
+				err = util.ExecuteCommand("crc config set network-mode system")
+				if err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
 			}
 		}
 
@@ -353,6 +366,14 @@ func InitializeScenario(s *godog.ScenarioContext) {
 				}
 
 				if err := os.Unsetenv("NO_PROXY"); err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+			}
+
+			if tag.Name == "@system_network" {
+				err := util.ExecuteCommand("crc config unset network-mode")
+				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}
@@ -960,9 +981,6 @@ func PodmanCommandIsAvailable() error {
 		path = os.ExpandEnv(unexpandedPath)
 		csshk = filepath.Join(userHomeDir, ".crc/machines/crc/id_ed25519")
 		dh = "npipe:////./pipe/crc-podman"
-	}
-	if runtime.GOOS == "linux" {
-		ch = "ssh://core@192.168.130.11:22/run/user/1000/podman/podman.sock"
 	}
 
 	os.Setenv("PATH", path)

--- a/test/extended/util/proxy.go
+++ b/test/extended/util/proxy.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 
 	"github.com/elazarl/goproxy"
 	log "github.com/sirupsen/logrus"
@@ -65,10 +64,7 @@ func RunProxy() {
 
 	log.SetOutput(f)
 
-	ipaddr := "127.0.0.1"        // user mode is default on windows and darwin
-	if runtime.GOOS == "linux" { // system mode is default on linux
-		ipaddr = "192.168.130.1"
-	}
+	ipaddr := "127.0.0.1" // user mode is default on windows, darwin and linux
 
 	addr := fmt.Sprintf("%s:8888", ipaddr)
 	proxy.Verbose = true

--- a/test/integration/podman_test.go
+++ b/test/integration/podman_test.go
@@ -57,9 +57,6 @@ var _ = Describe("podman-remote", Serial, Ordered, Label("microshift-preset"), f
 				csshk = filepath.Join(userHomeDir, ".crc/machines/crc/id_ed25519")
 				dh = "npipe:////./pipe/crc-podman"
 			}
-			if runtime.GOOS == "linux" {
-				ch = "ssh://core@192.168.130.11:22/run/user/1000/podman/podman.sock"
-			}
 
 			os.Setenv("PATH", path)
 			os.Setenv("CONTAINER_SSHKEY", csshk)

--- a/test/integration/proxy_test.go
+++ b/test/integration/proxy_test.go
@@ -3,7 +3,6 @@ package test_test
 import (
 	"os"
 	"os/exec"
-	"runtime"
 
 	crc "github.com/crc-org/crc/v2/test/extended/crc/cmd"
 	"github.com/crc-org/crc/v2/test/extended/util"
@@ -41,11 +40,6 @@ var _ = Describe("", Serial, Ordered, Label("openshift-preset", "goproxy"), func
 		httpsProxy := "http://127.0.0.1:8888"
 		noProxy := ".testing"
 
-		if runtime.GOOS == "linux" {
-			httpProxy = "http://192.168.130.1:8888"
-			httpsProxy = "http://192.168.130.1:8888"
-		}
-
 		// Start goproxy
 
 		It("configure CRC", func() {
@@ -53,9 +47,7 @@ var _ = Describe("", Serial, Ordered, Label("openshift-preset", "goproxy"), func
 			Expect(RunCRCExpectSuccess("config", "set", "https-proxy", httpsProxy)).To(ContainSubstring("Successfully configured https-proxy"))
 			Expect(RunCRCExpectSuccess("config", "set", "no-proxy", noProxy)).To(ContainSubstring("Successfully configured no-proxy"))
 			Expect(RunCRCExpectSuccess("config", "set", "proxy-ca-file", util.CACertTempLocation)).To(ContainSubstring("Successfully configured proxy-ca-file"))
-			if runtime.GOOS != "linux" {
-				Expect(RunCRCExpectSuccess("config", "set", "host-network-access", "true")).To(ContainSubstring("Changes to configuration property 'host-network-access' are only applied during 'crc setup'"))
-			}
+			Expect(RunCRCExpectSuccess("config", "set", "host-network-access", "true")).To(ContainSubstring("Changes to configuration property 'host-network-access' are only applied during 'crc setup'"))
 		})
 
 		It("setup CRC", func() {


### PR DESCRIPTION
Currently, the Linux default network mode is system. But many issues happen due to different system situations. 
For most user, user network mode already satisfied their demands. And user network mode no need to deal with complex system situations. 
So after discuss, it's better to set user as default network-mode, making sure CRC works well in default.  
If the user requires more functions, they can switch to system network mode. 

@gbraad @praveenkumar @anjannath have agreed on this being needed. 
It needs to start testing early during December.
In the worst case, we can revert before the new release in January. 