### PR TITLE
test (e2e) : Add test for checking `crc status` on a stopped crc cluster

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -61,6 +61,9 @@ Feature: Basic test
         Then stdout should match "(.*)[Ss]topped the instance"
         And executing "oc whoami" fails
         And kubeconfig is cleaned up
+        # Given CRC Cluster is stopped, When crc status is executed, Then crc should report that cluster is stopped without throwing any error
+        When executing "crc status"
+        Then stdout should match "(.*)Stopped"
         # status check
         When checking that CRC is stopped
         And stdout should not contain "Running"


### PR DESCRIPTION
## Description

Related to #4512

While refactoring in https://github.com/crc-org/crc/pull/4480, I had mistakenly added this code that was checking for VM IP without checking the status of the VM . 

Add integration test to verify that `crc status` works after user has run `crc stop` so that we don't run into this issue again in future.


Relates to: #4512, PR #4521

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
Add e2e test to verify `crc status` works on a stopped crc cluster

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
- [x] My code follows the style guidelines of this project
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I tested my code on specified platforms <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [x] Windows
    - [ ] MacOS