### PR TITLE
Avoid waiting forever on API response

### DIFF
--- a/pkg/crc/daemonclient/client.go
+++ b/pkg/crc/daemonclient/client.go
@@ -3,6 +3,7 @@ package daemonclient
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	networkclient "github.com/containers/gvisor-tap-vsock/pkg/client"
 	"github.com/crc-org/crc/v2/pkg/crc/api/client"
@@ -24,6 +25,7 @@ func New() *Client {
 			Transport: transport(),
 		}, "http://unix/network"),
 		APIClient: client.New(&http.Client{
+			Timeout:   30 * time.Second,
 			Transport: transport(),
 		}, "http://unix/api"),
 		SSEClient: client.NewSSEClient(transport()),


### PR DESCRIPTION
Set a default timeout of 30s to avoid crc to hang on commands waiting on API response

Fixes: #4518 