### PR TITLE
Return ErrNotImplemented from unixgramListener on windows and linux

### DIFF
--- a/cmd/crc/cmd/daemon_darwin.go
+++ b/cmd/crc/cmd/daemon_darwin.go
@@ -39,7 +39,7 @@ func unixgramListener(ctx context.Context, vn *virtualnetwork.VirtualNetwork) (*
 	if err != nil {
 		return conn, errors.Wrap(err, "failed to listen unixgram")
 	}
-	logging.Infof("listening on %s:", constants.UnixgramSocketPath)
+	logging.Infof("listening on %s", constants.UnixgramSocketPath)
 	vfkitConn, err := transport.AcceptVfkit(conn)
 	if err != nil {
 		return conn, errors.Wrap(err, "failed to accept vfkit connection")

--- a/cmd/crc/cmd/daemon_linux.go
+++ b/cmd/crc/cmd/daemon_linux.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/containers/gvisor-tap-vsock/pkg/transport"
 	"github.com/containers/gvisor-tap-vsock/pkg/virtualnetwork"
-	"github.com/crc-org/crc/v2/pkg/crc/constants"
-	"github.com/crc-org/crc/v2/pkg/crc/logging"
-
 	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/coreos/go-systemd/v22/daemon"
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/machine/libmachine/drivers"
 	"github.com/mdlayher/vsock"
 )
 
@@ -127,7 +127,7 @@ func httpListener() (net.Listener, error) {
 }
 
 func unixgramListener(_ context.Context, _ *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) {
-	return nil, nil
+	return nil, drivers.ErrNotImplemented
 }
 
 func startupDone() {

--- a/cmd/crc/cmd/daemon_windows.go
+++ b/cmd/crc/cmd/daemon_windows.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/gvisor-tap-vsock/pkg/virtualnetwork"
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/machine/libmachine/drivers"
 )
 
 func vsockListener() (net.Listener, error) {
@@ -38,7 +39,7 @@ func checkIfDaemonIsRunning() (bool, error) {
 }
 
 func unixgramListener(_ context.Context, _ *virtualnetwork.VirtualNetwork) (*net.UnixConn, error) {
-	return nil, nil
+	return nil, drivers.ErrNotImplemented
 }
 
 func startupDone() {


### PR DESCRIPTION
## Description
Error should not be nil in the case of `unixgramListener` implementation in `daemon_linux.go` and `daemon_windows.go`
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Relates to: #4764, PR https://github.com/crc-org/crc/pull/4753

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [x] Windows
    - [x] MacOS

## Summary by Sourcery

Return ErrNotImplemented for unsupported unixgramListener implementations on Linux and Windows and adjust macOS logging formatting

Bug Fixes:
- Make unixgramListener on Linux return drivers.ErrNotImplemented instead of nil
- Make unixgramListener on Windows return drivers.ErrNotImplemented instead of nil

Enhancements:
- Remove extraneous colon in the logging message for the darwin unixgramListener