### PR TITLE
gitignore: Fix cross-platform compatibility for sed in-place editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /docs/package-lock.json
 /release/
 /release-info.json
+/release-info.json-e
 *.crcbundle
 /tmp-embed/
 /RPMS/


### PR DESCRIPTION
- On macOS, `sed -i extension` requires a space between `-i` and the extension
  to perform in-place changes without creating a backup file.
- On Linux, `sed -i[extension]` or `--in-place[extension]` does not require a space,
  which makes it difficult to write a single command that works on both platforms.

As a result, the JSON backup file generated on macOS with the `-e` extension is ignored.

To test this change run `make gen_release_info` on all platform

- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS