### PR TITLE
fix : remove unnecessary logging for `crc-exists` file (#3676)

### DIFF
--- a/pkg/libmachine/persist/filestore.go
+++ b/pkg/libmachine/persist/filestore.go
@@ -83,9 +83,9 @@ func (s Filestore) SetExists(name string) error {
 func (s Filestore) Exists(name string) (bool, error) {
 	filename := filepath.Join(s.MachinesDir, name, fmt.Sprintf(".%s-exist", name))
 	_, err := os.Stat(filename)
-	log.Debugf("Checking file: %s", filename)
 
 	if os.IsNotExist(err) {
+		log.Debugf("file not found: %s", filename)
 		return false, nil
 	} else if err == nil {
 		return true, nil


### PR DESCRIPTION


## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #3676.

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

Remove unnecessary debug log statement for `crc-exists` file from filestore Exists() method

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
Remove unnecessary debug log statement for `crc-exists` file from filestore Exists() method

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
1. Start CRC cluster and monitor crc.log file 
2. It should not have redundant log statement for checking `crc-exists` file

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [x] Windows
    - [ ] MacOS