### PR TITLE
build: Fix compilation with newer go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/docker/docker v27.5.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
-	github.com/ebitengine/purego v0.8.2 // indirect
+	github.com/ebitengine/purego v0.8.3 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
-github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.8.3 h1:K+0AjQp63JEZTEMZiwsI9g0+hAMNohwUOtY0RPGexmc=
+github.com/ebitengine/purego v0.8.3/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=

--- a/vendor/github.com/ebitengine/purego/dlfcn.go
+++ b/vendor/github.com/ebitengine/purego/dlfcn.go
@@ -83,17 +83,17 @@ func loadSymbol(handle uintptr, name string) (uintptr, error) {
 // appear to work if you link directly to the C function on darwin arm64.
 
 //go:linkname dlopen dlopen
-var dlopen uintptr
+var dlopen uint8
 var dlopenABI0 = uintptr(unsafe.Pointer(&dlopen))
 
 //go:linkname dlsym dlsym
-var dlsym uintptr
+var dlsym uint8
 var dlsymABI0 = uintptr(unsafe.Pointer(&dlsym))
 
 //go:linkname dlclose dlclose
-var dlclose uintptr
+var dlclose uint8
 var dlcloseABI0 = uintptr(unsafe.Pointer(&dlclose))
 
 //go:linkname dlerror dlerror
-var dlerror uintptr
+var dlerror uint8
 var dlerrorABI0 = uintptr(unsafe.Pointer(&dlerror))

--- a/vendor/github.com/ebitengine/purego/dlfcn_darwin.go
+++ b/vendor/github.com/ebitengine/purego/dlfcn_darwin.go
@@ -17,8 +17,3 @@ const (
 //go:cgo_import_dynamic purego_dlsym dlsym "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic purego_dlerror dlerror "/usr/lib/libSystem.B.dylib"
 //go:cgo_import_dynamic purego_dlclose dlclose "/usr/lib/libSystem.B.dylib"
-
-//go:cgo_import_dynamic purego_dlopen dlopen "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlsym dlsym "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlerror dlerror "/usr/lib/libSystem.B.dylib"
-//go:cgo_import_dynamic purego_dlclose dlclose "/usr/lib/libSystem.B.dylib"

--- a/vendor/github.com/ebitengine/purego/internal/fakecgo/symbols.go
+++ b/vendor/github.com/ebitengine/purego/internal/fakecgo/symbols.go
@@ -121,81 +121,81 @@ func pthread_setspecific(key pthread_key_t, value unsafe.Pointer) int32 {
 }
 
 //go:linkname _malloc _malloc
-var _malloc uintptr
+var _malloc uint8
 var mallocABI0 = uintptr(unsafe.Pointer(&_malloc))
 
 //go:linkname _free _free
-var _free uintptr
+var _free uint8
 var freeABI0 = uintptr(unsafe.Pointer(&_free))
 
 //go:linkname _setenv _setenv
-var _setenv uintptr
+var _setenv uint8
 var setenvABI0 = uintptr(unsafe.Pointer(&_setenv))
 
 //go:linkname _unsetenv _unsetenv
-var _unsetenv uintptr
+var _unsetenv uint8
 var unsetenvABI0 = uintptr(unsafe.Pointer(&_unsetenv))
 
 //go:linkname _sigfillset _sigfillset
-var _sigfillset uintptr
+var _sigfillset uint8
 var sigfillsetABI0 = uintptr(unsafe.Pointer(&_sigfillset))
 
 //go:linkname _nanosleep _nanosleep
-var _nanosleep uintptr
+var _nanosleep uint8
 var nanosleepABI0 = uintptr(unsafe.Pointer(&_nanosleep))
 
 //go:linkname _abort _abort
-var _abort uintptr
+var _abort uint8
 var abortABI0 = uintptr(unsafe.Pointer(&_abort))
 
 //go:linkname _pthread_attr_init _pthread_attr_init
-var _pthread_attr_init uintptr
+var _pthread_attr_init uint8
 var pthread_attr_initABI0 = uintptr(unsafe.Pointer(&_pthread_attr_init))
 
 //go:linkname _pthread_create _pthread_create
-var _pthread_create uintptr
+var _pthread_create uint8
 var pthread_createABI0 = uintptr(unsafe.Pointer(&_pthread_create))
 
 //go:linkname _pthread_detach _pthread_detach
-var _pthread_detach uintptr
+var _pthread_detach uint8
 var pthread_detachABI0 = uintptr(unsafe.Pointer(&_pthread_detach))
 
 //go:linkname _pthread_sigmask _pthread_sigmask
-var _pthread_sigmask uintptr
+var _pthread_sigmask uint8
 var pthread_sigmaskABI0 = uintptr(unsafe.Pointer(&_pthread_sigmask))
 
 //go:linkname _pthread_self _pthread_self
-var _pthread_self uintptr
+var _pthread_self uint8
 var pthread_selfABI0 = uintptr(unsafe.Pointer(&_pthread_self))
 
 //go:linkname _pthread_get_stacksize_np _pthread_get_stacksize_np
-var _pthread_get_stacksize_np uintptr
+var _pthread_get_stacksize_np uint8
 var pthread_get_stacksize_npABI0 = uintptr(unsafe.Pointer(&_pthread_get_stacksize_np))
 
 //go:linkname _pthread_attr_getstacksize _pthread_attr_getstacksize
-var _pthread_attr_getstacksize uintptr
+var _pthread_attr_getstacksize uint8
 var pthread_attr_getstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_getstacksize))
 
 //go:linkname _pthread_attr_setstacksize _pthread_attr_setstacksize
-var _pthread_attr_setstacksize uintptr
+var _pthread_attr_setstacksize uint8
 var pthread_attr_setstacksizeABI0 = uintptr(unsafe.Pointer(&_pthread_attr_setstacksize))
 
 //go:linkname _pthread_attr_destroy _pthread_attr_destroy
-var _pthread_attr_destroy uintptr
+var _pthread_attr_destroy uint8
 var pthread_attr_destroyABI0 = uintptr(unsafe.Pointer(&_pthread_attr_destroy))
 
 //go:linkname _pthread_mutex_lock _pthread_mutex_lock
-var _pthread_mutex_lock uintptr
+var _pthread_mutex_lock uint8
 var pthread_mutex_lockABI0 = uintptr(unsafe.Pointer(&_pthread_mutex_lock))
 
 //go:linkname _pthread_mutex_unlock _pthread_mutex_unlock
-var _pthread_mutex_unlock uintptr
+var _pthread_mutex_unlock uint8
 var pthread_mutex_unlockABI0 = uintptr(unsafe.Pointer(&_pthread_mutex_unlock))
 
 //go:linkname _pthread_cond_broadcast _pthread_cond_broadcast
-var _pthread_cond_broadcast uintptr
+var _pthread_cond_broadcast uint8
 var pthread_cond_broadcastABI0 = uintptr(unsafe.Pointer(&_pthread_cond_broadcast))
 
 //go:linkname _pthread_setspecific _pthread_setspecific
-var _pthread_setspecific uintptr
+var _pthread_setspecific uint8
 var pthread_setspecificABI0 = uintptr(unsafe.Pointer(&_pthread_setspecific))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -280,7 +280,7 @@ github.com/docker/go-connections/tlsconfig
 # github.com/docker/go-units v0.5.0
 ## explicit
 github.com/docker/go-units
-# github.com/ebitengine/purego v0.8.2
+# github.com/ebitengine/purego v0.8.3
 ## explicit; go 1.18
 github.com/ebitengine/purego
 github.com/ebitengine/purego/internal/cgo


### PR DESCRIPTION
Building crc with go 1.24.3 or 1.23.9 fails with:
```
link: duplicated definition of symbol dlopen, from github.com/ebitengine/purego and github.com/ebitengine/purego
```

because of https://github.com/golang/go/issues/73617

ebitengine/purego 0.8.3 has a workaround for this bug.



## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #N

Relates to: #N, PR #N, ...

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS

## Summary by Sourcery

Bug Fixes:
- Bump purego dependency to v0.8.3 and update vendor directory to incorporate the workaround for the duplicated dlopen symbol issue on newer Go versions