### PR TITLE
CI: Update ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -14,7 +14,7 @@ jobs:
           - macOS-13
           - macOS-14
           - ubuntu-latest
-          - ubuntu-20.04
+          - ubuntu-22.04
         go:
           - '1.22'
     steps:


### PR DESCRIPTION
Ubuntu 20.04 is gonna be dimissed on March, oldest one available will be 22.04