### PR TITLE
stop: fix the warn message in case of nil error

### DIFF
--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -13,7 +13,7 @@ import (
 func (client *client) Stop() (state.State, error) {
 	defer func(input, output string) {
 		err := cleanKubeconfig(input, output)
-		if !errors.Is(err, os.ErrNotExist) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			logging.Warnf("Failed to remove crc contexts from kubeconfig: %v", err)
 		}
 	}(getGlobalKubeConfigPath(), getGlobalKubeConfigPath())


### PR DESCRIPTION
looks like it is missed during 0342835858fab4842706eb7caafb9f34bccff3f9 one and when crc is stopped, it show following warn message.
```
WARN Failed to remove crc contexts from kubeconfig: <nil>
Stopped the instance
```

This PR will make sure to handle nil error properly.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS

## Summary by Sourcery

Bug Fixes:
- Add a nil check before logging errors from cleanKubeconfig to avoid reporting a `<nil>` error