### PR TITLE
preflight: Don't put error message when check fails

### DIFF
--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -62,7 +62,7 @@ func (check *Check) doCheck(config crcConfig.Storage) error {
 
 	err := check.check()
 	if err != nil {
-		logging.Error(err.Error())
+		logging.Debug(err.Error())
 	}
 	return err
 }


### PR DESCRIPTION
preflight checks have auto fix functionality (most of them) otherwise Nofix tag make sure it is not fixable automatic so error out. we shouldn't put logging.error for these checks because it shows as part of setup.

## Summary by Sourcery

Enhancements:
- Change preflight check failure logs from error to debug level to hide them from setup output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted error logging to reduce the severity of certain log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->