### PR TITLE
context: use background() consistently

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -163,7 +163,7 @@ func downloadDataFiles(goos string, components []string, destDir string) ([]stri
 		if !shouldDownload(components, componentName) {
 			continue
 		}
-		filename, err := download.Download(context.TODO(), dl.url, destDir, dl.permissions, nil)
+		filename, err := download.Download(context.Background(), dl.url, destDir, dl.permissions, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compress/compress_test.go
+++ b/pkg/compress/compress_test.go
@@ -34,7 +34,7 @@ func testCompress(t *testing.T, baseDir string) {
 
 	destDir := t.TempDir()
 
-	fileList, err := extract.Uncompress(context.TODO(), testArchiveName, destDir)
+	fileList, err := extract.Uncompress(context.Background(), testArchiveName, destDir)
 	require.NoError(t, err)
 
 	_, d := filepath.Split(baseDir)

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -122,7 +122,7 @@ func (c *Cache) cacheExecutable() error {
 	// Check the file is tarball or not
 	if isTarball(assetTmpFile) {
 		// Extract the tarball and put it the cache directory.
-		extractedFiles, err = extract.UncompressWithFilter(context.TODO(), assetTmpFile, tmpDir,
+		extractedFiles, err = extract.UncompressWithFilter(context.Background(), assetTmpFile, tmpDir,
 			func(filename string) bool { return filepath.Base(filename) == c.GetExecutableName() })
 		if err != nil {
 			return errors.Wrapf(err, "Cannot uncompress '%s'", assetTmpFile)
@@ -154,7 +154,7 @@ func (c *Cache) getExecutable(destDir string) (string, error) {
 	destPath := filepath.Join(destDir, archiveName)
 	err := embed.Extract(archiveName, destPath)
 	if err != nil {
-		return download.Download(context.TODO(), c.archiveURL, destDir, 0600, nil)
+		return download.Download(context.Background(), c.archiveURL, destDir, 0600, nil)
 	}
 
 	return destPath, err

--- a/pkg/crc/machine/bundle/repository_test.go
+++ b/pkg/crc/machine/bundle/repository_test.go
@@ -40,7 +40,7 @@ func TestExtract(t *testing.T) {
 		OcBinDir: ocBinDir,
 	}
 
-	assert.NoError(t, repo.Extract(context.TODO(), filepath.Join("testdata", testBundle(t))))
+	assert.NoError(t, repo.Extract(context.Background(), filepath.Join("testdata", testBundle(t))))
 
 	bundle, err := repo.Get(testBundle(t))
 	assert.NoError(t, err)

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -125,12 +125,12 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset, enableBundle
 		}
 		var err error
 		logging.Infof("Downloading bundle: %s...", bundlePath)
-		if bundlePath, err = bundle.Download(context.TODO(), preset, bundlePath, enableBundleQuayFallback); err != nil {
+		if bundlePath, err = bundle.Download(context.Background(), preset, bundlePath, enableBundleQuayFallback); err != nil {
 			return err
 		}
 
 		logging.Infof("Uncompressing %s", bundlePath)
-		if _, err := bundle.Extract(context.TODO(), bundlePath); err != nil {
+		if _, err := bundle.Extract(context.Background(), bundlePath); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return errors.Wrap(err, "Use `crc setup -b <bundle-path>`")
 			}

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -60,7 +60,7 @@ func TestDotSlash(t *testing.T) {
 
 func TestZipSlip(t *testing.T) {
 	archiveName := filepath.Join("testdata", "zipslip.tar.gz")
-	_, err := Uncompress(context.TODO(), archiveName, t.TempDir())
+	_, err := Uncompress(context.Background(), archiveName, t.TempDir())
 	logging.Infof("error: %v", err)
 	assert.ErrorContains(t, err, "illegal file path")
 }
@@ -148,9 +148,9 @@ func testUncompress(t *testing.T, archiveName string, fileFilter func(string) bo
 	var fileList []string
 	var err error
 	if fileFilter != nil {
-		fileList, err = UncompressWithFilter(context.TODO(), archiveName, destDir, fileFilter)
+		fileList, err = UncompressWithFilter(context.Background(), archiveName, destDir, fileFilter)
 	} else {
-		fileList, err = Uncompress(context.TODO(), archiveName, destDir)
+		fileList, err = Uncompress(context.Background(), archiveName, destDir)
 	}
 	if err != nil {
 		return err

--- a/pkg/os/copy.go
+++ b/pkg/os/copy.go
@@ -23,7 +23,7 @@ func copyFile(src, dst string, sparse bool) error {
 	defer out.Close()
 
 	if sparse {
-		if _, err = CopySparse(context.TODO(), out, in); err != nil {
+		if _, err = CopySparse(context.Background(), out, in); err != nil {
 			return err
 		}
 	} else {

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -142,7 +142,7 @@ func DownloadBundle(bundleLocation string, bundleDestination string, bundleName 
 		return bundleDestination, err
 	}
 
-	filename, err := download.Download(context.TODO(), bundleLocation, bundleDestination, 0644, nil)
+	filename, err := download.Download(context.Background(), bundleLocation, bundleDestination, 0644, nil)
 	fmt.Printf("Downloading bundle from %s to %s.\n", bundleLocation, bundleDestination)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
In the codebase, there are 12 references to context.TODO() and 28 references to context.Background().

They both do the same thing functionally so here's a PR to make it more consistent and change all TODO references to Background.

Similar to:
- https://github.com/openshift/cert-manager-operator/pull/242
- https://github.com/openshift-kni/eco-goinfra/pull/680
- https://github.com/openshift-kni/eco-goinfra/pull/329
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/1216
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/681

## Summary by Sourcery

Enhancements:
- Replace context.TODO() with context.Background() in production code and tests for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal context usage for various download, extraction, and file copy operations to use a more appropriate background context. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->