### PR TITLE
chore : do not generate sed backup file while generating release info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,8 @@ cross-lint: $(TOOLS_BINDIR)/golangci-lint gen_release_info
 .PHONY: gen_release_info
 gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/$(CRC_VERSION)/ > $(RELEASE_INFO)
-	@sed -i'' -e s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
-	@sed -i'' -e s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
+	@sed -i"" -e s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
+	@sed -i"" -e s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
 
 .PHONY: linux-release-binary macos-release-binary windows-release-binary
 linux-release-binary: LDFLAGS+= $(RELEASE_VERSION_VARIABLES)


### PR DESCRIPTION
## Description
While working on windows, I observed that `make test` always generates two temporary files after execution:
```
        sed9zmH5g
        sedOFQN7I
```
Their content was similar to [release-info.json](https://github.com/crc-org/crc/blob/main/release-info.json.sample). On further debugging I found out they are getting created as backup files for sed replacement in Makefile. 
https://github.com/crc-org/crc/blob/6e991376f618e9244ddddd9b655c7ffd07d22865/Makefile#L273-L274

We had the option to not add any backup file, but somehow that option doesn't seem to work on windows. 

Relates to: https://github.com/crc-org/crc/commit/2636e4a41457962ceae35daa313e855f67a5d73d

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
Replace `''` with `""` to instruct sed to not generate a backup file while performing the inline replacement. For some reason `''` is not getting picked up on powershell and backup files are being generated.

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
`make test` should no longer generate additional files after execution on Windows. I have only verified this on Linux and Windows, it might be possible that these changes break `make test` on macOS

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [x] Windows
    - [ ] MacOS