### PR TITLE
[QE]add performance data gathering for microshift test cases

### DIFF
--- a/test/e2e/features/story_microshift.feature
+++ b/test/e2e/features/story_microshift.feature
@@ -7,7 +7,11 @@ Feature: Microshift test stories
 		And setting config property "persistent-volume-size" to value "20" succeeds
 		And ensuring network mode user
 		And executing single crc setup command succeeds
+		And get cpu data "Before start"
+		And get memory data "Before start"
 		And starting CRC with default bundle succeeds
+		And get cpu data "After start"
+		And get memory data "After start"
 		And ensuring oc command is available
 		And ensuring microshift cluster is fully operational
 		And executing "crc status" succeeds
@@ -32,9 +36,13 @@ Feature: Microshift test stories
 		When executing "oc expose svc httpd-example" succeeds
 		Then stdout should contain "httpd-example exposed"
 		When with up to "20" retries with wait period of "5s" http response from "http://httpd-example-testproj.apps.crc.testing" has status code "200"
+		And get cpu data "After deployment"
+		And get memory data "After deployment"
 		Then executing "curl -s http://httpd-example-testproj.apps.crc.testing" succeeds
 		And stdout should contain "Hello CRC!"
 		When executing "crc stop" succeeds
+		And get cpu data "After stop"
+		And get memory data "After stop"
 		And starting CRC with default bundle succeeds
 		And checking that CRC is running
 		And with up to "4" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps.crc.testing" has status code "200"

--- a/test/integration/podman_test.go
+++ b/test/integration/podman_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/crc-org/crc/v2/test/extended/crc/cmd"
 	"github.com/crc-org/crc/v2/test/extended/util"
@@ -12,7 +13,7 @@ import (
 )
 
 var _ = Describe("podman-remote", Serial, Ordered, Label("microshift-preset"), func() {
-
+	filename := "time-consume.txt"
 	// runs 1x after all the It blocks (specs) inside this Describe node
 	AfterAll(func() {
 
@@ -39,9 +40,12 @@ var _ = Describe("podman-remote", Serial, Ordered, Label("microshift-preset"), f
 
 		It("start CRC", func() {
 			// default values: "--memory", "10752", "--cpus", "4", "disk-size", "31"
-			Expect(
-				crcSuccess("start", "-p", pullSecretPath)).
-				To(ContainSubstring("Started the MicroShift cluster"))
+			start := time.Now()
+			message := crcSuccess("start", "-p", pullSecretPath)
+			duration := time.Since(start)
+			Expect(message).To(ContainSubstring("Started the MicroShift cluster"))
+			data := "crc start: " + duration.String() + "\n"
+			writeDataToFile(filename, data)
 		})
 
 		It("podman-env", func() {


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #N

Relates to: #N, PR #N, ...

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E scenarios now capture CPU and memory metrics at key lifecycle stages (before start, after start, after deployment, after stop) for improved observability.
  * Integration tests now record and log startup duration to help track performance and detect regressions.
  * These diagnostics are test-only and do not change product behavior or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->