### PR TITLE
test (e2e) : Improve crc version check to not fail on nightly builds

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -6,8 +6,7 @@ Feature: Basic test
 
     @darwin @linux @windows @release
     Scenario: CRC version
-        When executing crc version command
-        Then stdout should contain correct version
+        Then crc version has expected output
 
     @darwin @linux @windows
     Scenario: CRC help


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Relates to: #4640

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

Relax CRC version check to ignore version check if its a date.

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
+ Improve how to verify CRC version output. Instead of just doing a string match. Parse `crc version` JSON output and verify each field.
+ Add a special condition for the CRC version. If the version does not match but is an actual date, skip it.

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [x] MacOS