### PR TITLE
fix (shell) : Improve CRC shell detection on unix environments (#3767)

### DIFF
--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -2,7 +2,16 @@ package shell
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
+
+	crcos "github.com/crc-org/crc/v2/pkg/os"
+)
+
+var (
+	CommandRunner                           = crcos.NewLocalCommandRunner()
+	WindowsSubsystemLinuxKernelMetadataFile = "/proc/version"
 )
 
 type Config struct {
@@ -65,9 +74,9 @@ func GetEnvString(userShell string, envName string, envValue string) string {
 	case "cmd":
 		return fmt.Sprintf("SET %s=%s", envName, envValue)
 	case "fish":
-		return fmt.Sprintf("contains %s $fish_user_paths; or set -U fish_user_paths %s $fish_user_paths", envValue, envValue)
+		return fmt.Sprintf("contains %s $fish_user_paths; or set -U fish_user_paths %s $fish_user_paths", convertToLinuxStylePath(userShell, envValue), convertToLinuxStylePath(userShell, envValue))
 	default:
-		return fmt.Sprintf("export %s=\"%s\"", envName, envValue)
+		return fmt.Sprintf("export %s=\"%s\"", envName, convertToLinuxStylePath(userShell, envValue))
 	}
 }
 
@@ -81,8 +90,140 @@ func GetPathEnvString(userShell string, prependedPath string) string {
 	case "cmd":
 		pathStr = fmt.Sprintf("%s;%%PATH%%", prependedPath)
 	default:
-		pathStr = fmt.Sprintf("%s:$PATH", prependedPath)
+		pathStr = fmt.Sprintf("%s:$PATH", convertToLinuxStylePath(userShell, prependedPath))
 	}
 
 	return GetEnvString(userShell, "PATH", pathStr)
+}
+
+// convertToLinuxStylePath is a utility method to translate Windows paths to Linux environments (e.g. Git Bash).
+//
+// It receives two arguments:
+// - userShell : currently active shell
+// - path : Windows path to be converted
+//
+// It returns Linux equivalent of the Windows path.
+//
+// For example, a Windows path like `C:\Users\foo\.crc\bin\oc` is converted into `/C/Users/foo/.crc/bin/oc`.
+func convertToLinuxStylePath(userShell string, path string) string {
+	if IsWindowsSubsystemLinux() {
+		return convertToWindowsSubsystemLinuxPath(path)
+	}
+	if strings.Contains(path, "\\") &&
+		(userShell == "bash" || userShell == "zsh" || userShell == "fish") {
+		path = strings.ReplaceAll(path, ":", "")
+		path = strings.ReplaceAll(path, "\\", "/")
+
+		return fmt.Sprintf("/%s", path)
+	}
+	return path
+}
+
+// convertToWindowsSubsystemLinuxPath is a utility method to translate between Windows and WSL(Windows Subsystem for
+// Linux) paths. It relies on `wslpath` command to perform this conversion.
+//
+// It receives one argument:
+// - path : Windows path to be converted to WSL path
+//
+// It returns translated WSL equivalent of provided windows path.
+func convertToWindowsSubsystemLinuxPath(path string) string {
+	stdOut, _, err := CommandRunner.Run("wsl", "-e", "bash", "-c", fmt.Sprintf("wslpath -a '%s'", path))
+	if err != nil {
+		return path
+	}
+	return strings.TrimSpace(stdOut)
+}
+
+// IsWindowsSubsystemLinux detects whether current system is using Windows Subsystem for Linux or not
+//
+// It checks for these conditions to make sure that current system has WSL installed:
+// - `/proc/version` file is present
+// - `/proc/version` file contents contain keywords `Microsoft` and `WSL`
+//
+// It above conditions are met, then this method returns `true` otherwise `false`.
+func IsWindowsSubsystemLinux() bool {
+	procVersionContent, err := os.ReadFile(WindowsSubsystemLinuxKernelMetadataFile)
+	if err != nil {
+		return false
+	}
+	if strings.Contains(string(procVersionContent), "Microsoft") ||
+		strings.Contains(string(procVersionContent), "WSL") {
+		return true
+	}
+	return false
+}
+
+// detectShellByInvokingCommand is a utility method that tries to detect current shell in use by invoking `ps` command.
+// This method is extracted so that it could be used by unix systems as well as Windows (in case of WSL). It executes
+// the command provided in the method arguments and then passes the output to inspectProcessOutputForRecentlyUsedShell
+// for evaluation.
+//
+// It receives two arguments:
+// - defaultShell : default shell to revert back to in case it's unable to detect.
+// - command: command to be executed
+// - args: a string array containing command arguments
+//
+// It returns a string value representing current shell.
+func detectShellByInvokingCommand(defaultShell string, command string, args []string) string {
+	stdOut, _, err := CommandRunner.Run(command, args...)
+	if err != nil {
+		return defaultShell
+	}
+
+	detectedShell := inspectProcessOutputForRecentlyUsedShell(stdOut)
+	if detectedShell == "" {
+		return defaultShell
+	}
+	return detectedShell
+}
+
+// inspectProcessOutputForRecentlyUsedShell inspects output of ps command to detect currently active shell session.
+//
+// Note : This method assumes that ps command has already sorted the processes by `pid` in reverse order.
+// It parses the output into a struct, filters process types by name and returns the first element.
+//
+// It takes one argument:
+//
+// - psCommandOutput: output of ps command executed on a particular shell session
+//
+// It returns:
+//
+//   - a string value (one of `zsh`, `bash` or `fish`) for current shell environment in use. If it's not able to determine
+//     underlying shell type, it returns and empty string.
+//
+// This method tries to check all processes open and filters out shell sessions (one of `zsh`, `bash` or `fish)
+// It then returns first shell process.
+//
+// For example, if ps command gives this output:
+//
+//	2908 ps
+//	2889 fish
+//	823 bash
+//
+// Then this method would return `fish` as it's the first shell process.
+func inspectProcessOutputForRecentlyUsedShell(psCommandOutput string) string {
+	type ProcessOutput struct {
+		processID int
+		output    string
+	}
+	var processOutputs []ProcessOutput
+	lines := strings.Split(psCommandOutput, "\n")
+	for _, line := range lines {
+		lineParts := strings.Split(strings.TrimSpace(line), " ")
+		if len(lineParts) == 2 && (strings.Contains(lineParts[1], "zsh") ||
+			strings.Contains(lineParts[1], "bash") ||
+			strings.Contains(lineParts[1], "fish")) {
+			parsedProcessID, err := strconv.Atoi(lineParts[0])
+			if err == nil {
+				processOutputs = append(processOutputs, ProcessOutput{
+					processID: parsedProcessID,
+					output:    lineParts[1],
+				})
+			}
+		}
+	}
+	if len(processOutputs) > 0 {
+		return processOutputs[0].output
+	}
+	return ""
 }

--- a/pkg/os/shell/shell_test.go
+++ b/pkg/os/shell/shell_test.go
@@ -1,31 +1,228 @@
-//go:build !windows
-// +build !windows
-
 package shell
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDetectBash(t *testing.T) {
-	defer func(shell string) { os.Setenv("SHELL", shell) }(os.Getenv("SHELL"))
-	os.Setenv("SHELL", "/bin/bash")
-
-	shell, err := detect()
-
-	assert.Equal(t, "bash", shell)
-	assert.NoError(t, err)
+type MockCommandRunner struct {
+	commandName                string
+	commandArgs                []string
+	expectedOutputToReturn     string
+	expectedErrMessageToReturn string
+	expectedErrToReturn        error
 }
 
-func TestDetectFish(t *testing.T) {
-	defer func(shell string) { os.Setenv("SHELL", shell) }(os.Getenv("SHELL"))
-	os.Setenv("SHELL", "/bin/fish")
+func NewMockCommandRunner() *MockCommandRunner {
+	return NewMockCommandRunnerWithOutputErr("", "", nil)
+}
 
-	shell, err := detect()
+func NewMockCommandRunnerWithOutputErr(output string, errorMsg string, err error) *MockCommandRunner {
+	return &MockCommandRunner{
+		commandName:                "",
+		commandArgs:                []string{},
+		expectedOutputToReturn:     output,
+		expectedErrMessageToReturn: errorMsg,
+		expectedErrToReturn:        err,
+	}
+}
 
-	assert.Equal(t, "fish", shell)
+func (e *MockCommandRunner) Run(command string, args ...string) (string, string, error) {
+	e.commandName = command
+	e.commandArgs = args
+	return e.expectedOutputToReturn, e.expectedErrMessageToReturn, e.expectedErrToReturn
+}
+
+func (e *MockCommandRunner) RunPrivate(command string, args ...string) (string, string, error) {
+	e.commandName = command
+	e.commandArgs = args
+	return e.expectedOutputToReturn, e.expectedErrMessageToReturn, e.expectedErrToReturn
+}
+
+func (e *MockCommandRunner) RunPrivileged(_ string, cmdAndArgs ...string) (string, string, error) {
+	e.commandArgs = cmdAndArgs
+	return e.expectedOutputToReturn, e.expectedErrMessageToReturn, e.expectedErrToReturn
+}
+
+func TestGetPathEnvString(t *testing.T) {
+	tests := []struct {
+		name        string
+		userShell   string
+		path        string
+		expectedStr string
+	}{
+		{"fish shell", "fish", "C:\\Users\\foo\\.crc\\bin\\oc", "contains /C/Users/foo/.crc/bin/oc $fish_user_paths; or set -U fish_user_paths /C/Users/foo/.crc/bin/oc $fish_user_paths"},
+		{"powershell shell", "powershell", "C:\\Users\\foo\\oc.exe", "$Env:PATH = \"C:\\Users\\foo\\oc.exe;$Env:PATH\""},
+		{"cmd shell", "cmd", "C:\\Users\\foo\\oc.exe", "SET PATH=C:\\Users\\foo\\oc.exe;%PATH%"},
+		{"bash with windows path", "bash", "C:\\Users\\foo.exe", "export PATH=\"/C/Users/foo.exe:$PATH\""},
+		{"unknown with windows path", "unknown", "C:\\Users\\foo.exe", "export PATH=\"C:\\Users\\foo.exe:$PATH\""},
+		{"unknown shell with unix path", "unknown", "/home/foo/.crc/bin/oc", "export PATH=\"/home/foo/.crc/bin/oc:$PATH\""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPathEnvString(tt.userShell, tt.path)
+			if result != tt.expectedStr {
+				t.Errorf("GetPathEnvString(%s, %s) = %s; want %s", tt.userShell, tt.path, result, tt.expectedStr)
+			}
+		})
+	}
+}
+
+func TestConvertToLinuxStylePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		userShell    string
+		path         string
+		expectedPath string
+	}{
+		{"bash on windows, should convert", "bash", "C:\\Users\\foo\\.crc\\bin\\oc", "/C/Users/foo/.crc/bin/oc"},
+		{"zsh on windows, should convert", "zsh", "C:\\Users\\foo\\.crc\\bin\\oc", "/C/Users/foo/.crc/bin/oc"},
+		{"fish on windows, should convert", "fish", "C:\\Users\\foo\\.crc\\bin\\oc", "/C/Users/foo/.crc/bin/oc"},
+		{"powershell on windows, should NOT convert", "powershell", "C:\\Users\\foo\\.crc\\bin\\oc", "C:\\Users\\foo\\.crc\\bin\\oc"},
+		{"cmd on windows, should NOT convert", "cmd", "C:\\Users\\foo\\.crc\\bin\\oc", "C:\\Users\\foo\\.crc\\bin\\oc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertToLinuxStylePath(tt.userShell, tt.path)
+			if result != tt.expectedPath {
+				t.Errorf("convertToLinuxStylePath(%s, %s) = %s; want %s", tt.userShell, tt.path, result, tt.expectedPath)
+			}
+		})
+	}
+}
+
+func TestConvertToLinuxStylePath_WhenRunOnWSL_ThenExecuteWslPathBinary(t *testing.T) {
+	// Given
+	dir := t.TempDir()
+	wslVersionFilePath := filepath.Join(dir, "version")
+	wslVersionFile, err := os.Create(wslVersionFilePath)
 	assert.NoError(t, err)
+	defer func(wslVersionFile *os.File) {
+		err := wslVersionFile.Close()
+		assert.NoError(t, err)
+	}(wslVersionFile)
+	numberOfBytesWritten, err := wslVersionFile.WriteString("Linux version 5.15.167.4-microsoft-standard-WSL2 (root@f9c826d3017f) (gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37) #1 SMP Tue Nov 5 00:21:55 UTC 2024")
+	assert.NoError(t, err)
+	assert.Greater(t, numberOfBytesWritten, 0)
+	WindowsSubsystemLinuxKernelMetadataFile = wslVersionFilePath
+	mockCommandExecutor := NewMockCommandRunner()
+	CommandRunner = mockCommandExecutor
+	// When
+	convertToLinuxStylePath("wsl", "C:\\Users\\foo\\.crc\\bin\\oc")
+	// Then
+	assert.Equal(t, "wsl", mockCommandExecutor.commandName)
+	assert.Equal(t, []string{"-e", "bash", "-c", "wslpath -a 'C:\\Users\\foo\\.crc\\bin\\oc'"}, mockCommandExecutor.commandArgs)
+}
+
+func TestIsWindowsSubsystemLinux_whenInvalidKernelInfoFile_thenReturnFalse(t *testing.T) {
+	// Given + When
+	WindowsSubsystemLinuxKernelMetadataFile = "/i/dont/exist"
+	// Then
+	assert.Equal(t, false, IsWindowsSubsystemLinux())
+}
+
+func TestIsWindowsSubsystemLinux_whenValidKernelInfoFile_thenReturnTrue(t *testing.T) {
+	tests := []struct {
+		name               string
+		versionFileContent string
+		expectedResult     bool
+	}{
+		{
+			"version file contains WSL and Microsoft keywords, then return true",
+			"Linux version 5.15.167.4-microsoft-standard-WSL2 (root@f9c826d3017f) (gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37) #1 SMP Tue Nov 5 00:21:55 UTC 2024",
+			true,
+		},
+		{
+			"version file does NOT contain WSL and Microsoft keywords, then return false",
+			"invalid",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			dir := t.TempDir()
+			wslVersionFilePath := filepath.Join(dir, "version")
+			wslVersionFile, err := os.Create(wslVersionFilePath)
+			assert.NoError(t, err)
+			defer func(wslVersionFile *os.File) {
+				err := wslVersionFile.Close()
+				assert.NoError(t, err)
+				err = os.Remove(wslVersionFile.Name())
+				assert.NoError(t, err)
+			}(wslVersionFile)
+			numberOfBytesWritten, err := wslVersionFile.WriteString(tt.versionFileContent)
+			assert.NoError(t, err)
+			assert.Greater(t, numberOfBytesWritten, 0)
+			WindowsSubsystemLinuxKernelMetadataFile = wslVersionFilePath
+			// When
+			result := IsWindowsSubsystemLinux()
+
+			// Then
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestConvertToWindowsSubsystemLinuxPath(t *testing.T) {
+	// Given
+	mockCommandExecutor := NewMockCommandRunner()
+	CommandRunner = mockCommandExecutor
+
+	// When
+	convertToWindowsSubsystemLinuxPath("C:\\Users\\foo\\.crc\\bin\\oc")
+
+	// Then
+	assert.Equal(t, "wsl", mockCommandExecutor.commandName)
+	assert.Equal(t, []string{"-e", "bash", "-c", "wslpath -a 'C:\\Users\\foo\\.crc\\bin\\oc'"}, mockCommandExecutor.commandArgs)
+}
+
+func TestInspectProcessForRecentlyUsedShell(t *testing.T) {
+	tests := []struct {
+		name              string
+		psCommandOutput   string
+		expectedShellType string
+	}{
+		{
+			"nothing provided, then return empty string",
+			"",
+			"",
+		},
+		{
+			"bash shell, then detect bash shell",
+			"  31162 ps\n  435 bash",
+			"bash",
+		},
+		{
+			"zsh shell, then detect zsh shell",
+			"  31259 ps\n31253 zsh",
+			"zsh",
+		},
+		{
+			"fish shell, then detect fish shell",
+			"  31372 ps\n  31352 fish",
+			"fish",
+		},
+		{"bash and zsh shell, then detect zsh with more recent process id",
+			"  31259 ps\n  31253 zsh\n  435 bash",
+			"zsh",
+		},
+		{"bash and fish shell, then detect fish shell with more recent process id",
+			"    31372 ps\n  31352 fish\n  435 bash",
+			"fish",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given + When
+			result := inspectProcessOutputForRecentlyUsedShell(tt.psCommandOutput)
+			// Then
+			if result != tt.expectedShellType {
+				t.Errorf("%s inspectProcessOutputForRecentlyUsedShell() = %s; want %s", tt.name, result, tt.expectedShellType)
+			}
+		})
+	}
 }

--- a/pkg/os/shell/shell_unix.go
+++ b/pkg/os/shell/shell_unix.go
@@ -6,7 +6,6 @@ package shell
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 )
 
@@ -16,12 +15,11 @@ var (
 
 // detect detects user's current shell.
 func detect() (string, error) {
-	shell := os.Getenv("SHELL")
-
-	if shell == "" {
+	detectedShell := detectShellByInvokingCommand("", "ps", []string{"-o", "pid=,comm=", "--sort=-pid"})
+	if detectedShell == "" {
 		fmt.Printf("The default lines below are for a sh/bash shell, you can specify the shell you're using, with the --shell flag.\n\n")
 		return "", ErrUnknownShell
 	}
 
-	return filepath.Base(shell), nil
+	return filepath.Base(detectedShell), nil
 }

--- a/pkg/os/shell/shell_unix_test.go
+++ b/pkg/os/shell/shell_unix_test.go
@@ -4,6 +4,7 @@
 package shell
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
@@ -11,11 +12,75 @@ import (
 )
 
 func TestUnknownShell(t *testing.T) {
-	defer func(shell string) { os.Setenv("SHELL", shell) }(os.Getenv("SHELL"))
-	os.Setenv("SHELL", "")
+	// Given
+	mockCommandExecutor := NewMockCommandRunnerWithOutputErr("", "", nil)
+	CommandRunner = mockCommandExecutor
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
 
+	// When
 	shell, err := detect()
 
+	// Then
 	assert.Equal(t, err, ErrUnknownShell)
+	err = w.Close()
+	assert.NoError(t, err)
+	os.Stdout = originalStdout
+	var buf bytes.Buffer
+	nBytesRead, err := buf.ReadFrom(r)
+	assert.NoError(t, err)
+	assert.Greater(t, nBytesRead, int64(0))
+	assert.Equal(t, "The default lines below are for a sh/bash shell, you can specify the shell you're using, with the --shell flag.\n\n", buf.String())
+	assert.Equal(t, "ps", mockCommandExecutor.commandName)
+	assert.Equal(t, []string{"-o", "pid=,comm=", "--sort=-pid"}, mockCommandExecutor.commandArgs)
 	assert.Empty(t, shell)
+}
+
+func TestDetect_GivenPsOutputContainsShell_ThenReturnShellProcessWithMostRecentPid(t *testing.T) {
+	tests := []struct {
+		name              string
+		psCommandOutput   string
+		expectedShellType string
+	}{
+		{
+			"bash shell, then detect bash shell",
+			"  31162 ps\n  435 bash",
+			"bash",
+		},
+		{
+			"zsh shell, then detect zsh shell",
+			"  31259 ps\n31253 zsh",
+			"zsh",
+		},
+		{
+			"fish shell, then detect fish shell",
+			"  31372 ps\n  31352 fish",
+			"fish",
+		},
+		{"bash and zsh shell, then detect zsh with more recent process id",
+			"  31259 ps\n  31253 zsh\n  435 bash",
+			"zsh",
+		},
+		{"bash and fish shell, then detect fish shell with more recent process id",
+			"    31372 ps\n  31352 fish\n  435 bash",
+			"fish",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			mockCommandExecutor := NewMockCommandRunnerWithOutputErr(tt.psCommandOutput, "", nil)
+			CommandRunner = mockCommandExecutor
+
+			// When
+			shell, err := detect()
+
+			// Then
+			assert.Equal(t, "ps", mockCommandExecutor.commandName)
+			assert.Equal(t, []string{"-o", "pid=,comm=", "--sort=-pid"}, mockCommandExecutor.commandArgs)
+			assert.Equal(t, tt.expectedShellType, shell)
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/pkg/os/shell/shell_windows.go
+++ b/pkg/os/shell/shell_windows.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"unsafe"
 )
 
 var (
-	supportedShell = []string{"cmd", "powershell"}
+	supportedShell = []string{"cmd", "powershell", "bash", "zsh", "fish"}
 )
 
 // re-implementation of private function in https://github.com/golang/go/blob/master/src/syscall/syscall_windows.go
@@ -62,6 +63,10 @@ func shellType(shell string, defaultShell string) string {
 		return "powershell"
 	case strings.Contains(strings.ToLower(shell), "cmd"):
 		return "cmd"
+	case strings.Contains(strings.ToLower(shell), "wsl"):
+		return detectShellByInvokingCommand("bash", "wsl", []string{"-e", "bash", "-c", "ps -ao pid=,comm= --sort=-pid"})
+	case filepath.IsAbs(shell) && strings.Contains(strings.ToLower(shell), "bash"):
+		return "bash"
 	default:
 		return defaultShell
 	}


### PR DESCRIPTION
## Description

Fixes: #3797

Relates to: #3797

- Currently, we rely on `SHELL` environment variable for detecting active shell type. This will work when the environment variable is set. As per my observations, this environment variable is not set explicitly by various Linux shell environments (`bash`,`zsh`,`fish`). We should detect the currently active shell by checking the active processes instead.
- While generating statements for export statements on Windows, we shall make sure that we have converted windows paths to Linux paths.



## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
+ Instead of marking `shell_test.go` to not run on Windows, move unix-specific tests to `shell_unix_test.go`, add generic platform-independent tests to `shell_test.go`
+ Add `bash` and `zsh` to the list of supported shell environments on Windows.
+ Instead of instructing user to use `--shell` flag to print shell specific instructions, detect shell automatically by inspecting currently open processes:
  - On Linux use `ps` command to get list of active shell processes and pick the most recent process id.
  - On WSL (Windows Subsystem for Linux), use `wsl` tool to execute linux `ps` process to get list of active shell processes and return the one with most recent process id.
+ In the presence of UNIX-like shell environments, convert Windows paths to UNIX paths.
   - If WSL (Windows Subsystem for Linux) is detected, use `wslpath` utility tool to perform this conversion.
   - For other scenarios (like case of Git Bash), simply convert windows path delimiters to linux and remove the windows drive prefix

With these changes, we should see the correct output of `crc podman-env` and `crc oc-env` on:
- Windows Subsystem for Linux
   - [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) (default shell)
   - [fish](https://fishshell.com/) 
   - [zsh](https://en.wikipedia.org/wiki/Z_shell)
- Regular Linux distributions
  - [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) (default shell)
  - [fish](https://fishshell.com/)
  - [zsh](https://en.wikipedia.org/wiki/Z_shell)

Running `crc oc-env` on Git Bash:
### Old Behavior
```
$ crc oc-env
SET PATH=C:\Users\rokum\.crc\bin\oc;%PATH%
REM Run this command to configure your shell:
REM @FOR /f "tokens=*" %i IN ('crc oc-env') DO @call %i
```
### New Behavior
```
$ /c/Users/rokum/go/bin/crc oc-env
export PATH="/C/Users/rokum/.crc/bin/oc:$PATH"
# Run this command to configure your shell:
# eval $(crc oc-env)
```

## Testing
1. Start CRC cluster
2. Open some linux environment on windows (like Git Bash) and check result of `crc podman-env` / `crc oc-env` commands. They should not print output with respect to current shell in use.

## Contribution Checklist
- [X] I have read the [contributing guidelines](https://github.com/crc-org/crc/blob/main/developing.adoc)
- [X] My code follows the style guidelines of this project
- [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I tested my code on specified platforms <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [X] Windows
    - [ ] MacOS