### PR TITLE
update ocp and microshift bundles to 4.19.8 and 4.19.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ all: install
 
 SHELL := /bin/bash -o pipefail
 
-OPENSHIFT_VERSION ?= 4.19.3
+OPENSHIFT_VERSION ?= 4.19.8
 OKD_VERSION ?= 4.19.0-okd-scos.15
-MICROSHIFT_VERSION ?= 4.19.0
+MICROSHIFT_VERSION ?= 4.19.7
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 2.53.0
 COMMIT_SHA?=$(shell git rev-parse --short=6 HEAD)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default OpenShift to 4.19.8 and MicroShift to 4.19.7 for new builds.
  * Packages, images, and bundle names will reflect these updated versions.
  * Version information displayed in the product/CLI now shows the new versions.
  * Advanced users can still override these versions via environment settings during build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->