### PR TITLE
refactor: replace custom slice Contains method with `slices.Contains`

### DIFF
--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -17,7 +18,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
-	crcstrings "github.com/crc-org/crc/v2/pkg/strings"
 	openshiftapi "github.com/openshift/api/config/v1"
 	k8sapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,7 +95,7 @@ func getStatus(ctx context.Context, lister operatorLister, selector []string) (*
 
 	found := false
 	for _, c := range co.Items {
-		if len(selector) > 0 && !crcstrings.Contains(selector, c.ObjectMeta.Name) {
+		if len(selector) > 0 && !slices.Contains(selector, c.ObjectMeta.Name) {
 			continue
 		}
 		found = true

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/extract"
 	crcos "github.com/crc-org/crc/v2/pkg/os"
-	crcstrings "github.com/crc-org/crc/v2/pkg/strings"
 	"github.com/pkg/errors"
 )
 
@@ -58,7 +58,7 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 	// TODO: update this logic after major release of bundle like 4.14
 	// As of now we are using this logic to support older bundles of microshift and it need to be updated
 	// to only provide app domain route information as per preset.
-	if !crcstrings.Contains([]string{constants.AppsDomain, constants.MicroShiftAppDomain}, fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain)) {
+	if !slices.Contains([]string{constants.AppsDomain, constants.MicroShiftAppDomain}, fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain)) {
 		return nil, fmt.Errorf("unexpected bundle, it must have %s or %s apps domain", constants.AppsDomain, constants.MicroShiftAppDomain)
 	}
 	if bundleInfo.GetAPIHostname() != fmt.Sprintf("api%s", constants.ClusterDomain) {

--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -242,14 +243,14 @@ func cleanKubeconfig(input, output string) error {
 	var contextNames []string
 	authNames := make(map[string]struct{})
 	for name, context := range cfg.Contexts {
-		if contains(clusterNames, context.Cluster) {
+		if slices.Contains(clusterNames, context.Cluster) {
 			contextNames = append(contextNames, name)
 			authNames[context.AuthInfo] = struct{}{}
 		}
 	}
 	// keep auth if it is shared with other contexts
 	for _, context := range cfg.Contexts {
-		if !contains(clusterNames, context.Cluster) {
+		if !slices.Contains(clusterNames, context.Cluster) {
 			delete(authNames, context.AuthInfo)
 		}
 	}
@@ -268,15 +269,6 @@ func cleanKubeconfig(input, output string) error {
 	}
 
 	return clientcmd.WriteToFile(*cfg, output)
-}
-
-func contains(arr []string, str string) bool {
-	for _, a := range arr {
-		if a == str {
-			return true
-		}
-	}
-	return false
 }
 
 func mergeKubeConfigFile(kubeConfigFile string) error {

--- a/pkg/crc/manpages/manpages_unix.go
+++ b/pkg/crc/manpages/manpages_unix.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra/doc"
@@ -89,12 +90,7 @@ func appendToManPathEnvironmentVariable(folder string) error {
 
 func manPathAlreadyContains(manPathEnvVarValue string, folder string) bool {
 	manDirs := strings.Split(manPathEnvVarValue, string(os.PathListSeparator))
-	for _, manDir := range manDirs {
-		if manDir == folder {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(manDirs, folder)
 }
 
 func removeFromManPathEnvironmentVariable(manPathEnvVarValue string, folder string) error {

--- a/pkg/crc/preflight/preflight_checks_network_linux.go
+++ b/pkg/crc/preflight/preflight_checks_network_linux.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/systemd"
 	"github.com/crc-org/crc/v2/pkg/crc/systemd/states"
 	crcos "github.com/crc-org/crc/v2/pkg/os"
-	crcstring "github.com/crc-org/crc/v2/pkg/strings"
 )
 
 var nmPreflightChecks = []Check{
@@ -287,7 +287,7 @@ func checkSystemdResolvedIsRunning() error {
 	if err != nil {
 		return err
 	}
-	if !crcstring.Contains(systemdResolvedManageResolvFilePath, rFilePath) {
+	if !slices.Contains(systemdResolvedManageResolvFilePath, rFilePath) {
 		return fmt.Errorf("%s is not managed by systemd-resolved", resolvFilePath)
 	}
 	return checkSystemdServiceRunning("systemd-resolved.service")

--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -5,15 +5,6 @@ import (
 	"strings"
 )
 
-func Contains(input []string, match string) bool {
-	for _, v := range input {
-		if v == match {
-			return true
-		}
-	}
-	return false
-}
-
 // Split a multi line string in an array of string, one for each line
 func SplitLines(input string) []string {
 	output := []string{}

--- a/pkg/strings/strings_test.go
+++ b/pkg/strings/strings_test.go
@@ -6,51 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type containsTest struct {
-	input []string
-	match string
-	found bool
-}
-
-var containsTests = map[string]containsTest{
-	"Found": {
-		input: []string{"a", "b", "c"},
-		match: "b",
-		found: true,
-	},
-	"NotFound": {
-		input: []string{"a", "b", "c"},
-		match: "d",
-		found: false,
-	},
-	"OneElement": {
-		input: []string{"a"},
-		match: "a",
-		found: true,
-	},
-	"EmptyArray": {
-		input: []string{},
-		match: "a",
-		found: false,
-	},
-	"EmptyArrayEmptySearch": {
-		input: []string{},
-		match: "",
-		found: false,
-	},
-}
-
-func TestContains(t *testing.T) {
-	t.Run("Contains", func(t *testing.T) {
-		for name, test := range containsTests {
-			t.Run(name, func(t *testing.T) {
-				found := Contains(test.input, test.match)
-				assert.Equal(t, test.found, found)
-			})
-		}
-	})
-}
-
 type splitLinesTest struct {
 	input       string
 	splitOutput []string


### PR DESCRIPTION


## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Replaced the custom implementation of the slice Contains method with built-in [`slices.Contains`](https://pkg.go.dev/slices#Contains) function from the Go standard library.

This simplifies the code and improves readability and maintainability.


Relates to: PR https://github.com/crc-org/crc/pull/4591#discussion_r1940899623

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
- Remove crcstrings.Contains method from crcstrings package
- Use [`slices.Contains`](https://pkg.go.dev/slices#Contains) function from the Go standard library in removed method's place.

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
I've just verified that project is building and all tests are passing.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS