### PR TITLE
build: add macos-precheck make path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ $(BUILD_DIR)/windows-amd64/crc.exe: $(SOURCES)
 $(HOST_BUILD_DIR)/crc-embedder: $(SOURCES)
 	go build --tags="build" -ldflags="$(LDFLAGS)" -o $(HOST_BUILD_DIR)/crc-embedder $(GO_EXTRA_BUILDFLAGS) ./cmd/crc-embedder
 
-.PHONY: cross ## Cross compiles all binaries
+.PHONY: macos-precheck cross ## Cross compiles all binaries
 cross: $(BUILD_DIR)/macos-arm64/crc $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/windows-amd64/crc.exe
 
 .PHONY: containerized ## Cross compile from container
@@ -415,3 +415,9 @@ ADMIN_HELPER_VERSION = 0.0.12
 		 -e 's/__HELPER_SCRIPT_CHECKSUM__/'$(HELPER_SCRIPT_HASH)'/g' \
 		 -e 's/__ADMIN_HELPER_VERSION__/'$(ADMIN_HELPER_VERSION)'/g' \
 	     $< >$@
+
+.PHONY: macos-precheck
+macos-precheck:
+ifeq ($(GOOS),darwin)
+	@command -v pkg-config >/dev/null 2>&1 || { echo >&2 "Error: pkg-config is not installed. Please run 'brew install pkg-config'."; exit 1; }
+endif


### PR DESCRIPTION
Changes:
- Adds `macos-precheck` make path to make sure that dependencies for mac builds are checked-for.

### Build process improvements:

* **Added `macos-precheck` target**: Introduced a new target in the `Makefile` to verify the presence of `pkg-config` on macOS systems. If `pkg-config` is missing, the build process will terminate with an error message instructing the user to install it using Homebrew.
* **Updated `.PHONY` declarations**: Included the new `macos-precheck` target in the `.PHONY` section to ensure it is treated as a non-file target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a pre-check step for macOS users to ensure required tools are installed before building. If a necessary tool is missing, users will receive a clear error message with installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->