### PR TITLE
Fix duplicate imports

### DIFF
--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -5,7 +5,6 @@ import (
 	"github.com/crc-org/crc/v2/pkg/crc/cluster"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
 	"github.com/crc-org/crc/v2/pkg/crc/network/httpproxy"
-	"github.com/crc-org/crc/v2/pkg/crc/preset"
 	crcpreset "github.com/crc-org/crc/v2/pkg/crc/preset"
 )
 
@@ -50,7 +49,7 @@ type StartConfig struct {
 }
 
 type ClusterConfig struct {
-	ClusterType   preset.Preset
+	ClusterType   crcpreset.Preset
 	ClusterCACert string
 	KubeConfig    string
 	KubeAdminPass string

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/network"
-	"github.com/crc-org/crc/v2/pkg/crc/preset"
 	crcpreset "github.com/crc-org/crc/v2/pkg/crc/preset"
 	"github.com/crc-org/crc/v2/pkg/os/darwin/launchd"
 )
@@ -110,7 +109,7 @@ var daemonLaunchdChecks = []Check{
 // Passing 'SystemNetworkingMode' to getPreflightChecks currently achieves this
 // as there are no user networking specific checks
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(preset.OpenShift), preset.OpenShift, false)
+	return getPreflightChecks(true, network.SystemNetworkingMode, constants.GetDefaultBundlePath(crcpreset.OpenShift), crcpreset.OpenShift, false)
 }
 
 func getChecks(_ network.Mode, bundlePath string, preset crcpreset.Preset, enableBundleQuayFallback bool) []Check {


### PR DESCRIPTION
Broken out from #4712 for easier reviewing.

In this change, `"github.com/crc-org/crc/v2/pkg/crc/preset"` was imported more than once in these files and newer versions of GolangCI-lint were throwing errors.

## Summary by Sourcery

Remove duplicate imports of the preset package and standardize import alias

Bug Fixes:
- Remove duplicate imports of 'github.com/crc-org/crc/v2/pkg/crc/preset' that were causing linter errors

Enhancements:
- Standardize the import alias for the preset package to 'crcpreset' across multiple files