### PR TITLE
test (e2e) : Use pinned version of crc while executing e2e tests (#4629)

### DIFF
--- a/images/build-e2e/lib/darwin/run.sh
+++ b/images/build-e2e/lib/darwin/run.sh
@@ -4,6 +4,7 @@
 bundleLocation=""
 e2eTagExpression=""
 crcMemory=""
+crcBinaryDir="/usr/local/bin"
 targetFolder="crc-e2e"
 junitFilename="e2e-junit.xml"
 while [[ $# -gt 0 ]]; do
@@ -34,6 +35,11 @@ while [[ $# -gt 0 ]]; do
         shift 
         shift 
         ;;
+        -crcBinaryDir)
+        crcBinaryDir="$2"
+        shift
+        shift
+        ;;
         *)    # unknown option
         shift 
         ;;
@@ -50,7 +56,7 @@ then
     tags="$tags && $e2eTagExpression"
 fi
 cd $targetFolder/bin
-./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --cleanup-home=false --crc-memory=$crcMemory --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
+./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --crc-binary=$crcBinaryDir --cleanup-home=false --crc-memory=$crcMemory --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
 
 # Transform results to junit
 cd ..

--- a/images/build-e2e/lib/linux/run.sh
+++ b/images/build-e2e/lib/linux/run.sh
@@ -4,6 +4,7 @@
 bundleLocation=""
 e2eTagExpression=""
 crcMemory=""
+crcBinaryDir="/usr/local/bin"
 targetFolder="crc-e2e"
 junitFilename="e2e-junit.xml"
 while [[ $# -gt 0 ]]; do
@@ -34,6 +35,11 @@ while [[ $# -gt 0 ]]; do
         shift 
         shift 
         ;;
+        -crcBinaryDir)
+        crcBinaryDir="$2"
+        shift
+        shift
+        ;;
         *)    # unknown option
         shift 
         ;;
@@ -50,7 +56,7 @@ then
     tags="$tags && $e2eTagExpression"
 fi
 cd $targetFolder/bin
-./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --cleanup-home=false --crc-memory=$crcMemory --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
+./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --crc-binary=$crcBinaryDir --cleanup-home=false --crc-memory=$crcMemory --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
 
 # Transform results to junit
 cd ..

--- a/images/build-e2e/lib/windows/run.ps1
+++ b/images/build-e2e/lib/windows/run.ps1
@@ -9,6 +9,8 @@ param(
     $junitFilename="e2e-junit.xml",
     [Parameter(HelpMessage='Customize memory for the cluster to run the tests')]
     $crcMemory=""
+    [Parameter(HelpMessage='Customize crc binary location')]
+    $crcBinaryDir="C:\Program Files\Red Hat OpenShift Local"
 )
 
 # Prepare run e2e
@@ -28,7 +30,7 @@ if ($e2eTagExpression) {
 }
 $dir = "$PWD"
 cd $targetFolder\bin
-e2e.test.exe --bundle-location=$bundleLocation --pull-secret-file=$targetFolderdir\pull-secret --crc-memory=$crcMemory --cleanup-home=false --godog.tags="$tags" --godog.format=junit > $resultsDir\e2e.results
+e2e.test.exe --bundle-location=$bundleLocation --pull-secret-file=$targetFolderdir\pull-secret --crc-binary=$crcBinaryDir --crc-memory=$crcMemory --cleanup-home=false --godog.tags="$tags" --godog.format=junit > $resultsDir\e2e.results
 
 # Transform results to junit
 cd ..


### PR DESCRIPTION


## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4629

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->
⚠️ We need to test these changes by building a container image based on these changes and updating pipeline to use that specific container image

Instead of assuming e2e tests would pick up crc binary added by the pipeline, that may or may not work if some user has added a binary in any of the PATH dirs, explicitly specify crc installation dir during the test run

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
+ In test images `run.sh` script introduce a new variable `crcBinaryDir` that would contain path to directory that contains CRC binary
+ Add another command line argument `--crc-binary` for explicitly specifying test arguments
## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
⚠️ It's not tested yet.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS