### PR TITLE
Update OpenShift bundle to 4.19.3 (stable channel)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: install
 
 SHELL := /bin/bash -o pipefail
 
-OPENSHIFT_VERSION ?= 4.19.0
+OPENSHIFT_VERSION ?= 4.19.3
 OKD_VERSION ?= 4.19.0-okd-scos.1
 MICROSHIFT_VERSION ?= 4.19.0
 BUNDLE_EXTENSION = crcbundle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default OpenShift version used during build and packaging processes to 4.19.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->