### PR TITLE
start.go: Set chronyd in manual mode

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -440,6 +440,9 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		if _, _, err := sshRunner.RunPrivileged("Turning off the ntp server", "timedatectl set-ntp off"); err != nil {
 			return nil, errors.Wrap(err, "Failed to stop network time synchronization")
 		}
+		if _, _, err := sshRunner.RunPrivileged("Manual mode for chrony config", "tee /etc/chrony.conf <<< \"manual\""); err != nil {
+			return nil, errors.Wrap(err, "Failed to update manual mode for /etc/chrony.conf")
+		}
 		logging.Info("Setting clock to vm clock (UTC timezone)")
 		dateCmd := fmt.Sprintf("date -s '%s'", time.Now().Format(time.UnixDate))
 		if _, _, err := sshRunner.RunPrivileged("Setting clock same as host", dateCmd); err != nil {


### PR DESCRIPTION
From 4.17 kubelet-dependency.target have chrony-wait-service as dependency which start the chrony service again in the VM and set the time back to normal which cause no cert rotation for cluster and test are failing.

This PR set the chrony conf to manual which prevent to update the VM time even restart of chronyd service.



Fixes: #4337 

Dependency: https://github.com/crc-org/snc/pull/1016

To test this try following
```
$ crc setup  -b https://storage.googleapis.com/crc-bundle/crc_libvirt_4.19.0-ec.2_amd64_1016.crcbundle
$ sudo timedatectl set-ntp off
$ sudo date -s '13 month'
$ CRC_DEBUG_ENABLE_STOP_NTP=true  ./crc start -b https://storage.googleapis.com/crc-bundle/crc_libvirt_4.19.0-ec.2_amd64_1016.crcbundle --log-level debug
```