### PR TITLE
test (e2e) : change nodeport service access in jkube e2e test (#4683)

### DIFF
--- a/test/e2e/features/application_deployment.feature
+++ b/test/e2e/features/application_deployment.feature
@@ -37,7 +37,4 @@ Feature: Application Deployment Test
         Then executing "curl -s http://quarkus-testproj.apps-crc.testing" succeeds
         And stdout should contain "{"applicationName":"JKube","message":"Subatomic JKube really whips the llama's ass!"}"
         # Access application via Service's NodePort
-        And executing "QUARKUS_NODEPORT=`oc get svc quarkus -o jsonpath='{.spec.ports[0].nodePort}'`" succeeds
-        And executing "CRC_IP=`crc ip`" succeeds
-        Then executing "curl -s http://$CRC_IP:$QUARKUS_NODEPORT" succeeds
-        And stdout should contain "{"applicationName":"JKube","message":"Subatomic JKube really whips the llama's ass!"}"
+        Then ensure service "quarkus" is accessible via NodePort with response body "{"applicationName":"JKube","message":"Subatomic JKube really whips the llama's ass!"}"


### PR DESCRIPTION


## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4683

Relates to: #4636

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

Usage of unix style variables to store temporary command results isn't working on windows. Execute the same steps using golang code in order to make check platform independent.

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
Remove the steps involving setting/evaluating unix style variables and add a custom step to extract NodePort and crc machine ip and hit the endpoint.

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
I've tested it on my windows machine to verify test is still passing after making changes

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [x] Windows
    - [x] MacOS