### PR TITLE
return error when no tag or `latest` tag is specified

### DIFF
--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -316,10 +316,23 @@ func TestGetFQDN(t *testing.T) {
 }
 
 func TestGetBundleNameFromURI(t *testing.T) {
+	var noTagErr = &NoTagError{}
+	var unsupportedTagErr = &UnsupportedTagError{}
+
 	// URI with no tag
 	bundleName, err := GetBundleNameFromURI("docker://quay.io/crcont/openshift-bundle")
 	assert.Equal(t, "", bundleName)
-	assert.Error(t, err)
+	assert.ErrorAs(t, err, &noTagErr)
+
+	// URI with colon but no tag
+	bundleName, err = GetBundleNameFromURI("docker://quay.io/crcont/openshift-bundle:")
+	assert.Equal(t, "", bundleName)
+	assert.ErrorAs(t, err, &noTagErr)
+
+	// URI with 'latest' tag
+	bundleName, err = GetBundleNameFromURI("docker://quay.io/crcont/openshift-bundle:latest")
+	assert.Equal(t, "", bundleName)
+	assert.ErrorAs(t, err, &unsupportedTagErr)
 
 	// URI with tag
 	bundleName, err = GetBundleNameFromURI("docker://quay.io/crcont/openshift-bundle:4.17.3")


### PR DESCRIPTION
Fixes: #4520 


## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)


## Testing
```
$ crc setup -b docker://quay.io/crcont/openshift-bundle
ERRO No tag found in bundle URI

$ crc setup -b docker://quay.io/crcont/openshift-bundle:
ERRO No tag found in bundle URI

$ crc setup -b docker://quay.io/crcont/openshift-bundle:latest
ERRO 'latest' tag is not supported; use a specific version
```

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

## Summary by Sourcery

Require explicit version tags in bundle URIs by rejecting empty or 'latest' tags and updating tests accordingly.

Bug Fixes:
- Return an error when bundle URIs lack a version tag or explicitly use the 'latest' tag.

Tests:
- Add unit tests to verify error handling for URIs with no tag and with the 'latest' tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for Docker bundle URIs to reject empty tags and the "latest" tag, requiring explicit version tags.

* **Tests**
  * Added test cases to confirm specific error responses for Docker URIs missing tags or using the "latest" tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->