### PR TITLE
Bundle: Add regex for pr generated bundle

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -266,16 +266,16 @@ func GetBundleInfoFromName(bundleName string) (*FilenameInfo, error) {
 	/*
 		crc_preset_driver_version_arch_customSuffix.crcbundle
 
-		crc                      : Matches the fixed crc part
-		(?:(?:_)([[:alpha:]]+))? : Matches the preset part (optional)
-		([[:alpha:]]+)           : Matches the next mandatory alphabetic part (e.g., libvirt)
-		(%s = semverRegex)       : Matches the version in SemVer format (e.g., 4.16.7 or 4.16.7-ec.2)
-		([[:alnum:]]+)           : Matches the architecture or platform part (e.g. amd64)
-		(?:(?:_)([0-9]+))?       : Optionally matches a trailing number after an underscore (e.g. 2345).
-		\.crcbundle              : Matches the file extension .crcbundle
+		crc                                : Matches the fixed crc part
+		(?:(?:_)([[:alpha:]]+))?           : Matches the preset part (optional)
+		([[:alpha:]]+)                     : Matches the next mandatory alphabetic part (e.g., libvirt)
+		(%s = semverRegex)                 : Matches the version in SemVer format (e.g., 4.16.7 or 4.16.7-ec.2)
+		([[:alnum:]]+)                     : Matches the architecture or platform part (e.g. amd64)
+		(?:_([0-9]+)(?:_([0-9]+))?)?       : Matches an optional underscore + number (_1234), followed optionally by another underscore + number (_5678)
+		\.crcbundle                        : Matches the file extension .crcbundle
 	*/
 	semverRegex := "(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-(?:(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+(?:[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?"
-	bundleRegex := `crc(?:(?:_)([[:alpha:]]+))?_([[:alpha:]]+)_(%s)_([[:alnum:]]+)(?:(?:_)([0-9]+))?\.crcbundle`
+	bundleRegex := `crc(?:(?:_)([[:alpha:]]+))?_([[:alpha:]]+)_(%s)_([[:alnum:]]+)(?:_([0-9]+)(?:_([0-9]+))?)?\.crcbundle`
 	compiledRegex := regexp.MustCompile(fmt.Sprintf(bundleRegex, semverRegex))
 	filenameParts := compiledRegex.FindStringSubmatch(bundleName)
 

--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -224,6 +224,8 @@ func TestGetBundleInfoFromNameValid(t *testing.T) {
 		{"crc_okd_vfkit_4.16.7_amd64_2342465234654.crcbundle", preset.OKD.String(), "vfkit", "4.16.7", "amd64", "2342465234654"},
 		{"crc_hyperv_4.18.0_arm64.crcbundle", preset.OpenShift.String(), "hyperv", "4.18.0", "arm64", ""},
 		{"crc_libvirt_4.18.0-ec.2_amd64.crcbundle", preset.OpenShift.String(), "libvirt", "4.18.0-ec.2", "amd64", ""},
+		// crc_okd_vfkit_4.16.7_amd64_12345_2342465234654.crcbundle can be name of bundle if generated from a PR bundle
+		{"crc_okd_vfkit_4.16.7_amd64_12345_2342465234654.crcbundle", preset.OKD.String(), "vfkit", "4.16.7", "amd64", "12345", "2342465234654"},
 
 		{"crc_microshift_hyperv_4.18.0_x86.crcbundle", preset.Microshift.String(), "hyperv", "4.18.0", "x86", ""},
 		{"crc_microshift_hyperv_4.18.0_x86_1233.crcbundle", preset.Microshift.String(), "hyperv", "4.18.0", "x86", "1233"},


### PR DESCRIPTION
bundle which are generated from the pr using CI have the pr number as part of bundle name like `crc_microshift_libvirt_4.18.11_amd64_1073.crcbundle` (created using snc/pr-1073). If we generate bundle using `crc bundle generate` command for that bundle for testing changes then bundle name become something like
`crc_microshift_libvirt_4.18.11_amd64_1073_1748324604.crcbundle` which failed the bundle name regex and cause issue like.
```
WARN Using crc_microshift_libvirt_4.18.11_amd64_1073_1748324604.crcbundle bundle, but crc_microshift_libvirt_4.18.2_amd64.crcbundle is expected for this release
bundle filename is in unrecognized format
```
This pr add another group in current regex to make sure this is also parse correctly and we can able to test these bundle.


## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

## Summary by Sourcery

Allow the bundle metadata parser to recognize and correctly parse filenames generated from PR bundles by updating the regex to handle two numeric suffix groups

Bug Fixes:
- Extend bundle filename regex to accept PR-generated bundles with both PR number and timestamp suffixes

Tests:
- Add unit test for bundle filenames containing PR number and timestamp segments