### PR TITLE
Update openshift/microshift bundle to 4.19.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ all: install
 
 SHELL := /bin/bash -o pipefail
 
-OPENSHIFT_VERSION ?= 4.18.2
+OPENSHIFT_VERSION ?= 4.19.0
 OKD_VERSION ?= 4.19.0-okd-scos.1
-MICROSHIFT_VERSION ?= 4.18.2
+MICROSHIFT_VERSION ?= 4.19.0
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 2.51.0
 COMMIT_SHA?=$(shell git rev-parse --short=6 HEAD)


### PR DESCRIPTION
## Summary by Sourcery

Update default OpenShift and MicroShift versions to 4.19.0

Enhancements:
- Bump OPENSHIFT_VERSION to 4.19.0
- Bump MICROSHIFT_VERSION to 4.19.0