### PR TITLE
CI: Update images from rhel-8-release-golang tag to rhel-9-release-golag

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "CRC environment",
-    "image": "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19",
+    "image": "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20",
 
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "CRC environment",
-    "image": "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20",
+    "image": "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20",
 
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "CRC environment",
-    "image": "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19",
+    "image": "registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19",
 
     "customizations": {
         "vscode": {

--- a/.github/workflows/choco-release.yml
+++ b/.github/workflows/choco-release.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - windows-2022
         go:
-          - '1.23'
+          - '1.24'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -20,7 +20,7 @@ jobs:
           - macOS-13
           - macOS-14
         go:
-          - '1.23'
+          - '1.24'
     steps:
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/.github/workflows/make-check-win.yml
+++ b/.github/workflows/make-check-win.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - windows-2022
         go:
-          - '1.23'
+          - '1.24'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04
         go:
-          - '1.23'
+          - '1.24'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/.github/workflows/make-rpm.yml
+++ b/.github/workflows/make-rpm.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-latest
         go:
-          - '1.23'
+          - '1.24'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/.github/workflows/qe-image.yml
+++ b/.github/workflows/qe-image.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.23'
+          - '1.24'
         os: ['linux', 'windows', 'darwin']
         arch: ['amd64', 'arm64']
         exclude:

--- a/.github/workflows/test-okd-bundle.yml
+++ b/.github/workflows/test-okd-bundle.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.23'
+          - '1.24'
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/Users/runner/.kube/config'

--- a/.github/workflows/verify-devcontainer.yml
+++ b/.github/workflows/verify-devcontainer.yml
@@ -8,7 +8,7 @@ jobs:
   verify-devcontainer:
     runs-on: ubuntu-24.04
     container:
-      image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20
+      image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20
       options: --cpus 4
     steps:
       - name: Run `git clone`

--- a/.github/workflows/verify-devcontainer.yml
+++ b/.github/workflows/verify-devcontainer.yml
@@ -8,7 +8,7 @@ jobs:
   verify-devcontainer:
     runs-on: ubuntu-24.04
     container:
-      image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19
+      image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20
       options: --cpus 4
     steps:
       - name: Run `git clone`

--- a/.github/workflows/verify-devcontainer.yml
+++ b/.github/workflows/verify-devcontainer.yml
@@ -8,7 +8,7 @@ jobs:
   verify-devcontainer:
     runs-on: ubuntu-24.04
     container:
-      image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19
+      image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19
       options: --cpus 4
     steps:
       - name: Run `git clone`

--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-2022']
-        go: ['1.23']
+        go: ['1.24']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/.github/workflows/windows-chocolatey.yml
+++ b/.github/workflows/windows-chocolatey.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - windows-2022
         go:
-          - '1.23'
+          - '1.24'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ RELEASE_DIR ?= release
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-GOVERSION = 1.23
+GOVERSION = 1.24
 
 HOST_BUILD_DIR=$(BUILD_DIR)/$(GOOS)-$(GOARCH)
 GOPATH ?= $(shell go env GOPATH)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crc-org/crc/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/images/build-e2e/Containerfile
+++ b/images/build-e2e/Containerfile
@@ -1,5 +1,5 @@
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20 AS builder
 
 USER root
 

--- a/images/build-e2e/Containerfile
+++ b/images/build-e2e/Containerfile
@@ -1,5 +1,5 @@
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS builder
 
 USER root
 

--- a/images/build-e2e/Containerfile
+++ b/images/build-e2e/Containerfile
@@ -1,5 +1,5 @@
 
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
 
 USER root
 

--- a/images/build-integration/Containerfile
+++ b/images/build-integration/Containerfile
@@ -1,5 +1,5 @@
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20 AS builder
 
 USER root
 

--- a/images/build-integration/Containerfile
+++ b/images/build-integration/Containerfile
@@ -1,5 +1,5 @@
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS builder
 
 USER root
 

--- a/images/build-integration/Containerfile
+++ b/images/build-integration/Containerfile
@@ -1,5 +1,5 @@
 
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
 
 USER root
 

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20 AS builder
 MAINTAINER CRC <devtools-cdk@redhat.com>
 
 WORKDIR /opt/src

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS builder
 MAINTAINER CRC <devtools-cdk@redhat.com>
 
 WORKDIR /opt/src

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
 MAINTAINER CRC <devtools-cdk@redhat.com>
 
 WORKDIR /opt/src

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used by openshift CI
 # It builds an image containing crc and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/crc-org/crc
 COPY . .
 RUN make release

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used by openshift CI
 # It builds an image containing crc and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/crc-org/crc
 COPY . .
 RUN make release

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used by openshift CI
 # It builds an image containing crc and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/crc-org/crc
 COPY . .
 RUN make release

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/crc-org/crc/tools
 
-go 1.23.1
+go 1.24.1
 
 require (
 	github.com/cfergeau/gomod2rpmdeps v0.0.0-20210223144124-2042c4850ca8

--- a/update-go-version.sh
+++ b/update-go-version.sh
@@ -13,9 +13,9 @@ go mod edit -go "${golang_base_version}.0"
 go mod edit -go "${golang_base_version}.1" tools/go.mod
 
 sed -i "s,^GOVERSION = 1.[0-9]\+,GOVERSION = ${golang_base_version}," Makefile
-sed -i "s,^\(FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-\)1.[0-9]\+,\1${golang_base_version}," images/*/Dockerfile
-sed -i "s,^\(FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-\)1.[0-9]\+,\1${golang_base_version}," images/*/Containerfile
-sed -i "s,\(registry.ci.openshift.org/openshift/release:rhel-8-release-golang-\)1.[0-9]\+,\1${golang_base_version}," .devcontainer/devcontainer.json
+sed -i "s,^\(FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-\)1.[0-9]\+,\1${golang_base_version}," images/*/Dockerfile
+sed -i "s,^\(FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-\)1.[0-9]\+,\1${golang_base_version}," images/*/Containerfile
+sed -i "s,\(registry.ci.openshift.org/openshift/release:rhel-9-release-golang-\)1.[0-9]\+,\1${golang_base_version}," .devcontainer/devcontainer.json
 for f in .github/workflows/*.yml; do
     if [ $(yq  eval '.jobs.build.strategy.matrix | has("go")' "$f") == "true" ]; then
       yq eval --inplace ".jobs.build.strategy.matrix.go[0] = ${golang_base_version} | .jobs.build.strategy.matrix.go[0] style=\"single\"" "$f";
@@ -25,4 +25,4 @@ for f in .github/workflows/*.yml; do
     fi
 done
 # Use sed for verify-devcontainer because image is from registry.ci.openshift
-sed -i "s,\(registry.ci.openshift.org/openshift/release:rhel-8-release-golang-\)1.[0-9]\+,\1${golang_base_version}," .github/workflows/verify-devcontainer.yml
+sed -i "s,\(registry.ci.openshift.org/openshift/release:rhel-9-release-golang-\)1.[0-9]\+,\1${golang_base_version}," .github/workflows/verify-devcontainer.yml


### PR DESCRIPTION
By default crc support 2 major release so better to update the images to rhel-9 since rhel-10 is released and available from quite some time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded build and development base images from RHEL 8 to RHEL 9 for improved security and compatibility.
  * Bumped Go toolchain across CI, local builds, and tooling to 1.24.
  * Updated verification and CI workflows to use the new base images and Go version.
  * Enhanced the version-update script to propagate the new base image and Go version across build and installer workflows.
  
These changes standardize and modernize the build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->