### PR TITLE
Don't check dns resolution for user mode networking

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -491,12 +491,12 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	// Check DNS lookup before starting the kubelet
-	if queryOutput, err := dns.CheckCRCLocalDNSReachable(ctx, servicePostStartConfig); err != nil {
-		if !client.useVSock() {
+	logging.Info("Check internal and public DNS query...")
+	if !client.useVSock() {
+		if queryOutput, err := dns.CheckCRCLocalDNSReachable(ctx, servicePostStartConfig); err != nil {
 			return nil, errors.Wrapf(err, "Failed internal DNS query: %s", queryOutput)
 		}
 	}
-	logging.Info("Check internal and public DNS query...")
 
 	if queryOutput, err := dns.CheckCRCPublicDNSReachable(servicePostStartConfig); err != nil {
 		logging.Warnf("Failed public DNS query from the cluster: %v : %s", err, queryOutput)


### PR DESCRIPTION
For user mode networking route-controller/admin-helper
take care of the routes which is created for the application. Even
till now, result of dns resolution is ignored for user mode networking
but this PR make sure it shouldn't even run instead ignoring. Since it
is ignored but host command still run then debug logs filled with
following error and after retry loop end it is ignored, with this PR
`host` command not even run for user mode network setting.

```
$ host -R 3 foo.apps-crc.testing
foo.apps-crc.testing has address 192.168.127.2
Host foo.apps-crc.testing not found: 3(NXDOMAIN)
```

## Summary by Sourcery

Bug Fixes:
- Add -t A flag to the host command invocation to prevent NXDOMAIN errors from missing non-A records