### PR TITLE
log: use structured error logging instead of stderr print in command execution

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -111,8 +111,8 @@ func Execute() {
 	}
 
 	if err := rootCmd.ExecuteContext(telemetry.NewContext(context.Background())); err != nil {
+		logging.Error(err.Error())
 		runPostrun()
-		_, _ = fmt.Fprintln(os.Stderr, err.Error())
 		var e exec.CodeExitError
 		if errors.As(err, &e) {
 			os.Exit(e.ExitStatus())


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4662


<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->
Replace stderr logging with structured logging in command execution for clearer output
## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

1. Run gvproxy in a terminal:
```
gvyas@Gunjans-MacBook-Pro ~ % ~/work/gvisor-tap-vsock/bin/gvproxy
INFO[0000] gvproxy version v0.8.5-8-gd1bc1f75
INFO[0000] waiting for clients...
```
2. Run `crc setup` in another terminal:
```
gvyas@Gunjans-MacBook-Pro ~ % crc setup
INFO Using bundle path /Users/gvyas/.crc/cache/crc_microshift_vfkit_4.18.2_arm64.crcbundle
INFO Checking if running macOS version >= 13.x
INFO Checking if running as non-root
INFO Checking if crc-admin-helper executable is cached
INFO Checking if running on a supported CPU architecture
INFO Checking if crc executable symlink exists
INFO Checking minimum RAM requirements
INFO Check if Podman binary exists in: /Users/gvyas/.crc/bin/oc
INFO Checking if running emulated on Apple silicon
INFO Checking if vfkit is installed
INFO Checking if CRC bundle is extracted in '$HOME/.crc'
INFO Checking if /Users/gvyas/.crc/cache/crc_microshift_vfkit_4.18.2_arm64.crcbundle exists
INFO Checking if old launchd config for tray and/or daemon exists
INFO Checking if crc daemon plist file is present and loaded
WARN Skipping above check...
INFO Checking SSH port availability
ERRO crc uses port 2222 to run SSH
```

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

## Summary by Sourcery

Enhancements:
- Replace fmt.Fprintln(os.Stderr, ...) with logging.Error in root command error handler