### PR TITLE
fix (daemon) : Add `docker.internal` entry to virtual network DNS config (#3784)

### DIFF
--- a/cmd/crc/cmd/daemon_test.go
+++ b/cmd/crc/cmd/daemon_test.go
@@ -3,12 +3,16 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"testing"
 
+	"github.com/containers/gvisor-tap-vsock/pkg/types"
 	"github.com/crc-org/crc/v2/pkg/crc/api/client"
+	crcConfig "github.com/crc-org/crc/v2/pkg/crc/config"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -83,4 +87,70 @@ func TestCheckDaemonVersion_WhenErrorReturnedWhileFetchingVersion_ThenReturnFals
 	// Then
 	assert.NoError(t, err)
 	assert.Equal(t, false, result)
+}
+
+func TestCreateNewVirtualNetworkConfig(t *testing.T) {
+	// Given
+	oldPcapFileEnvVal := os.Getenv("CRC_DAEMON_PCAP_FILE")
+	err := os.Setenv("CRC_DAEMON_PCAP_FILE", "/tmp/pcapfile")
+	assert.NoError(t, err)
+	defer func(key, value string) {
+		err := os.Setenv(key, value)
+		assert.NoError(t, err)
+	}("CRC_DAEMON_PCAP_FILE", oldPcapFileEnvVal)
+	testCrcConfig := crcConfig.New(crcConfig.NewEmptyInMemoryStorage(), crcConfig.NewEmptyInMemorySecretStorage())
+
+	// When
+	virtualNetworkConfig := createNewVirtualNetworkConfig(testCrcConfig)
+
+	// Then
+	assert.Equal(t, false, virtualNetworkConfig.Debug)
+	assert.Equal(t, "/tmp/pcapfile", virtualNetworkConfig.CaptureFile)
+	assert.Equal(t, 4000, virtualNetworkConfig.MTU)
+	assert.Equal(t, "192.168.127.0/24", virtualNetworkConfig.Subnet)
+	assert.Equal(t, "192.168.127.1", virtualNetworkConfig.GatewayIP)
+	assert.ElementsMatch(t, []string{"192.168.127.254"}, virtualNetworkConfig.GatewayVirtualIPs)
+	assert.Equal(t, "5a:94:ef:e4:0c:dd", virtualNetworkConfig.GatewayMacAddress)
+	assert.Equal(t, types.Protocol("hyperkit"), virtualNetworkConfig.Protocol)
+
+	assert.Len(t, virtualNetworkConfig.DHCPStaticLeases, 1)
+	assert.Equal(t, "5a:94:ef:e4:0c:ee", virtualNetworkConfig.DHCPStaticLeases["192.168.127.2"])
+
+	assert.Len(t, virtualNetworkConfig.DNS, 4)
+	assert.Equal(t, "apps-crc.testing.", virtualNetworkConfig.DNS[0].Name)
+	assert.Equal(t, net.ParseIP("192.168.127.2"), virtualNetworkConfig.DNS[0].DefaultIP)
+	assert.Equal(t, "crc.testing.", virtualNetworkConfig.DNS[1].Name)
+	assert.Equal(t, "host", virtualNetworkConfig.DNS[1].Records[0].Name)
+	assert.Equal(t, net.ParseIP("192.168.127.254"), virtualNetworkConfig.DNS[1].Records[0].IP)
+	assert.Equal(t, "gateway", virtualNetworkConfig.DNS[1].Records[1].Name)
+	assert.Equal(t, net.ParseIP("192.168.127.1"), virtualNetworkConfig.DNS[1].Records[1].IP)
+	assert.Equal(t, "api", virtualNetworkConfig.DNS[1].Records[2].Name)
+	assert.Equal(t, net.ParseIP("192.168.127.2"), virtualNetworkConfig.DNS[1].Records[2].IP)
+	assert.Equal(t, "api-int", virtualNetworkConfig.DNS[1].Records[3].Name)
+	assert.Equal(t, net.ParseIP("192.168.127.2"), virtualNetworkConfig.DNS[1].Records[3].IP)
+	assert.Equal(t, regexp.MustCompile("crc-(.*?)-master-0"), virtualNetworkConfig.DNS[1].Records[4].Regexp)
+	assert.Equal(t, net.ParseIP("192.168.126.11"), virtualNetworkConfig.DNS[1].Records[4].IP)
+
+	assert.Equal(t, "containers.internal.", virtualNetworkConfig.DNS[2].Name)
+	assert.Len(t, virtualNetworkConfig.DNS[2].Records, 1)
+	assert.Equal(t, "gateway", virtualNetworkConfig.DNS[2].Records[0].Name)
+	assert.Equal(t, net.ParseIP("192.168.127.254"), virtualNetworkConfig.DNS[2].Records[0].IP)
+	assert.Equal(t, "docker.internal.", virtualNetworkConfig.DNS[3].Name)
+	assert.Len(t, virtualNetworkConfig.DNS[3].Records, 1)
+	assert.Equal(t, "gateway", virtualNetworkConfig.DNS[3].Records[0].Name)
+	assert.Equal(t, net.ParseIP("192.168.127.254"), virtualNetworkConfig.DNS[3].Records[0].IP)
+}
+
+func TestCreateNewVirtualNetworkConfig_WhenHostNetworkConfigSet_ThenSetNAT(t *testing.T) {
+	// Given
+	testCrcConfig := crcConfig.New(crcConfig.NewEmptyInMemoryStorage(), crcConfig.NewEmptyInMemorySecretStorage())
+	testCrcConfig.AddSetting("host-network-access", false, crcConfig.ValidateBool, crcConfig.SuccessfullyApplied, "test message")
+	_, err := testCrcConfig.Set(crcConfig.HostNetworkAccess, true)
+	assert.NoError(t, err)
+
+	// When
+	virtualNetworkConfig := createNewVirtualNetworkConfig(testCrcConfig)
+
+	// Then
+	assert.Equal(t, "127.0.0.1", virtualNetworkConfig.NAT["192.168.127.254"])
 }


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #3784

Port of https://github.com/containers/gvisor-tap-vsock/pull/251 to add `docker.internal.` DNS record to CRC daemon virtual network config.

Relates to: PR https://github.com/containers/gvisor-tap-vsock/pull/251

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
+ Move virtualNetwork config construction to a method so that it becomes testable
+ Add another entry to DNS zones for `docker.internal.`

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
I've only verified it using a unit test.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS