### PR TITLE
win: Remove unused "UnixgramPath" constants

### DIFF
--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -7,5 +7,4 @@ const (
 	DaemonHTTPNamedPipe        = `\\.\pipe\crc-http`
 	DaemonTaskName             = "crcDaemon"
 	AdminHelperServiceName     = "crcAdminHelper"
-	UnixgramSocketPath         = ""
 )


### PR DESCRIPTION
It’s only needed on darwin

## Summary by Sourcery

Chores:
- Remove an unnecessary constant that is not used on the Windows platform