### PR TITLE
systemd: Add state for activating service

### DIFF
--- a/pkg/crc/systemd/states/state.go
+++ b/pkg/crc/systemd/states/state.go
@@ -10,6 +10,7 @@ const (
 	Unknown State = iota
 	Running
 	Listening
+	Activating
 	Stopped
 	NotFound
 	Error
@@ -19,6 +20,7 @@ var states = []string{
 	"unknown",
 	"active (running)",
 	"active (listening)",
+	"activating (start)",
 	"inactive (dead)",
 	"could not be found",
 	"error",
@@ -37,6 +39,9 @@ func Compare(input string) State {
 	}
 	if strings.Contains(input, states[Listening]) {
 		return Listening
+	}
+	if strings.Contains(input, states[Activating]) {
+		return Activating
 	}
 	if strings.Contains(input, states[Stopped]) {
 		return Stopped


### PR DESCRIPTION
In OCP-4.19 bundles ovs-configuration service is by default active which
was not the case for older bundle so when we check the status it throw
the error because systemd activating state is not implemented. Since it
is the error and in `UpdateResolvFileOnInstance` function logic which
implemented as part of https://github.com/praveenkumar/crc/commit/60040cd097db5eabf1f9234292b5e001b207f2ef, update the /etc/resolv.conf setting
using old method which doesn't work on the bundles with ovs as CNI.

This pr add the activating condition for systemd state logic which
make sure the resolv.conf applied right way.

After this change the instance have
```
$ cat /etc/resolv.conf
search crc.testing
nameserver 192.168.127.1
```

and route controller pod have
```
sh-5.1$ cat /etc/resolv.conf
search openshift-ingress.svc.cluster.local svc.cluster.local cluster.local crc.testing
nameserver 10.217.4.10
options ndots:5
```

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Activating" state to the system status options, improving visibility of transitional states during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes #4823