### PR TITLE
test (e2e) : add more assertions to verify crc status output

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -41,6 +41,7 @@ Feature: Basic test
         * stdout should match "(?s)(.*)https:\/\/console-openshift-console\.apps-crc\.testing(.*)$"
         # status
         When checking that CRC is running
+        And checking the CRC status JSON output is valid
         # ip
         When executing crc ip command succeeds
         Then stdout should match "\d+\.\d+\.\d+\.\d+"

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -14,6 +14,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/common/pkg/strongunits"
+	"github.com/spf13/cast"
+
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/machine"
 	"github.com/crc-org/crc/v2/pkg/crc/preset"
@@ -515,6 +518,8 @@ func InitializeScenario(s *godog.ScenarioContext) {
 		CheckOutputMatchWithRetry)
 	s.Step(`^checking that CRC is (running|stopped)$`,
 		CheckCRCStatus)
+	s.Step(`^checking the CRC status JSON output is valid$`,
+		CheckCRCStatusJSONOutput)
 	s.Step(`^execut(?:e|ing) crc (.*) command$`,
 		ExecuteCRCCommand)
 	s.Step(`^execut(?:e|ing) crc (.*) command (.*)$`,
@@ -688,6 +693,52 @@ func CheckCRCStatus(state string) error {
 		return crcCmd.WaitForClusterInState(state)
 	}
 	return crcCmd.CheckCRCStatus(state)
+}
+
+func CheckCRCStatusJSONOutput() error {
+	err := util.ExecuteCommand("crc status -ojson")
+	if err != nil {
+		return err
+	}
+	crcStatusJSONOutput := util.GetLastCommandOutput("stdout")
+	var crcStatusJSONOutputObj map[string]interface{}
+	if err := json.Unmarshal([]byte(crcStatusJSONOutput), &crcStatusJSONOutputObj); err != nil {
+		return err
+	}
+	crcStatusSuccess := crcStatusJSONOutputObj["success"]
+	if crcStatusSuccess != true {
+		return fmt.Errorf("failure in asserting 'success' field of crc status json output, expected : true, actual : %t", crcStatusSuccess)
+	}
+	crcStatus := crcStatusJSONOutputObj["crcStatus"]
+	if crcStatus != "Running" {
+		return fmt.Errorf("failure in asserting 'crcStatus' field of crc status json output, expected : 'Running', actual : %s", crcStatus)
+	}
+	crcCacheDir := crcStatusJSONOutputObj["cacheDir"]
+	if crcCacheDir != filepath.Join(util.CRCHome, "cache") {
+		return fmt.Errorf("failure is asserting 'cacheDir' field of crc status json output, expected : %s, actual %s", filepath.Join(util.CRCHome, "cache"), crcCacheDir)
+	}
+	crcOpenShiftStatus := crcStatusJSONOutputObj["openshiftStatus"]
+	if crcOpenShiftStatus != "Running" {
+		return fmt.Errorf("failure in asserting 'openshiftStatus' field of crc status json output, expected : 'Running', actual : %s", crcOpenShiftStatus)
+	}
+	crcOpenShiftVersion := crcStatusJSONOutputObj["openshiftVersion"]
+	if !strings.HasPrefix(cast.ToString(crcOpenShiftVersion), "4.") {
+		return fmt.Errorf("failure in asserting 'openshiftVersion' field of crc status json output, expected with prefix: '4.', actual : %s", crcOpenShiftVersion)
+	}
+	crcPresetStr := crcStatusJSONOutputObj["preset"]
+	crcPreset, err := preset.ParsePresetE(crcPresetStr.(string))
+	if err != nil {
+		return fmt.Errorf("failure in asserting 'preset' field of crc status json output, %v", err)
+	}
+	crcDiskSize := crcStatusJSONOutputObj["diskSize"]
+	if strongunits.B(cast.ToUint64(crcDiskSize)) > strongunits.GiB(constants.DefaultDiskSize).ToBytes() {
+		return fmt.Errorf("failure in asserting 'diskSize' field of crc status json output, expected less than or equal to %d bytes, actual : %d bytes", strongunits.GiB(constants.DefaultDiskSize).ToBytes(), strongunits.B(cast.ToUint64(crcDiskSize)))
+	}
+	crcRAMSize := crcStatusJSONOutputObj["ramSize"]
+	if strongunits.B(cast.ToUint64(crcRAMSize)) > constants.GetDefaultMemory(crcPreset).ToBytes() {
+		return fmt.Errorf("failure in asserting 'ramSize' field of crc status json output, expected less than or equal to %d bytes, actual : %d bytes", constants.GetDefaultMemory(crcPreset).ToBytes(), cast.ToUint64(crcRAMSize))
+	}
+	return nil
 }
 
 func DeleteFileFromCRCHome(fileName string) error {


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

~:warning: This test is expected to fail on main branch, it should be merged after #4603~

Add stricter assertions to verify output of crc status.

We only verify that the CRC status output contains the keyword `Running` or `Stopped`, depending on the cluster state. However, we should also verify other attributes, such as `diskSize`, `ramsSize`, `openshiftStatus`, `cacheDir`, etc.

Relates to: PR #4603

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
Add another step in basic test scenario to verify output of `crc status -ojson`. Parse JSON output into a map and verify that values are as expected or within allowed limit.

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
I just verified that Basic scenario E2E test is passing when #4603 is applied.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [x] MacOS