### PR TITLE
build: Use backup file in gen_release_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /docs/package-lock.json
 /release/
 /release-info.json
-/release-info.json-e
+/release-info.json.bak
 *.crcbundle
 /tmp-embed/
 /RPMS/

--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,9 @@ cross-lint: $(TOOLS_BINDIR)/golangci-lint gen_release_info
 .PHONY: gen_release_info
 gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/$(CRC_VERSION)/ > $(RELEASE_INFO)
-	@sed -i"" -e s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
-	@sed -i"" -e s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
+	@sed -i.bak -e s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
+	@sed -i.bak -e s/@OPENSHIFT_VERSION@/$(OPENSHIFT_VERSION)/ $(RELEASE_INFO)
+	@rm -f $(RELEASE_INFO).bak
 
 .PHONY: linux-release-binary macos-release-binary windows-release-binary
 linux-release-binary: LDFLAGS+= $(RELEASE_VERSION_VARIABLES)


### PR DESCRIPTION
Using `sed -i` cross-platform is problematic as the `-i` flag does not
behave the same on macOS and linux (see 5e561ad5b).
The `sed` on macOS currently treat `-e` as a backup extension while on
linux it's treated as a flag. This does not seem to make a difference,
but it is very magic.

This commit specifies a backup extension to `sed -i`, which works for me
on macOS and linux. `-e` will be used as a flag on all platforms.



## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. check that `make gen_release_info` does not error out, generates a valid release-info.yaml file and does not leave a .bak file around
-->

## Contribution Checklist
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [x] MacOS


Haven't tested on Windows, but this would be needed as this was initially changed because of windows issues.