### PR TITLE
Remove extraneous .ObjectMeta references

### DIFF
--- a/pkg/crc/cluster/cert_renewal.go
+++ b/pkg/crc/cluster/cert_renewal.go
@@ -29,8 +29,8 @@ func approvePendingCSRs(ctx context.Context, ocConfig oc.Config, expectedSignerN
 			if !isPending(csr) {
 				continue
 			}
-			logging.Debugf("Approving csr %s (signerName: %s)", csr.ObjectMeta.Name, expectedSignerName)
-			_, stderr, err := ocConfig.RunOcCommand("adm", "certificate", "approve", csr.ObjectMeta.Name)
+			logging.Debugf("Approving csr %s (signerName: %s)", csr.Name, expectedSignerName)
+			_, stderr, err := ocConfig.RunOcCommand("adm", "certificate", "approve", csr.Name)
 			if err != nil {
 				return fmt.Errorf("Not able to approve csr (%v : %s)", err, stderr)
 			}

--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -95,7 +95,7 @@ func getStatus(ctx context.Context, lister operatorLister, selector []string) (*
 
 	found := false
 	for _, c := range co.Items {
-		if len(selector) > 0 && !slices.Contains(selector, c.ObjectMeta.Name) {
+		if len(selector) > 0 && !slices.Contains(selector, c.Name) {
 			continue
 		}
 		found = true
@@ -103,20 +103,20 @@ func getStatus(ctx context.Context, lister operatorLister, selector []string) (*
 			switch con.Type {
 			case openshiftapi.OperatorAvailable:
 				if con.Status != openshiftapi.ConditionTrue {
-					logging.Debug(c.ObjectMeta.Name, " operator not available, Reason: ", con.Reason)
-					cs.unavailable = append(cs.unavailable, c.ObjectMeta.Name)
+					logging.Debug(c.Name, " operator not available, Reason: ", con.Reason)
+					cs.unavailable = append(cs.unavailable, c.Name)
 					cs.Available = false
 				}
 			case openshiftapi.OperatorDegraded:
 				if con.Status == openshiftapi.ConditionTrue {
-					logging.Debug(c.ObjectMeta.Name, " operator is degraded, Reason: ", con.Reason)
-					cs.degraded = append(cs.degraded, c.ObjectMeta.Name)
+					logging.Debug(c.Name, " operator is degraded, Reason: ", con.Reason)
+					cs.degraded = append(cs.degraded, c.Name)
 					cs.Degraded = true
 				}
 			case openshiftapi.OperatorProgressing:
 				if con.Status == openshiftapi.ConditionTrue {
-					logging.Debug(c.ObjectMeta.Name, " operator is still progressing, Reason: ", con.Reason)
-					cs.progressing = append(cs.progressing, c.ObjectMeta.Name)
+					logging.Debug(c.Name, " operator is still progressing, Reason: ", con.Reason)
+					cs.progressing = append(cs.progressing, c.Name)
 					cs.Progressing = true
 				}
 			case openshiftapi.OperatorUpgradeable:
@@ -125,7 +125,7 @@ func getStatus(ctx context.Context, lister operatorLister, selector []string) (*
 				continue
 			case "Disabled": // non official status, used by insights and cluster baremetal operators
 				if con.Status == openshiftapi.ConditionTrue {
-					logging.Debug(c.ObjectMeta.Name, " operator is disabled, Reason: ", con.Reason)
+					logging.Debug(c.Name, " operator is disabled, Reason: ", con.Reason)
 					cs.Disabled = true
 				}
 			case "ManagementStateDegraded": // only for the network operator
@@ -133,7 +133,7 @@ func getStatus(ctx context.Context, lister operatorLister, selector []string) (*
 			case "RecentBackup": // only for etcd operator
 				continue
 			default:
-				logging.Debugf("Unexpected operator status for %s: %s", c.ObjectMeta.Name, con.Type)
+				logging.Debugf("Unexpected operator status for %s: %s", c.Name, con.Type)
 			}
 		}
 	}


### PR DESCRIPTION
Broken out from #4712 for easier reviewing.

The object references for `.ObjectMeta.` are extra and not needed.  They are flagged by the newer versions of GolangCI-lint too.

## Summary by Sourcery

Remove unnecessary `.ObjectMeta` references in cluster-related code

Enhancements:
- Simplify code by directly accessing object names instead of using `.ObjectMeta.Name`

Chores:
- Update code to comply with newer GolangCI-lint linting rules