### PR TITLE
Makefile: Improve containerized target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,12 +113,9 @@ $(HOST_BUILD_DIR)/crc-embedder: $(SOURCES)
 cross: $(BUILD_DIR)/macos-arm64/crc $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/linux-arm64/crc $(BUILD_DIR)/windows-amd64/crc.exe
 
 .PHONY: containerized ## Cross compile from container
+containerized: image := $(shell grep -m 1 '^FROM' images/openshift-ci/Dockerfile | awk '{print $$2}')
 containerized: clean
-	${CONTAINER_RUNTIME} build -t crc-build -f images/build .
-	${CONTAINER_RUNTIME} run --name crc-cross crc-build make cross
-	${CONTAINER_RUNTIME} cp crc-cross:/opt/app-root/src/out ./
-	${CONTAINER_RUNTIME} rm crc-cross
-	${CONTAINER_RUNTIME} rmi crc-build
+	${CONTAINER_RUNTIME} run --rm -v ${PWD}:/data${SELINUX_VOLUME_LABEL} ${image} /bin/bash -c "cd /data && make cross"
 
 .PHONY: generate_mocks
 generate_mocks: $(TOOLS_BINDIR)/mockery


### PR DESCRIPTION
As of now for this target we are building image first and then copy the binaries out from container to host. This PR uses same base image which openshift-ci using and mount the current working directory and execute cross builds so that building image is not required and also binary directly available to host.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Streamlined the containerized build workflow into a single run step, reducing setup and cleanup overhead and improving local/CI reliability.
- Refactor
  - Build target now automatically derives the container image to minimize manual configuration and maintenance.
- Style
  - Minor build script cleanups for clarity.

No user-facing changes; application behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->