### PR TITLE
test (e2e) : move manpage checks to a separate scenario (#4608)

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -35,7 +35,6 @@ Feature: Basic test
         * setting config property "enable-cluster-monitoring" to value "true" succeeds
         * setting config property "memory" to value "16000" succeeds
         Given executing single crc setup command succeeds
-        And executing "man -P cat crc" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         # Check if user can copy-paste login details for developer and kubeadmin users
@@ -74,4 +73,3 @@ Feature: Basic test
         And kubeconfig is cleaned up
         # cleanup
         When executing crc cleanup command succeeds
-        And executing "man -P cat crc" fails

--- a/test/e2e/features/manpages.feature
+++ b/test/e2e/features/manpages.feature
@@ -1,0 +1,58 @@
+@story_manpages
+Feature: Check generation and cleanup of manpages
+
+  @linux @darwin
+  Scenario Outline: verify man pages are accessible after setup
+    Given executing single crc setup command succeeds
+    And executing "export MANPATH=$HOME/.local/share/man:$MANPATH" succeeds
+    Then executing "man -P cat 1 <crc-subcommand>" succeeds
+
+    @linux @darwin
+    Examples: Man pages to check
+      | crc-subcommand       |
+      | crc                  |
+      | crc-bundle-generate  |
+      | crc-config           |
+      | crc-start            |
+      | crc-bundle           |
+      | crc-console          |
+      | crc-status           |
+      | crc-cleanup          |
+      | crc-delete           |
+      | crc-stop             |
+      | crc-config-get       |
+      | crc-ip               |
+      | crc-version          |
+      | crc-config-set       |
+      | crc-oc-env           |
+      | crc-config-unset     |
+      | crc-podman-env       |
+      | crc-config-view      |
+      | crc-setup            |
+
+  Scenario Outline: verify man pages are NOT accessible after cleanup
+    Given executing crc cleanup command succeeds
+    Then executing "man -P cat 1 <crc-subcommand>" fails
+
+    @linux @darwin
+    Examples: Man pages to check
+      | crc-subcommand       |
+      | crc                  |
+      | crc-bundle-generate  |
+      | crc-config           |
+      | crc-start            |
+      | crc-bundle           |
+      | crc-console          |
+      | crc-status           |
+      | crc-cleanup          |
+      | crc-delete           |
+      | crc-stop             |
+      | crc-config-get       |
+      | crc-ip               |
+      | crc-version          |
+      | crc-config-set       |
+      | crc-oc-env           |
+      | crc-config-unset     |
+      | crc-podman-env       |
+      | crc-config-view      |
+      | crc-setup            |


### PR DESCRIPTION
## Description



<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4608 

Relates to: #4586


<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->
In #4586 , I had added step to check `man -P cat crc` to verify whether man pages are correctly generated after executing `crc setup` in basic scenario
- Currently, man pages are only generated for Linux/MacOS. I had added this in basic scenario which caused failure on Windows.
- On MacOS, I'm seeing an issue that if for some reason `manpath` is not updated correctly; `man` command fails to list manpages for CRC. I see that there is an already existing entry for some crc named man page (see https://github.com/crc-org/crc/issues/4608#issuecomment-2650598324)

Update `basic.feature` to remove manpage checks and add a new scenario `manpages.feature` to verify manpage generation and cleanup. This new scenario would only be enabled for `@darwin` and `@linux` environments.

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
These changes update how we verify manpage generation:
+ Update manpages step in basic scenario to skip execution for windows
+ Instead of relying of man command output, only verify whether we've generated the man pages files correctly in the specified directory.

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
I've run `manpages.feature` on MacOS, Linux machine to verify that these changes don't break anything.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [x] MacOS