### PR TITLE
[QE] Set env var windows

### DIFF
--- a/test/extended/crc/cmd/cmd.go
+++ b/test/extended/crc/cmd/cmd.go
@@ -89,19 +89,12 @@ func (c Command) Execute() error {
 func (c Command) env() []string {
 	var env []string
 	if !c.updateCheck {
-		env = append(env, envVariable("CRC_DISABLE_UPDATE_CHECK", "true"))
+		env = append(env, util.EnvVariable("CRC_DISABLE_UPDATE_CHECK", "true"))
 	}
 	if c.disableNTP {
-		env = append(env, envVariable("CRC_DEBUG_ENABLE_STOP_NTP", "true"))
+		env = append(env, util.EnvVariable("CRC_DEBUG_ENABLE_STOP_NTP", "true"))
 	}
 	return env
-}
-
-func envVariable(key, value string) string {
-	if runtime.GOOS == "windows" {
-		return fmt.Sprintf("$env:%s=%s;", key, value)
-	}
-	return fmt.Sprintf("%s=%s", key, value)
 }
 
 func (c Command) validate() error {

--- a/test/extended/crc/cmd/cmd_test.go
+++ b/test/extended/crc/cmd/cmd_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestCommand(t *testing.T) {
 	assert.Equal(t, "crc setup", Command{
-		command: "setup",
+		command:     "setup",
+		updateCheck: true,
 	}.ToString())
 	assert.Equal(t, "CRC_DEBUG_ENABLE_STOP_NTP=true crc start -b bundle", Command{
 		command:     "start -b bundle",
@@ -16,7 +17,8 @@ func TestCommand(t *testing.T) {
 		updateCheck: true,
 	}.ToString())
 	assert.Equal(t, "CRC_DISABLE_UPDATE_CHECK=true CRC_DEBUG_ENABLE_STOP_NTP=true crc start -b bundle", Command{
-		command:    "start -b bundle",
-		disableNTP: true,
+		command:     "start -b bundle",
+		disableNTP:  true,
+		updateCheck: false,
 	}.ToString())
 }

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -22,6 +22,23 @@ var (
 	CRCHome string
 )
 
+func EnvVariable(key, value string) string {
+	var prefix = ""
+	var suffix = ""
+	if runtime.GOOS == "windows" {
+		prefix = "$env:"
+		suffix = ";"
+		switch value {
+		case "true":
+			value = "$true"
+		case "false":
+			value = "$false"
+		default:
+		}
+	}
+	return fmt.Sprintf("%s%s=%s%s", prefix, key, value, suffix)
+}
+
 func CopyFilesToTestDir() error {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/crc-org/crc/v2/test/extended/crc/cmd"
+	"github.com/crc-org/crc/v2/test/extended/util"
 	. "github.com/onsi/gomega"
 )
 
@@ -21,8 +22,8 @@ type CRCBuilder struct {
 // NewCRCCommand returns a CRCBuilder for running CRC.
 func NewCRCCommand(args ...string) *CRCBuilder {
 	cmd := exec.Command("crc", args...)
-	cmd.Env = append(os.Environ(), "CRC_DISABLE_UPDATE_CHECK=true")
-	cmd.Env = append(os.Environ(), "CRC_LOG_LEVEL=debug")
+	cmd.Env = append(os.Environ(), util.EnvVariable("CRC_DISABLE_UPDATE_CHECK", "true"))
+	cmd.Env = append(cmd.Env, util.EnvVariable("CRC_LOG_LEVEL", "debug"))
 	return &CRCBuilder{
 		cmd: cmd,
 	}


### PR DESCRIPTION
## Description

CI sets some configurations using env var, `FOO=bar`, but windows do not support that format, it should be `$env:FOO=bar;`

Fixes: #4618 