### PR TITLE
refactor (shell) : detect shell on windows using gopsutil too (#4588)

### DIFF
--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -1,9 +1,13 @@
 package shell
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/shirou/gopsutil/v4/process"
+	"github.com/spf13/cast"
 
 	crcos "github.com/crc-org/crc/v2/pkg/os"
 )
@@ -11,6 +15,8 @@ import (
 var (
 	CommandRunner                           = crcos.NewLocalCommandRunner()
 	WindowsSubsystemLinuxKernelMetadataFile = "/proc/version"
+	ErrUnknownShell                         = errors.New("Error: Unknown shell")
+	currentProcessSupplier                  = createCurrentProcess
 )
 
 type Config struct {
@@ -18,6 +24,20 @@ type Config struct {
 	Delimiter  string
 	Suffix     string
 	PathSuffix string
+}
+
+// AbstractProcess is an interface created to abstract operations of the gopsutil library
+// It is created so that we can override the behavior while writing unit tests by providing
+// a mock implementation.
+type AbstractProcess interface {
+	Name() (string, error)
+	Parent() (AbstractProcess, error)
+}
+
+// RealProcess is a wrapper implementation of AbstractProcess to wrap around the gopsutil library's
+// process.Process object. This implementation is used in production code.
+type RealProcess struct {
+	*process.Process
 }
 
 func GetShell(userShell string) (string, error) {
@@ -150,4 +170,51 @@ func IsWindowsSubsystemLinux() bool {
 		return true
 	}
 	return false
+}
+
+func (p *RealProcess) Parent() (AbstractProcess, error) {
+	parentProcess, err := p.Process.Parent()
+	if err != nil {
+		return nil, err
+	}
+	return &RealProcess{parentProcess}, nil
+}
+
+func createCurrentProcess() AbstractProcess {
+	currentProcess, err := process.NewProcess(cast.ToInt32(os.Getpid()))
+	if err != nil {
+		return nil
+	}
+	return &RealProcess{currentProcess}
+}
+
+// detectShellByCheckingProcessTree attempts to identify the shell being used by
+// examining the process tree starting from the given process ID. This function
+// traverses up to ProcessDepthLimit levels up the process hierarchy.
+// Parameters:
+//   - pid (int): The process ID to start checking from.
+//
+// Returns:
+//   - string: The name of the shell if found (e.g., "zsh", "bash", "fish");
+//     otherwise, an empty string is returned if no matching shell is detected
+//     or an error occurs during the process tree traversal.
+//
+// Examples:
+//
+//	shellName := detectShellByCheckingProcessTree(1234)
+func detectShellByCheckingProcessTree(p AbstractProcess) string {
+	for p != nil {
+		processName, err := p.Name()
+		if err != nil {
+			return ""
+		}
+		if processName == "zsh" || processName == "bash" || processName == "fish" {
+			return processName
+		}
+		p, err = p.Parent()
+		if err != nil {
+			return ""
+		}
+	}
+	return ""
 }

--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/shirou/gopsutil/v4/process"
@@ -208,7 +209,9 @@ func detectShellByCheckingProcessTree(p AbstractProcess) string {
 		if err != nil {
 			return ""
 		}
-		if processName == "zsh" || processName == "bash" || processName == "fish" {
+		if slices.ContainsFunc(supportedShell, func(listElem string) bool {
+			return strings.HasPrefix(processName, listElem)
+		}) {
 			return processName
 		}
 		p, err = p.Parent()

--- a/pkg/os/shell/shell_darwin.go
+++ b/pkg/os/shell/shell_darwin.go
@@ -1,5 +1,0 @@
-package shell
-
-var (
-	supportedShell = []string{"bash", "zsh", "fish"}
-)

--- a/pkg/os/shell/shell_linux.go
+++ b/pkg/os/shell/shell_linux.go
@@ -1,5 +1,0 @@
-package shell
-
-var (
-	supportedShell = []string{"bash", "zsh", "fish"}
-)

--- a/pkg/os/shell/shell_unix.go
+++ b/pkg/os/shell/shell_unix.go
@@ -4,49 +4,9 @@
 package shell
 
 import (
-	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
-
-	"github.com/shirou/gopsutil/v4/process"
-	"github.com/spf13/cast"
 )
-
-var (
-	ErrUnknownShell        = errors.New("Error: Unknown shell")
-	currentProcessSupplier = createCurrentProcess
-)
-
-// AbstractProcess is an interface created to abstract operations of the gopsutil library
-// It is created so that we can override the behavior while writing unit tests by providing
-// a mock implementation.
-type AbstractProcess interface {
-	Name() (string, error)
-	Parent() (AbstractProcess, error)
-}
-
-// RealProcess is a wrapper implementation of AbstractProcess to wrap around the gopsutil library's
-// process.Process object. This implementation is used in production code.
-type RealProcess struct {
-	*process.Process
-}
-
-func (p *RealProcess) Parent() (AbstractProcess, error) {
-	parentProcess, err := p.Process.Parent()
-	if err != nil {
-		return nil, err
-	}
-	return &RealProcess{parentProcess}, nil
-}
-
-func createCurrentProcess() AbstractProcess {
-	currentProcess, err := process.NewProcess(cast.ToInt32(os.Getpid()))
-	if err != nil {
-		return nil
-	}
-	return &RealProcess{currentProcess}
-}
 
 // detect detects user's current shell.
 func detect() (string, error) {
@@ -57,35 +17,4 @@ func detect() (string, error) {
 	}
 
 	return filepath.Base(detectedShell), nil
-}
-
-// detectShellByCheckingProcessTree attempts to identify the shell being used by
-// examining the process tree starting from the given process ID. This function
-// traverses up to ProcessDepthLimit levels up the process hierarchy.
-// Parameters:
-//   - pid (int): The process ID to start checking from.
-//
-// Returns:
-//   - string: The name of the shell if found (e.g., "zsh", "bash", "fish");
-//     otherwise, an empty string is returned if no matching shell is detected
-//     or an error occurs during the process tree traversal.
-//
-// Examples:
-//
-//	shellName := detectShellByCheckingProcessTree(1234)
-func detectShellByCheckingProcessTree(p AbstractProcess) string {
-	for p != nil {
-		processName, err := p.Name()
-		if err != nil {
-			return ""
-		}
-		if processName == "zsh" || processName == "bash" || processName == "fish" {
-			return processName
-		}
-		p, err = p.Parent()
-		if err != nil {
-			return ""
-		}
-	}
-	return ""
 }

--- a/pkg/os/shell/shell_unix.go
+++ b/pkg/os/shell/shell_unix.go
@@ -8,6 +8,10 @@ import (
 	"path/filepath"
 )
 
+var (
+	supportedShell = []string{"bash", "zsh", "fish"}
+)
+
 // detect detects user's current shell.
 func detect() (string, error) {
 	detectedShell := detectShellByCheckingProcessTree(currentProcessSupplier())

--- a/pkg/os/shell/shell_unix_test.go
+++ b/pkg/os/shell/shell_unix_test.go
@@ -5,34 +5,11 @@ package shell
 
 import (
 	"bytes"
-	"errors"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// MockedProcess is a mock implementation of AbstractProcess for testing purposes.
-type MockedProcess struct {
-	name           string
-	parent         *MockedProcess
-	nameGetFails   bool
-	parentGetFails bool
-}
-
-func (m MockedProcess) Parent() (AbstractProcess, error) {
-	if m.parentGetFails || m.parent == nil {
-		return nil, errors.New("failed to get the pid")
-	}
-	return m.parent, nil
-}
-
-func (m MockedProcess) Name() (string, error) {
-	if m.nameGetFails {
-		return "", errors.New("failed to get the name")
-	}
-	return m.name, nil
-}
 
 func TestUnknownShell(t *testing.T) {
 	tests := []struct {
@@ -182,17 +159,4 @@ func TestGetCurrentProcess(t *testing.T) {
 	currentProcessName, err := currentProcess.Name()
 	assert.NoError(t, err)
 	assert.Greater(t, len(currentProcessName), 0)
-}
-
-func createNewMockProcessTreeFrom(processes []MockedProcess) AbstractProcess {
-	if len(processes) == 0 {
-		return nil
-	}
-	head := &processes[0]
-	current := head
-	for i := 1; i < len(processes); i++ {
-		current.parent = &processes[i]
-		current = current.parent
-	}
-	return head
 }


### PR DESCRIPTION

## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
As a follow up to #4572, updating shell detection logic on windows to also rely on gopsutil library to detect the shell name by inspecting parent processes of `crc.exe` process.

Fixes: #4588

Relates to: PR #4572

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
This PR mostly includes moving some methods so that they become accessible in windows environments too.

+ Move shell detection using `gopsutil` logic from `shell_unix.go` -> `shell.go` so that it can be reused in `shell_windows.go` as well
+ Remove `shell_linux.go`/ `shell_darwin.go` as they only contained a single constant that I moved to `shell_unix.go`
+ Remove `getProcessEntry` and related methods from `shell_windows.go` as we're reusing gopsutil approach that is working well on Windows

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
1. Start CRC in windows environment
2. Verify `crc oc-env` is working as expected in 
    - CMD
    - PowerShell
    - GitBash
    - WSL
      - bash
      - fish
      - zsh

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [x] Windows
    - [x] MacOS