### PR TITLE
[QE]extend waiting time for JKube deployment verify

### DIFF
--- a/test/e2e/features/application_deployment.feature
+++ b/test/e2e/features/application_deployment.feature
@@ -33,7 +33,7 @@ Feature: Application Deployment Test
         # Access application via Route
         And executing "oc get routes -lapp=quarkus" succeeds
         Then stdout should contain "quarkus"
-        And with up to "4" retries with wait period of "1m" http response from "http://quarkus-testproj.apps-crc.testing" has status code "200"
+        And with up to "10" retries with wait period of "1m" http response from "http://quarkus-testproj.apps-crc.testing" has status code "200"
         Then executing "curl -s http://quarkus-testproj.apps-crc.testing" succeeds
         And stdout should contain "{"applicationName":"JKube","message":"Subatomic JKube really whips the llama's ass!"}"
         # Access application via Service's NodePort


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: e2e test failure of "Application Deployment Test"

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

## Summary by Sourcery

Tests:
- Increase retries from 4 to 10 with a 1-minute wait period for the HTTP status code check in the Application Deployment Test feature.