### PR TITLE
vfkit: Update to latest version (0.6.1)

### DIFF
--- a/pkg/crc/machine/vfkit/constants.go
+++ b/pkg/crc/machine/vfkit/constants.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	VfkitVersion = "0.5.0"
+	VfkitVersion = "0.6.1"
 	vfkitCommand = "vfkit"
 )
 


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #3410, #4513 

Relates to: https://github.com/crc-org/vfkit/pull/76

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

Hi, this change updates the bundled vfkit version from `0.5.0` to `0.6.1`.
The objective is to incorporate improvements from vfkit, potentially improving VM stability during `crc start` on macOS.

I confirmed this single-line change at least aligns with the last version bump in https://github.com/crc-org/crc/commit/bb70f215d869ce920a876f8c5008fa64bd611112 . 

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
1. Update `VfkitVersion` constant in `pkg/crc/machine/vfkit/constants.go` from `"0.5.0"` to `"0.6.1"`.

I checked `go.mod` already points at `0.6.1`. https://github.com/crc-org/crc/blob/87a33f46d7fbba1ca63adf67ab5e9dc6885d54d1/go.mod#L21

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

- Testing should be performed on macOS. 
- Verify the following commands complete without errors: `crc setup`, `crc start`, `crc status`, `crc stop`, `crc status`, `crc delete`, `crc cleanup`

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

## Summary by Sourcery

Update vfkit version to 0.6.1 to potentially improve VM stability on macOS

Bug Fixes:
- Upgrade vfkit to latest version to address potential VM stability issues during crc start on macOS

Enhancements:
- Bumped vfkit version from 0.5.0 to 0.6.1 to incorporate latest improvements