### PR TITLE
Update okd bundle to 4.19.0-okd-scos.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: install
 SHELL := /bin/bash -o pipefail
 
 OPENSHIFT_VERSION ?= 4.19.3
-OKD_VERSION ?= 4.19.0-okd-scos.1
+OKD_VERSION ?= 4.19.0-okd-scos.15
 MICROSHIFT_VERSION ?= 4.19.0
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 2.53.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the default OKD version to 4.19.0-okd-scos.15. New builds and deployments will use this version by default. Users relying on the previous default may observe the newer release in their workflows. Existing environments pinned to a specific version are unaffected. No changes to commands or workflows beyond the version bump; this aligns the default with the latest 4.19.0 SCOS stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->