### PR TITLE
Verify if binary exists before executing

### DIFF
--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -10,6 +10,8 @@ import (
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 )
 
+var privilegedCommand = "sudo"
+
 func runCmd(command string, args []string, env map[string]string) (string, string, error) {
 	cmd := exec.Command(command, args...) // #nosec G204
 	if len(env) != 0 {
@@ -44,11 +46,15 @@ func runPrivate(command string, args []string, env map[string]string) (string, s
 // RunPrivileged executes a command using sudo
 // provide a reason why root is needed as the first argument
 func RunPrivileged(reason string, cmdAndArgs ...string) (string, string, error) {
-	sudo, err := exec.LookPath("sudo")
+	sudo, err := exec.LookPath(privilegedCommand)
 	if err != nil {
 		return "", "", errors.New("sudo executable not found")
 	}
 	logging.Infof("Using root access: %s", reason)
+	_, err = exec.LookPath(cmdAndArgs[0])
+	if err != nil {
+		return "", "", errors.New(cmdAndArgs[0] + " executable not found")
+	}
 	return run(sudo, cmdAndArgs, map[string]string{})
 }
 

--- a/pkg/os/exec_test.go
+++ b/pkg/os/exec_test.go
@@ -1,0 +1,13 @@
+package os
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunPrivileged(t *testing.T) {
+	privilegedCommand = "echo"
+	_, _, err := RunPrivileged("it should fail", "i-dont-exist")
+	assert.ErrorContains(t, err, "i-dont-exist executable not found")
+}


### PR DESCRIPTION
## Description

Verify if the binary exists before running it with sudo.
Actually the exit code is not useful, only show that a result different than 0 was returned.

```
...
INFO Checking if vsock is correctly configured    
INFO Setting up vsock support                     
INFO Using root access: Setting CAP_NET_BIND_SERVICE capability for /home/hector/Projects/crc/out/linux-amd64/crc executable 
exit status 1
```

With this tiny modification, is easy for the user to understand what is missing:

```
...
INFO Checking if vsock is correctly configured    
INFO Setting up vsock support                     
INFO Using root access: Setting CAP_NET_BIND_SERVICE capability for /home/hector/Projects/crc/out/linux-amd64/crc executable 
setcap executable not found
```

I was testing `crc` inside an openSUSE Tumbleweed version 20250219.

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes

Just an extra verification for the existence of binaries used and a small unit test.

Unfortunately with this unit test the `sudo` command will be invoked in each test call and most of the container images doesn't have it. The solution for this was to use an unexported package-level variable, this variable can be overwritten inside the test, avoiding the use of an interface.

> Chapter 11 - The Go Programming Language, page 312

<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing

Added a unit test that should fail trying to find a binary named `i-dont-exist`.
Thanks to @rohanKanojia who gives me a north on that.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS