### PR TITLE
start: Delay pull secret on disk check to end

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -447,6 +447,9 @@ func (p *PullSecretMemoizer) Value() (string, error) {
 func WaitForPullSecretPresentOnInstanceDisk(ctx context.Context, sshRunner *ssh.Runner) error {
 	logging.Info("Waiting until the user's pull secret is written to the instance disk...")
 	pullSecretPresentFunc := func() error {
+		if err := sshRunner.WaitForConnectivity(ctx, 30*time.Second); err != nil {
+			return err
+		}
 		stdout, stderr, err := sshRunner.RunPrivate(fmt.Sprintf("sudo cat %s", vmPullSecretPath))
 		if err != nil {
 			return fmt.Errorf("failed to read %s file: %v: %s", vmPullSecretPath, err, stderr)

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -580,10 +580,6 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Failed to update ssh public key to machine config")
 	}
 
-	if err := cluster.WaitForPullSecretPresentOnInstanceDisk(ctx, sshRunner); err != nil {
-		return nil, errors.Wrap(err, "Failed to update pull secret on the disk")
-	}
-
 	if err := cluster.UpdateUserPasswords(ctx, ocConfig, startConfig.KubeAdminPassword, startConfig.DeveloperPassword); err != nil {
 		return nil, errors.Wrap(err, "Failed to update kubeadmin user password")
 	}
@@ -612,6 +608,10 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	logging.Infof("Starting %s instance... [waiting for the cluster to stabilize]", startConfig.Preset)
 	if err := cluster.WaitForClusterStable(ctx, instanceIP, constants.KubeconfigFilePath, proxyConfig); err != nil {
 		logging.Warnf("Cluster is not ready: %v", err)
+	}
+
+	if err := cluster.WaitForPullSecretPresentOnInstanceDisk(ctx, sshRunner); err != nil {
+		return nil, errors.Wrap(err, "Failed to update pull secret on the disk")
 	}
 
 	waitForProxyPropagation(ctx, ocConfig, proxyConfig)


### PR DESCRIPTION
In current scenario MCO is patched with user provided pull secret and just after, we check if pull secret is part of disk which takes ~1 min since MCD make that change and the report to MCO. In this PR we are delaying this pull secret check to end because instead of blocking it for ~1 min better to execute other part and at the end check if pull secret is part of disk image.

With this PR (crc start time, 6 runs)
```
real	4m9.247s
user	0m0.557s
sys	0m0.165s

real	4m0.455s
user	0m0.619s
sys	0m0.168s

real	4m5.962s
user	0m0.445s
sys	0m0.154s

real	3m59.594s
user	0m0.661s
sys	0m0.179s

real	4m3.958s
user	0m0.563s
sys	0m0.177s

real	4m28.806s
user	0m0.460s
sys	0m0.171s
```

Without this PR
```
real	5m7.235s
user	0m0.797s
sys	0m0.181s

real	4m28.741s
user	0m0.891s
sys	0m0.195s

real	6m6.815s
user	0m0.747s
sys	0m0.194s

real	5m1.733s
user	0m0.395s
sys	0m0.199s

real	4m30.551s
user	0m0.466s
sys	0m0.173s

real	4m31.067s
user	0m0.673s
sys	0m0.183s
```

## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #N

Relates to: #N, PR #N, ...

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

## Summary by Sourcery

Enhancements:
- Move pull secret disk presence verification to the end of the start process to prevent early blocking and improve performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when accessing the pull secret by ensuring connectivity checks are performed before each attempt.
  - Adjusted the sequence of operations during cluster startup to wait for cluster stabilization before verifying the presence of the pull secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->