### PR TITLE
test (machine) : add some unit tests for growing lvm size based on `persistent-volume-size` config option in microshift preset

### DIFF
--- a/pkg/crc/config/validations_test.go
+++ b/pkg/crc/config/validations_test.go
@@ -136,3 +136,25 @@ func TestValidateNoProxy(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePersistentVolumeSize(t *testing.T) {
+	tests := []struct {
+		name                     string
+		persistentVolumeSize     string
+		expectedValidationResult bool
+	}{
+		{"equal to 15G", "15", true},
+		{"greater than 15G", "20", true},
+		{"less than 15G", "7", false},
+		{"invalid integer value", "an-elephant", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualValidationResult, _ := validatePersistentVolumeSize(tt.persistentVolumeSize)
+			if actualValidationResult != tt.expectedValidationResult {
+				t.Errorf("validatePersistentVolumeSize(%s) : got %v, want %v", tt.persistentVolumeSize, actualValidationResult, tt.expectedValidationResult)
+			}
+		})
+	}
+}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -169,7 +169,7 @@ func getrootPartition(sshRunner *crcssh.Runner, preset crcPreset.Preset) (string
 	return rootPart, nil
 }
 
-func growLVForMicroshift(sshRunner *crcssh.Runner, lvFullName string, rootPart string, persistentVolumeSize int) error {
+func growLVForMicroshift(sshRunner crcos.CommandRunner, lvFullName string, rootPart string, persistentVolumeSize int) error {
 	if _, _, err := sshRunner.RunPrivileged("Resizing the physical volume(PV)", "/usr/sbin/pvresize", "--devices", rootPart, rootPart); err != nil {
 		return err
 	}

--- a/pkg/crc/machine/start_test.go
+++ b/pkg/crc/machine/start_test.go
@@ -1,0 +1,127 @@
+package machine
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/containers/common/pkg/strongunits"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockedSSHRunner struct {
+	mockedSSHCommandToOutput map[string]string
+	mockedSSHCommandToError  map[string]error
+	mockedSSHCommandToArgs   map[string]string
+}
+
+func (r *MockedSSHRunner) RunPrivileged(reason string, cmdAndArgs ...string) (string, string, error) {
+	if r.mockedSSHCommandToError[reason] != nil {
+		return "", "", r.mockedSSHCommandToError[reason]
+	}
+	r.mockedSSHCommandToArgs[reason] = strings.Join(cmdAndArgs, ",")
+	output, ok := r.mockedSSHCommandToOutput[reason]
+	if !ok {
+		r.mockedSSHCommandToOutput[reason] = ""
+	}
+	return output, "", nil
+}
+
+func (r *MockedSSHRunner) Run(_ string, _ ...string) (string, string, error) {
+	// No-op
+	return "", "", nil
+}
+
+func (r *MockedSSHRunner) RunPrivate(_ string, _ ...string) (string, string, error) {
+	// No-op
+	return "", "", nil
+}
+
+func NewMockedSSHRunner() *MockedSSHRunner {
+	return &MockedSSHRunner{
+		mockedSSHCommandToOutput: map[string]string{},
+		mockedSSHCommandToArgs:   map[string]string{},
+		mockedSSHCommandToError:  map[string]error{},
+	}
+}
+
+func TestGrowLVForMicroShift_WhenResizeAttemptFails_ThenThrowErrorExplainingWhereItFailed(t *testing.T) {
+	testCases := []struct {
+		name                                    string
+		volumeGroupSizeOutput                   string
+		logicalVolumeSizeOutput                 string
+		physicalVolumeListCommandFailed         error
+		physicalVolumeGroupSizeCommandFailed    error
+		logicalVolumeSizeCommandFailed          error
+		extendingLogicalVolumeSizeCommandFailed error
+		expectedReturnedError                   error
+	}{
+		{"when listing physical volume devices failed, then throw error", "", "", errors.New("listing volumes failed"), nil, nil, nil, errors.New("listing volumes failed")},
+		{"when fetching volume group size failed, then throw error", "", "", nil, errors.New("fetching volume group size failed"), nil, nil, errors.New("fetching volume group size failed")},
+		{"when parsing volume group size failed, then throw error", "invalid", "", nil, nil, nil, nil, errors.New("strconv.Atoi: parsing \"invalid\": invalid syntax")},
+		{"when fetching lv size failed, then throw error", "42966450176", "", nil, nil, errors.New("fetching lvm size failed"), nil, errors.New("fetching lvm size failed")},
+		{"when parsing lv size failed, then throw error", "42966450176", "invalid", nil, nil, nil, nil, errors.New("strconv.Atoi: parsing \"invalid\": invalid syntax")},
+		{"when extending lv size failed, then throw error", "42966450176", "16106127360", nil, nil, nil, errors.New("extending lv failed"), errors.New("extending lv failed")},
+	}
+
+	// Loop through each test case
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Given
+			sshRunner := NewMockedSSHRunner()
+			sshRunner.mockedSSHCommandToError["Resizing the physical volume(PV)"] = tc.physicalVolumeListCommandFailed
+			sshRunner.mockedSSHCommandToError["Get the volume group size"] = tc.physicalVolumeGroupSizeCommandFailed
+			sshRunner.mockedSSHCommandToOutput["Get the volume group size"] = tc.volumeGroupSizeOutput
+			sshRunner.mockedSSHCommandToError["Get the size of root logical volume"] = tc.logicalVolumeSizeCommandFailed
+			sshRunner.mockedSSHCommandToOutput["Get the size of root logical volume"] = tc.logicalVolumeSizeOutput
+			sshRunner.mockedSSHCommandToError["Extending and resizing the logical volume(LV)"] = tc.extendingLogicalVolumeSizeCommandFailed
+
+			// When
+			err := growLVForMicroshift(sshRunner, "rhel/root", "/dev/vda5", 15)
+
+			// Then
+			assert.EqualError(t, err, tc.expectedReturnedError.Error(), "Error messages should match")
+		})
+	}
+}
+
+func TestGrowLVForMicroShift_WhenPhysicalVolumeAvailableForResize_ThenSizeToIncreaseIsCalculatedAndGrown(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		existingVolumeGroupSize strongunits.B
+		oldPersistentVolumeSize strongunits.B
+		persistentVolumeSize    int
+		expectPVSizeToGrow      bool
+		expectedIncreaseInSize  strongunits.B
+	}{
+		{"when disk size can not accommodate persistent volume size growth, then do NOT grow lv", strongunits.GiB(31).ToBytes(), strongunits.GiB(15).ToBytes(), 20, false, strongunits.B(0)},
+		{"when disk size can accommodate persistent volume size growth, then grow lv", strongunits.GiB(41).ToBytes(), strongunits.GiB(15).ToBytes(), 20, true, strongunits.GiB(6).ToBytes()},
+		{"when requested persistent volume size less than present persistent volume size, then do NOT grow lv", strongunits.GiB(31).ToBytes(), strongunits.GiB(20).ToBytes(), 15, false, strongunits.B(0)},
+		{"when requested disk size less than present persistent volume size, then do NOT grow lv", strongunits.GiB(31).ToBytes(), strongunits.GiB(20).ToBytes(), 41, false, strongunits.B(0)},
+		// https://github.com/crc-org/crc/issues/4186#issuecomment-2656129015
+		{"when disk size has more space than requested persistent volume growth, then lv growth larger than requested", strongunits.GiB(45).ToBytes(), strongunits.GiB(15).ToBytes(), 20, true, strongunits.GiB(10).ToBytes()},
+	}
+
+	// Loop through each test case
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Given
+			sshRunner := NewMockedSSHRunner()
+			sshRunner.mockedSSHCommandToOutput["resizing the physical volume(PV)"] = "Physical volume \"/dev/vda5\" changed"
+			sshRunner.mockedSSHCommandToOutput["Get the volume group size"] = fmt.Sprintf("%d", tc.existingVolumeGroupSize.ToBytes())
+			sshRunner.mockedSSHCommandToOutput["Get the size of root logical volume"] = fmt.Sprintf("%d", tc.oldPersistentVolumeSize.ToBytes())
+
+			// When
+			err := growLVForMicroshift(sshRunner, "rhel/root", "/dev/vda5", tc.persistentVolumeSize)
+
+			// Then
+			assert.NoError(t, err)
+			_, lvExpanded := sshRunner.mockedSSHCommandToOutput["Extending and resizing the logical volume(LV)"]
+			assert.Equal(t, tc.expectPVSizeToGrow, lvExpanded)
+			if tc.expectPVSizeToGrow {
+				assert.Contains(t, sshRunner.mockedSSHCommandToArgs["Extending and resizing the logical volume(LV)"], fmt.Sprintf("+%db", tc.expectedIncreaseInSize.ToBytes()))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Add some unit tests for method [`growLVForMicroshift` ](https://github.com/crc-org/crc/blob/main/pkg/crc/machine/start.go#L172)

Relates to: #4186, PR #4623

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes

+ Replace `*crcssh.Runner` growLVForMicroshift method argument to receive an interface instead
+ Add unit tests using mocked implementation of ssh runner to verify various combinations of `persistent-volume-size` and size growth performed by the method

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
I've only verified that build is passing.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [x] Windows
    - [x] MacOS