### PR TITLE
[QE]add time consume track in resize case

### DIFF
--- a/images/build-integration/lib/darwin/run.sh
+++ b/images/build-integration/lib/darwin/run.sh
@@ -56,6 +56,9 @@ fi
 # Copy results
 cd ..
 cp bin/integration.results results/integration.results
+if [[ -f bin/time-consume.txt ]]; then
+  cp bin/time-consume.txt results/time-consume.txt
+fi
 if which xsltproc &>/dev/null
 then
   cat bin/out/integration.xml | xsltproc filter.xsl - > results/$junitFilename

--- a/images/build-integration/lib/linux/run.sh
+++ b/images/build-integration/lib/linux/run.sh
@@ -57,6 +57,9 @@ fi
 # Copy results
 cd ..
 cp bin/integration.results results/integration.results
+if [[ -f bin/time-consume.txt ]]; then
+  cp bin/time-consume.txt results/time-consume.txt
+fi
 if which xsltproc &>/dev/null
 then
   cat bin/out/integration.xml | xsltproc filter.xsl - > results/$junitFilename

--- a/images/build-integration/lib/windows/run.ps1
+++ b/images/build-integration/lib/windows/run.ps1
@@ -35,6 +35,9 @@ if ($labelFilter) {
 # Copy results
 cd ..
 cp bin\integration.results results\integration.results
+if (Test-Path "bin/time-consume.txt") {
+    Copy-Item "bin/time-consume.txt" "results/time-consume.txt"
+}
 $prejunit = "$resultsDir\$junitFilename.pre"
 cp bin\out\integration.xml $prejunit
 

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -114,3 +114,16 @@ func crcCmd(op string, args ...string) []string {
 	}
 	return append(cmd, args...)
 }
+
+func writeDataToFile(filename string, data string) {
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Println("Failed to open file:", filename)
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(data)
+	if err != nil {
+		fmt.Println("Failed to write to file")
+	}
+}


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #N

Relates to: #N, PR #N, ...

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

## Summary by Sourcery

Add timing measurements for CRC start and stop commands in resize integration tests and log durations to a file.

Tests:
- Measure and log duration of CRC start/stop operations across default, custom, and default2 scenarios in resize tests.
- Introduce writeJSONToFile helper to create or append timing entries to time-consume.txt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test cases to measure and log the time taken for starting and stopping the cluster in various configurations.
  * Added a utility to record timing data into a log file for performance tracking.
* **Chores**
  * Updated integration test scripts to include timing logs in the test results archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->