### PR TITLE
Issue 4781: Fix disksize/ramsize status check as part of e2e

### DIFF
--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -744,7 +744,11 @@ func CheckCRCStatusJSONOutput() error {
 		return fmt.Errorf("failure in asserting 'diskSize' field of crc status json output, expected greater than or equal to %d bytes, actual : %d bytes", strongunits.GiB(constants.DefaultDiskSize).ToBytes(), strongunits.B(cast.ToUint64(crcDiskSize)))
 	}
 	crcRAMSize := crcStatusJSONOutputObj["ramSize"]
-	if strongunits.B(cast.ToUint64(crcRAMSize)) < constants.GetDefaultMemory(crcPreset).ToBytes() {
+	if strongunits.B(cast.ToUint64(crcRAMSize)) < (constants.GetDefaultMemory(crcPreset).ToBytes() - strongunits.GiB(1).ToBytes()) {
+		// This is a workaround for the fact that crc status json output
+		// which doesn't return the exact RAM size used to create the VM,
+		// but rather the `free -b` output, which is less than the actual RAM size.
+		// some amount of overhead memory used by the kernel and system components.
 		return fmt.Errorf("failure in asserting 'ramSize' field of crc status json output, expected greater than or equal to %d bytes, actual : %d bytes", constants.GetDefaultMemory(crcPreset).ToBytes(), cast.ToUint64(crcRAMSize))
 	}
 	return nil

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -737,7 +737,10 @@ func CheckCRCStatusJSONOutput() error {
 		return fmt.Errorf("failure in asserting 'preset' field of crc status json output, %v", err)
 	}
 	crcDiskSize := crcStatusJSONOutputObj["diskSize"]
-	if strongunits.B(cast.ToUint64(crcDiskSize)) < strongunits.GiB(constants.DefaultDiskSize).ToBytes() {
+	if strongunits.GiB(cast.ToUint64(crcDiskSize)) < strongunits.GiB(constants.DefaultDiskSize-1) {
+		// This is a workaround for the fact that crc status json output
+		// which doesn't return the actual disk size, but rather the
+		// size of `/sysroot` mount, which is less than the actual disk size.
 		return fmt.Errorf("failure in asserting 'diskSize' field of crc status json output, expected greater than or equal to %d bytes, actual : %d bytes", strongunits.GiB(constants.DefaultDiskSize).ToBytes(), strongunits.B(cast.ToUint64(crcDiskSize)))
 	}
 	crcRAMSize := crcStatusJSONOutputObj["ramSize"]


### PR DESCRIPTION
Relax disk and RAM size checks in CRC status JSON output validation

- Updated CheckCRCStatusJSONOutput to allow for minor discrepancies in reported disk and RAM sizes.
- The disk size check now accounts for the fact that `crc status -ojson` reports the size of the `/sysroot` mount (from `df -B1 --output=size,used,target /sysroot`), which can be less than the actual VM disk size due to other partitions and filesystem overhead.
- The RAM size check now allows for up to 1 GiB less than the configured value, since `free -b` output reflects available memory after kernel and system overhead.
- These changes improve test reliability by avoiding false negatives caused by environment-specific variations in resource reporting.

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #4781 


## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

## Summary by Sourcery

Improve end-to-end test reliability by relaxing disk and RAM size validations in CRC status JSON output to account for system reporting overhead.

Tests:
- Relax disk size assertion to accept reported `/sysroot` mount size slightly below configured default
- Allow RAM size check to tolerate up to 1 GiB of kernel and system overhead in reported value