### PR TITLE
test (config) : Add some unit tests for config settings

### DIFF
--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -182,3 +182,183 @@ func TestPath(t *testing.T) {
 		IsSecret:  false,
 	}, cfg.Get(ProxyCAFile))
 }
+
+func TestWhenInvalidKeySetThenErrorIsThrown(t *testing.T) {
+	// Given
+	cfg, err := newInMemoryConfig()
+	require.NoError(t, err)
+
+	// When + Then
+	_, err = cfg.Set("i-dont-exist", "i-should-not-be-set")
+	assert.Error(t, err, "Configuration property 'i-dont-exist' does not exist")
+}
+
+var configDefaultValuesTestArguments = []struct {
+	key          string
+	defaultValue interface{}
+}{
+	{
+		KubeAdminPassword, "",
+	},
+	{
+		CPUs, uint(4),
+	},
+	{
+		Memory, uint(10752),
+	},
+	{
+		DiskSize, 31,
+	},
+	{
+		NameServer, "",
+	},
+	{
+		PullSecretFile, "",
+	},
+	{
+		DisableUpdateCheck, false,
+	},
+	{
+		ExperimentalFeatures, false,
+	},
+	{
+		EmergencyLogin, false,
+	},
+	{
+		PersistentVolumeSize, 15,
+	},
+	{
+		HostNetworkAccess, false,
+	},
+	{
+		HTTPProxy, "",
+	},
+	{
+		HTTPSProxy, "",
+	},
+	{
+		NoProxy, "",
+	},
+	{
+		ProxyCAFile, Path(""),
+	},
+	{
+		EnableClusterMonitoring, false,
+	},
+	{
+		ConsentTelemetry, "",
+	},
+	{
+		IngressHTTPPort, 80,
+	},
+	{
+		IngressHTTPSPort, 443,
+	},
+	{
+		EnableBundleQuayFallback, false,
+	},
+	{
+		Preset, "openshift",
+	},
+}
+
+func TestDefaultKeyValuesSetInConfig(t *testing.T) {
+	for _, tt := range configDefaultValuesTestArguments {
+		t.Run(tt.key, func(t *testing.T) {
+			// Given
+			cfg, err := newInMemoryConfig()
+			require.NoError(t, err)
+
+			// When + Then
+			assert.Equal(t, SettingValue{
+				Value:     tt.defaultValue,
+				Invalid:   false,
+				IsDefault: true,
+			}, cfg.Get(tt.key))
+		})
+	}
+}
+
+var configProvidedValuesTestArguments = []struct {
+	key           string
+	providedValue interface{}
+}{
+	{
+		KubeAdminPassword, "kubeadmin-secret-password",
+	},
+	{
+		CPUs, uint(8),
+	},
+	{
+		Memory, uint(21504),
+	},
+	{
+		DiskSize, 62,
+	},
+	{
+		NameServer, "127.0.0.1",
+	},
+	{
+		DisableUpdateCheck, true,
+	},
+	{
+		ExperimentalFeatures, true,
+	},
+	{
+		EmergencyLogin, true,
+	},
+	{
+		PersistentVolumeSize, 20,
+	},
+	{
+		HTTPProxy, "http://proxy-via-http-proxy-property:3128",
+	},
+	{
+		HTTPSProxy, "https://proxy-via-http-proxy-property:3128",
+	},
+	{
+		NoProxy, "http://no-proxy-property:3128",
+	},
+	{
+		EnableClusterMonitoring, true,
+	},
+	{
+		ConsentTelemetry, "yes",
+	},
+	{
+		IngressHTTPPort, 8080,
+	},
+	{
+		IngressHTTPSPort, 6443,
+	},
+	{
+		EnableBundleQuayFallback, true,
+	},
+	{
+		Preset, "microshift",
+	},
+}
+
+func TestSetProvidedValuesOverrideDefaultValuesInConfig(t *testing.T) {
+	for _, tt := range configProvidedValuesTestArguments {
+		t.Run(tt.key, func(t *testing.T) {
+
+			// When + Then
+
+			// Given
+			cfg, err := newInMemoryConfig()
+			require.NoError(t, err)
+
+			// When
+			_, err = cfg.Set(tt.key, tt.providedValue)
+			require.NoError(t, err)
+
+			// Then
+			assert.Equal(t, SettingValue{
+				Value:     tt.providedValue,
+				Invalid:   false,
+				IsDefault: false,
+			}, cfg.Get(tt.key))
+		})
+	}
+}


### PR DESCRIPTION



## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->


Relates to: #3832, PR #4451

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->
Extracted some unit tests out of #4451 as I needed them while working on #3832


## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
These unit tests verify these scenarios for config:
- when we try to set invalid key, throw error
- whether default key values are as expected
- whether we're able to override default values by providing new value

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
N/A

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS