### PR TITLE
start: Use force option to unlock core user to set password

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -752,7 +752,7 @@ func enableEmergencyLogin(sshRunner *crcssh.Runner) error {
 		return err
 	}
 	logging.Infof("Emergency login password for core user is stored to %s", constants.PasswdFilePath)
-	_, _, err := sshRunner.Run(fmt.Sprintf("sudo passwd core --unlock && echo %s | sudo passwd core --stdin", b))
+	_, _, err := sshRunner.Run(fmt.Sprintf("sudo passwd core -f --unlock && echo %s | sudo passwd core --stdin", b))
 	return err
 }
 


### PR DESCRIPTION
After switching to image mode looks like emergency password set fails for microshift with following error and exit with 254 error code.
```
$  sudo passwd core --unlock && echo vOaTn8x2 | sudo passwd -f core --stdin
Unlocking password for user core.
passwd: Warning: unlocked password would be empty.
passwd: Unsafe operation (use -f to force)
```

This PR use force option as suggested by error message to fix the emergency login.

fixes: #4734

## Summary by Sourcery

Bug Fixes:
- Use the force option (-f) when unlocking the core user password to prevent failures during emergency login setup.