### PR TITLE
Clean filepath before reading the content

### DIFF
--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -38,7 +38,7 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 		return nil, errors.Wrapf(err, "could not find cached bundle info in %s", path)
 	}
 	jsonFilepath := filepath.Join(path, metadataFilename)
-	content, err := os.ReadFile(jsonFilepath)
+	content, err := os.ReadFile(filepath.Clean(jsonFilepath))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %s file", jsonFilepath)
 	}


### PR DESCRIPTION
Looks like security job is failing because it detect unsanitized input from file, this should fix following

```
  ✗ [Medium] Path Traversal
   ID: 2ce4a8d7-4fb1-41b5-8841-dc76ea48e503
   Path: pkg/crc/machine/bundle/repository.go, line 41
   Info: Unsanitized input from file name flows into os.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
```

