### PR TITLE
[QE] manage absence of xml filter to process xml result

### DIFF
--- a/images/build-e2e/lib/linux/run.sh
+++ b/images/build-e2e/lib/linux/run.sh
@@ -63,10 +63,16 @@ cd $targetFolder/bin
 cd ..
 init_line=$(grep -n '<?xml version="1.0" encoding="UTF-8"?>' results/e2e.results | awk '{split($0,n,":"); print n[1]}')
 if ! command -v xsltproc &>/dev/null
-then 
-  sudo yum install -y xsltproc || echo "Warning: Failed to install xsltproc"
+then
+  sudo yum install -y xsltproc || sudo yum install -y --nogpgcheck xsltproc || echo "Warning: Failed to install xsltproc"
 fi
-tail -n +$init_line results/e2e.results | xsltproc filter.xsl - > results/$junitFilename
+
+if command -v xsltproc &>/dev/null
+then
+  tail -n +$init_line results/e2e.results | xsltproc filter.xsl - > results/$junitFilename
+else
+  tail -n +$init_line results/e2e.results > results/$junitFilename
+fi
 
 # Copy logs and diagnose
 cp -r bin/out/test-results/* results


### PR DESCRIPTION
## Description

On RHEL pre releases xlstproc is failing to install due to unsigned package libxslt

This provide a fallback to install unsigned package, and control if finally command is available


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Test report generation no longer fails when a required system tool is missing; the script attempts installation with a retry and, if unavailable, falls back to writing raw results while issuing a warning.
  - Conditional transformation ensures JUnit output is produced when possible, improving reliability of e2e results.

- Chores
  - Updated e2e build script to detect tool availability at runtime and apply transformation only when supported, simplifying control flow and removing the previous unconditional processing path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->