### PR TITLE
Handle vfkit connection in goroutine to prevent blocking

### DIFF
--- a/cmd/crc/cmd/daemon_darwin.go
+++ b/cmd/crc/cmd/daemon_darwin.go
@@ -33,7 +33,7 @@ func httpListener() (net.Listener, error) {
 	return ln, nil
 }
 
-func unixgramListener(vn *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) {
+func unixgramListener(ctx context.Context, vn *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) {
 	_ = os.Remove(constants.UnixgramSocketPath)
 	conn, err := transport.ListenUnixgram(fmt.Sprintf("unixgram://%v", constants.UnixgramSocketPath))
 	if err != nil {
@@ -45,7 +45,7 @@ func unixgramListener(vn *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) 
 		return conn, errors.Wrap(err, "failed to accept vfkit connection")
 	}
 	go func() {
-		err := vn.AcceptVfkit(context.Background(), vfkitConn)
+		err := vn.AcceptVfkit(ctx, vfkitConn)
 		if err != nil {
 			logging.Errorf("failed to accept vfkit connection: %v", err)
 			return

--- a/cmd/crc/cmd/daemon_darwin.go
+++ b/cmd/crc/cmd/daemon_darwin.go
@@ -44,8 +44,14 @@ func unixgramListener(vn *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) 
 	if err != nil {
 		return conn, errors.Wrap(err, "failed to accept vfkit connection")
 	}
-	err = vn.AcceptVfkit(context.Background(), vfkitConn)
-	return conn, errors.Wrap(err, "failed to accept vfkit connection")
+	go func() {
+		err := vn.AcceptVfkit(context.Background(), vfkitConn)
+		if err != nil {
+			logging.Errorf("failed to accept vfkit connection: %v", err)
+			return
+		}
+	}()
+	return conn, err
 }
 
 func checkIfDaemonIsRunning() (bool, error) {

--- a/cmd/crc/cmd/daemon_linux.go
+++ b/cmd/crc/cmd/daemon_linux.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -125,7 +126,7 @@ func httpListener() (net.Listener, error) {
 	return ln, nil
 }
 
-func unixgramListener(_ *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) {
+func unixgramListener(_ context.Context, _ *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) {
 	return nil, nil
 }
 

--- a/cmd/crc/cmd/daemon_windows.go
+++ b/cmd/crc/cmd/daemon_windows.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"net"
 
 	"github.com/Microsoft/go-winio"
@@ -36,7 +37,7 @@ func checkIfDaemonIsRunning() (bool, error) {
 	return checkDaemonVersion()
 }
 
-func unixgramListener(_ *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) {
+func unixgramListener(_ context.Context, _ *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Description
A bug is being consistently seen where crc is unable to connect to the daemon on restart/recreation. This fix will help prevent seeing this issue.
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4736

Relates to: https://github.com/crc-org/crc/pull/4738

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS

## Summary by Sourcery

Bug Fixes:
- Handle vfkit connections asynchronously to prevent daemon startup from blocking on macOS.