### PR TITLE
fix (console) : Throw error for `crc console` configured with MicroShift preset (#4561)

### DIFF
--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/crc-org/crc/v2/pkg/crc/preset"
+
 	"github.com/crc-org/crc/v2/pkg/crc/api/client"
 	"github.com/crc-org/crc/v2/pkg/crc/daemonclient"
 	crcErrors "github.com/crc-org/crc/v2/pkg/crc/errors"
@@ -44,6 +46,9 @@ func showConsole(client *daemonclient.Client) (*client.ConsoleResult, error) {
 
 func runConsole(writer io.Writer, client *daemonclient.Client, consolePrintURL, consolePrintCredentials bool, outputFormat string) error {
 	result, err := showConsole(client)
+	if err == nil && result.ClusterConfig.ClusterType == preset.Microshift {
+		err = fmt.Errorf("error : this option is only supported for %s and %s preset", preset.OpenShift, preset.OKD)
+	}
 	return render(&consoleResult{
 		Success:                 err == nil,
 		state:                   toState(result),


### PR DESCRIPTION




## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4561

Relates to: https://github.com/crc-org/docs/issues/16
<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->
Instead of printing wrong information simply throw an error to indicate to the user that `crc console` option is unsupported for MicroShift preset

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
Instead of printing wrong information like this:
```
To login as a regular user, run 'oc login -u developer -p developer '.
To login as an admin, run 'oc login -u kubeadmin -p  '
```
Thrown error message saying console option is not supported for MicroShift preset:
```
error : this option is not supported for microshift preset. Please refer to the documentation for a list of supported presets for using this option
```

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
1. `crc config set preset microshift`
2. `crc setup`
3. `crc start`
4. `crc console` should throw error

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [x] Windows
    - [ ] MacOS