### PR TITLE
[QE] add cpu and memory consume track to e2e test

### DIFF
--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -12,6 +12,7 @@ Feature: 4 Openshift stories
 	@darwin @linux @windows @testdata @story_health @needs_namespace
 	Scenario: Overall cluster health
 		Given executing "oc new-project testproj" succeeds
+		And get cpu data "After start"
 		When executing "oc apply -f httpd-example.yaml" succeeds
 		And executing "oc rollout status deployment httpd-example" succeeds
 		Then stdout should contain "successfully rolled out"
@@ -23,10 +24,12 @@ Feature: 4 Openshift stories
 		Then stdout should contain "httpd-example exposed"
 		When executing "oc expose svc httpd-example" succeeds
 		Then stdout should contain "httpd-example exposed"
+		And get cpu data "After deployment"
 		When with up to "20" retries with wait period of "5s" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
 		Then executing "curl -s http://httpd-example-testproj.apps-crc.testing" succeeds
 		And stdout should contain "Hello CRC!"
 		When executing "crc stop" succeeds
+		And get cpu data "After stop"
 		And starting CRC with default bundle succeeds
 		And checking that CRC is running
 		And with up to "4" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"

--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -13,6 +13,7 @@ Feature: 4 Openshift stories
 	Scenario: Overall cluster health
 		Given executing "oc new-project testproj" succeeds
 		And get cpu data "After start"
+		And get memory data "After start"
 		When executing "oc apply -f httpd-example.yaml" succeeds
 		And executing "oc rollout status deployment httpd-example" succeeds
 		Then stdout should contain "successfully rolled out"
@@ -25,11 +26,13 @@ Feature: 4 Openshift stories
 		When executing "oc expose svc httpd-example" succeeds
 		Then stdout should contain "httpd-example exposed"
 		And get cpu data "After deployment"
+		And get memory data "After deployment"
 		When with up to "20" retries with wait period of "5s" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
 		Then executing "curl -s http://httpd-example-testproj.apps-crc.testing" succeeds
 		And stdout should contain "Hello CRC!"
 		When executing "crc stop" succeeds
 		And get cpu data "After stop"
+		And get memory data "After stop"
 		And starting CRC with default bundle succeeds
 		And checking that CRC is running
 		And with up to "4" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"

--- a/test/extended/util/fileops.go
+++ b/test/extended/util/fileops.go
@@ -91,7 +91,7 @@ func CreateFile(fileName string) error {
 }
 
 func WriteToFile(text string, fileName string) error {
-	file, err := os.OpenFile(fileName, os.O_RDWR, 0644)
+	file, err := os.OpenFile(fileName, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Add cpu consume track to e2e test case

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added memory-usage collection alongside CPU measurements in the Openshift health scenario; results are saved for later analysis and collection errors are logged without stopping tests.

* **Bug Fixes**
  * Test-result writes now append to result files instead of overwriting, preserving previous data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->