### PR TITLE
e2e: Fix disksize and ram check

### DIFF
--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -731,12 +731,12 @@ func CheckCRCStatusJSONOutput() error {
 		return fmt.Errorf("failure in asserting 'preset' field of crc status json output, %v", err)
 	}
 	crcDiskSize := crcStatusJSONOutputObj["diskSize"]
-	if strongunits.B(cast.ToUint64(crcDiskSize)) > strongunits.GiB(constants.DefaultDiskSize).ToBytes() {
-		return fmt.Errorf("failure in asserting 'diskSize' field of crc status json output, expected less than or equal to %d bytes, actual : %d bytes", strongunits.GiB(constants.DefaultDiskSize).ToBytes(), strongunits.B(cast.ToUint64(crcDiskSize)))
+	if strongunits.B(cast.ToUint64(crcDiskSize)) < strongunits.GiB(constants.DefaultDiskSize).ToBytes() {
+		return fmt.Errorf("failure in asserting 'diskSize' field of crc status json output, expected greater than or equal to %d bytes, actual : %d bytes", strongunits.GiB(constants.DefaultDiskSize).ToBytes(), strongunits.B(cast.ToUint64(crcDiskSize)))
 	}
 	crcRAMSize := crcStatusJSONOutputObj["ramSize"]
-	if strongunits.B(cast.ToUint64(crcRAMSize)) > constants.GetDefaultMemory(crcPreset).ToBytes() {
-		return fmt.Errorf("failure in asserting 'ramSize' field of crc status json output, expected less than or equal to %d bytes, actual : %d bytes", constants.GetDefaultMemory(crcPreset).ToBytes(), cast.ToUint64(crcRAMSize))
+	if strongunits.B(cast.ToUint64(crcRAMSize)) < constants.GetDefaultMemory(crcPreset).ToBytes() {
+		return fmt.Errorf("failure in asserting 'ramSize' field of crc status json output, expected greater than or equal to %d bytes, actual : %d bytes", constants.GetDefaultMemory(crcPreset).ToBytes(), cast.ToUint64(crcRAMSize))
 	}
 	return nil
 }


### PR DESCRIPTION
Looks like wrong condition introduce during 12fb2344 one. ram/disk size should be greater or equal to default values.

## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4781

## Summary by Sourcery

Fix e2e test suite to assert disk and RAM sizes are greater than or equal to their default values

Tests:
- Update diskSize assertion to use >= default disk size and correct error message
- Update ramSize assertion to use >= default RAM size and correct error message