### PR TITLE
Spec: use inbuild gobuildid to generate build id with -B option

### DIFF
--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -65,7 +65,7 @@ export GOFLAGS="-mod=vendor"
 mkdir embed-files
 cp /usr/bin/crc-driver-libvirt embed-files/crc-driver-libvirt-%{gohostarch}
 cp /usr/bin/crc-admin-helper embed-files/crc-admin-helper-linux-%{gohostarch}
-make COMMIT_SHA=__COMMIT_SHA__ GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ release
+make COMMIT_SHA=__COMMIT_SHA__ GO_EXTRA_LDFLAGS="-B gobuildid" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ release
 
 %install
 # with fedora macros: gopkginstall


### PR DESCRIPTION
As of now, a random build ID (20 digits) generated and added to binary but with go-1.23.x it is causing following issue in the CI

```
/usr/lib/golang/pkg/tool/linux_amd64/link: -B option too long (max 16 digits): 0x1c32bce09ea23923c57a3cca65fd91e377714192
```

Looks like `gobuilid` can be used to generate it with -B options without random ID hack and it can work without isssue for CI

- https://github.com/golang/go/issues/70380

```
$ readelf -n out/linux-amd64/crc

Displaying notes found in: .note.gnu.property
  Owner                Data size 	Description
  GNU                  0x00000010	NT_GNU_PROPERTY_TYPE_0
      Properties: x86 ISA needed: x86-64-baseline

Displaying notes found in: .note.gnu.build-id
  Owner                Data size 	Description
  GNU                  0x00000014	NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: f1c4d1d70301bc12737353faf4ee38de3cd25930

```

