### PR TITLE
[QE]remove okd preset test on arm64

### DIFF
--- a/images/build-e2e/lib/darwin/run.sh
+++ b/images/build-e2e/lib/darwin/run.sh
@@ -50,7 +50,8 @@ done
 mkdir -p $targetFolder/results
 
 # Run tests
-tags="darwin"
+arch=$(uname -m)
+tags="$arch,darwin"
 if [ ! -z "$e2eTagExpression" ]
 then
     tags="$tags && $e2eTagExpression"

--- a/images/build-e2e/lib/linux/run.sh
+++ b/images/build-e2e/lib/linux/run.sh
@@ -50,7 +50,8 @@ done
 mkdir -p $targetFolder/results
 
 # Run tests
-tags="linux"
+arch=$(uname -m)
+tags="$arch,linux"
 if [ ! -z "$e2eTagExpression" ]
 then
     tags="$tags && $e2eTagExpression"

--- a/images/build-e2e/lib/windows/run.ps1
+++ b/images/build-e2e/lib/windows/run.ps1
@@ -24,7 +24,7 @@ $resultsDir = "$targetFolderDir\results"
 New-Item -ItemType directory -Path "$resultsDir" -Force
 
 # Run tests
-$tags="windows"
+$tags="x86_64,windows"
 if ($e2eTagExpression) {
     $tags="$tags && $e2eTagExpression"
 }

--- a/test/e2e/features/config.feature
+++ b/test/e2e/features/config.feature
@@ -162,7 +162,6 @@ Feature: Test configuration settings
         And stdout should contain "Successfully unset configuration property 'preset'"
         And "JSON" config file "crc.json" in CRC home folder does not contain key "preset"
         
-
     Scenario: CRC config set and get preset property (positive cases) 
         When setting config property "preset" to value "<preset-value>" succeeds
         And "JSON" config file "crc.json" in CRC home folder contains key "preset" with value matching "<preset-value>" 
@@ -172,11 +171,16 @@ Feature: Test configuration settings
         And stdout should contain "Successfully unset configuration property 'preset'"
         And "JSON" config file "crc.json" in CRC home folder does not contain key "preset"
         
-        @linux @darwin @windows 
+        @x86_64
         Examples: Config property preset setting positive
             | preset-value  |
             | microshift    | 
             | okd           | 
+
+        @arm64 @aarch64
+        Examples: Config property preset setting positive
+            | preset-value  |
+            | microshift    | 
             
     Scenario: CRC config set preset (negtive cases) 
         When setting config property "preset" to value "<preset-value>" fails


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4632

Relates to: #N, PR #N, ...

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS