### PR TITLE
ci : remove step for uploading gh context artifact (#4615)

### DIFF
--- a/.github/workflows/linux-qe-template.yml
+++ b/.github/workflows/linux-qe-template.yml
@@ -1,18 +1,18 @@
 name: linux-qe-template
 
 on:
-  workflow_call:  
-    inputs:  
-      trigger-workflow-run-id:  
-        required: true  
+  workflow_call:
+    inputs:
+      trigger-workflow-run-id:
+        required: true
         type: string
-      qe-type:  
+      qe-type:
         description: type of test; allowed values e2e or integration
-        required: true  
+        required: true
         type: string
       preset:
         description: preset type only required if qe-type is e2e
-        type: string  
+        type: string
 
 jobs:
   linux-qe:
@@ -21,13 +21,6 @@ jobs:
       statuses: write # needed to update commit status (pending/failure/sucess)
       checks: write # as documented in https://github.com/mikepenz/action-junit-report?tab=readme-ov-file#pr-run-permissions
     steps:
-      - name: Download gh context
-        id: download-gh-context-artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: gh-context
-          run-id: ${{inputs.trigger-workflow-run-id}}
-          github-token: ${{ github.token }}
       - name: Download bundle_version
         uses: actions/download-artifact@v4
         with:
@@ -43,10 +36,10 @@ jobs:
           testing-farm --help
 
           # Get origin commit sha for testing
-          commit_sha=$(cat gh_context.json | jq -r '.event.after')
+          commit_sha=${{ github.event.workflow_run.head_commit.id }}
           if [[ -z "${commit_sha}" ]] || [[ "${commit_sha}" == null ]]; then
-            # on first PR creation .event.after is empty, then .sha is used as commit instead
-            commit_sha=$(cat gh_context.json | jq -r '.event.pull_request.head.sha')
+            # if .head_commit.id is empty, then .head_sha is used as commit instead
+            commit_sha=${{ github.event.workflow_run.head_sha }}
           fi
           echo "commit_sha=${commit_sha}" >> "$GITHUB_ENV"
 
@@ -94,17 +87,17 @@ jobs:
             -d "${data}"
 
       - name: Reserve machine and test
-        env: 
+        env:
           TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
           PULL_SECRET: ${{ secrets.PULL_SECRET }}
         run: |
           echo "${PULL_SECRET}" > pull-secret
 
-          # the target can only be accessed through a bastion (which can only be accessed from self-hosted runner) 
+          # the target can only be accessed through a bastion (which can only be accessed from self-hosted runner)
           # as so we need to map the ssh-agent from the host to the containers used to access the target host
-          
+
           #rm -f id_rsa id_rsa.pub
-          ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa -q 
+          ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa -q
           cp ~/.ssh/id_rsa .
           eval $(ssh-agent -s)
           echo $SSH_AUTH_SOCK > ssh_auth_sock
@@ -149,12 +142,12 @@ jobs:
              -install 'true' \
              -aName 'crc' \
              -freshEnv 'false' \
-             -download 'false' 
+             -download 'false'
           podman logs -f crc-linux-install-${{inputs.qe-type}}-${{inputs.preset}}
 
           # Download arm64 bundle in the reserved machine
           echo "Start download bundle on reserved machine"
-          
+
           if [[ "${{inputs.preset}}" == "microshift" ]]; then
             bundle_url="https://crcqe-asia.s3.ap-south-1.amazonaws.com/bundles/microshift/${{ env.microshift_bundle_v }}-arm64"
             bundle_name="crc_microshift_libvirt_${{ env.microshift_bundle_v }}_arm64.crcbundle"
@@ -177,7 +170,7 @@ jobs:
              -aBaseURL $bundle_url \
              -aName $bundle_name \
              -freshEnv 'false' \
-             -download 'true' 
+             -download 'true'
           podman logs -f download_bundle
 
           # load image
@@ -211,20 +204,20 @@ jobs:
             -v $PWD/pull-secret:/opt/crc/pull-secret:z \
             -v $PWD:/data:z \
             quay.io/crcont/crc-${{inputs.qe-type}}:gh-linux-arm64 \
-                ${cmd} 
+                ${cmd}
           podman logs -f crc-${{inputs.qe-type}}-${{inputs.preset}}
 
       - name: Test Report
         id: test-report
         uses: mikepenz/action-junit-report@v5
-        if: always() 
+        if: always()
         with:
           fail_on_failure: true
           include_passed: true
           detailed_summary: true
           require_tests:  true
           report_paths: '**/*.xml'
-      
+
       - name: Upload e2e results
         uses: actions/upload-artifact@v4
         if: always()
@@ -236,12 +229,12 @@ jobs:
             **/*.log
 
       - name: Return machine and clear env
-        env: 
+        env:
           TESTING_FARM_API_TOKEN: ${{ secrets.TESTING_FARM_API_TOKEN }}
         if: always()
         run: |
           export TESTING_FARM_API_TOKEN=${TESTING_FARM_API_TOKEN}
-          testing-farm cancel $(cat requestid) 
+          testing-farm cancel $(cat requestid)
           podman rmi quay.io/crcont/crc-${{inputs.qe-type}}:gh-linux-arm64
           rm -r results
           kill $(cat ssh_agent_pid)
@@ -252,7 +245,7 @@ jobs:
           set -xuo
           # Status msg
           data="{\"state\":\"success\""
-          if [[ ${{steps.test-report.outcome}} != "success" ]]; then 
+          if [[ ${{steps.test-report.outcome}} != "success" ]]; then
             data="{\"state\":\"failure\""
           fi
           data="${data},\"description\":\"Finished ${{inputs.qe-type}}-${{inputs.preset}} on Linux ARM64\""
@@ -264,8 +257,3 @@ jobs:
             -H "Authorization: Bearer ${{ github.token }}" \
             https://api.github.com/repos/${{ github.repository }}/statuses/${{ env.commit_sha }} \
             -d "${data}"
-
-      
-          
-
-

--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -95,20 +95,11 @@ jobs:
           podman push quay.io/crcont/${{ env.IMAGE_NAME_INTEGRATION}}:vnext-${{matrix.os}}-${{matrix.arch}}
           podman tag quay.io/crcont/${{ env.IMAGE_NAME_E2E}}:gh-${{matrix.os}}-${{matrix.arch}} quay.io/crcont/${{ env.IMAGE_NAME_E2E}}:vnext-${{matrix.os}}-${{matrix.arch}}
           podman push quay.io/crcont/${{ env.IMAGE_NAME_E2E}}:vnext-${{matrix.os}}-${{matrix.arch}}
-  save-gh-context:
+  save-bundle-version:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
-      - name: Save the GH context in an artifact
-        env:
-          GH_CONTEXT: ${{ toJSON(github) }}
-        run: echo $GH_CONTEXT > gh_context.json
-      - name: Upload the GH context artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: gh-context
-          path: gh_context.json
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Save the bundle version

--- a/.github/workflows/windows-qe-tpl.yml
+++ b/.github/workflows/windows-qe-tpl.yml
@@ -1,20 +1,20 @@
-# The template is intended to be used from a workflow run 
+# The template is intended to be used from a workflow run
 # as it will pick the artifacts from the triger (through workflow_id param)
 name: windows-qe-tpl
 
-on:  
-  workflow_call:  
-    inputs:  
-      trigger-workflow-run-id:  
-        required: true  
+on:
+  workflow_call:
+    inputs:
+      trigger-workflow-run-id:
+        required: true
         type: string
-      qe-type:  
+      qe-type:
         description: type of test; allowed values e2e or integration
-        required: true  
+        required: true
         type: string
       preset:
         description: preset type only required if qe-type is e2e
-        type: string  
+        type: string
 
 jobs:
   windows-qe:
@@ -32,16 +32,8 @@ jobs:
           windows-featurepack: '23h2-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
-      
+
     steps:
-    - name: Download gh context
-      id: download-gh-context-artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: gh-context
-        run-id: ${{inputs.trigger-workflow-run-id}}
-        github-token: ${{ github.token }}
-    
     - name: Download windows installer
       id: download-windows-installer-artifact
       uses: actions/download-artifact@v4
@@ -63,13 +55,13 @@ jobs:
         PULL_SECRET: ${{ secrets.PULL_SECRET }}
       run: |
         # Get origin commit sha for testing
-        commit_sha=$(cat gh_context.json | jq -r '.event.after')
+        commit_sha=${{ github.event.workflow_run.head_commit.id }}
         if [[ -z "${commit_sha}" ]] || [[ "${commit_sha}" == null ]]; then
-          # on first PR creation .event.after is empty, then .sha is used as commit instead
-          commit_sha=$(cat gh_context.json | jq -r '.event.pull_request.head.sha')
+          # if .head_commit.id is empty, then .head_sha is used as commit instead
+          commit_sha=${{ github.event.workflow_run.head_sha }}
         fi
         echo "commit_sha=${commit_sha}" >> "$GITHUB_ENV"
-        
+
         # Set status_context
         status_context="ci/gh/${{inputs.qe-type}}"
         if [[ "${{inputs.qe-type}}" == "e2e" ]]; then
@@ -164,13 +156,13 @@ jobs:
           -v $PWD/pull-secret:/opt/crc/pull-secret:z \
           -v $PWD:/data:z \
           quay.io/crcont/crc-${{inputs.qe-type}}:gh-windows-amd64 \
-              ${cmd} 
+              ${cmd}
         podman logs -f crc-${{inputs.qe-type}}
 
     - name: Test Report
       id: test-report
       uses: mikepenz/action-junit-report@v5
-      if: always() 
+      if: always()
       with:
         fail_on_failure: true
         include_passed: true
@@ -194,7 +186,7 @@ jobs:
         set -xuo
         # Status msg
         data="{\"state\":\"success\""
-        if [[ ${{steps.test-report.outcome}} != "success" ]]; then 
+        if [[ ${{steps.test-report.outcome}} != "success" ]]; then
           data="{\"state\":\"failure\""
         fi
         data="${data},\"description\":\"Finished ${{inputs.qe-type}}-${{inputs.preset}} on Windows\""
@@ -212,7 +204,7 @@ jobs:
       run: |
         # Make sure lock is removed
         rm -rf .pulumi/locks/*
-        # Destroy 
+        # Destroy
         podman run -d --name windows-destroy --rm \
           -v ${PWD}:/workspace:z \
           -e ARM_TENANT_ID=${{secrets.ARM_TENANT_ID}} \
@@ -224,5 +216,5 @@ jobs:
           quay.io/redhat-developer/mapt:v0.6.9 azure \
             windows destroy \
             --project-name 'windows-desktop-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}-${{inputs.qe-type}}-${{inputs.preset}}' \
-            --backed-url azblob://crc-qenvs-state/${{ github.repository }}-${{ github.run_id }} 
+            --backed-url azblob://crc-qenvs-state/${{ github.repository }}-${{ github.run_id }}
         podman logs -f windows-destroy


### PR DESCRIPTION


## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4615

Rather than uploading/downloading github context as GitHub artifact across workflow runs. We can rely on `workflow_run` payload to extract the commit SHA.

Some unwanted changes were introduced due to my IDE removing trailing whitespace (which should be harmless in my opinion).

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
+ Remove steps to upload/download github context as github artifact
+ Use already existing fields from github `workflow_run` payload to extract latest commit SHA
+ There are some changes to remove trailing whitespace (they automatically got removed due to my IDE setting).

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
I had only tested in my local fork that these fields are available in workflow_run payload:
- `github.event.workflow_run.head_commit.id`
- `github.event.workflow_run.head_sha`

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS