### PR TITLE
Add Config to Disable Hosts File Modification

### DIFF
--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -27,6 +27,7 @@ const (
 	ProxyCAFile              = "proxy-ca-file"
 	ConsentTelemetry         = "consent-telemetry"
 	EnableClusterMonitoring  = "enable-cluster-monitoring"
+	ModifyHostsFile          = "modify-hosts-file"
 	KubeAdminPassword        = "kubeadmin-password"
 	DeveloperPassword        = "developer-password"
 	Preset                   = "preset"
@@ -106,6 +107,9 @@ func RegisterSettings(cfg *Config) {
 
 	cfg.AddSetting(EnableClusterMonitoring, false, ValidateBool, SuccessfullyApplied,
 		"Enable cluster monitoring Operator (true/false, default: false)")
+
+	cfg.AddSetting(ModifyHostsFile, true, ValidateBool, SuccessfullyApplied,
+		"Allow CRC to modify the system hosts file (true/false, default: true)")
 
 	// Telemeter Configuration
 	cfg.AddSetting(ConsentTelemetry, "", validateYesNo, SuccessfullyApplied,

--- a/pkg/crc/config/settings_test.go
+++ b/pkg/crc/config/settings_test.go
@@ -252,6 +252,9 @@ var configDefaultValuesTestArguments = []struct {
 		EnableClusterMonitoring, false,
 	},
 	{
+		ModifyHostsFile, true,
+	},
+	{
 		ConsentTelemetry, "",
 	},
 	{
@@ -330,6 +333,9 @@ var configProvidedValuesTestArguments = []struct {
 	},
 	{
 		EnableClusterMonitoring, true,
+	},
+	{
+		ModifyHostsFile, false,
 	},
 	{
 		ConsentTelemetry, "yes",

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -64,6 +64,10 @@ func (client *client) networkMode() network.Mode {
 	return crcConfig.GetNetworkMode(client.config)
 }
 
+func (client *client) modifyHostsFile() bool {
+	return client.config.Get(crcConfig.ModifyHostsFile).AsBool()
+}
+
 func (client *client) monitoringEnabled() bool {
 	return client.config.Get(crcConfig.EnableClusterMonitoring).AsBool()
 }

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -696,7 +696,7 @@ func createHost(machineConfig config.MachineConfig, preset crcPreset.Preset) err
 		if err := cluster.GenerateUserPassword(constants.GetKubeAdminPasswordPath(), "kubeadmin"); err != nil {
 			return errors.Wrap(err, "Error generating new kubeadmin password")
 		}
-		if err = os.WriteFile(constants.GetDeveloperPasswordPath(), []byte(constants.DefaultDeveloperPassword), 0600); err != nil {
+		if err = os.WriteFile(constants.GetDeveloperPasswordPath(), []byte(constants.DefaultDeveloperPassword), 0o600); err != nil {
 			return errors.Wrap(err, "Error writing developer password")
 		}
 	}
@@ -750,7 +750,7 @@ func enableEmergencyLogin(sshRunner *crcssh.Runner) error {
 	for i := range b {
 		b[i] = charset[rand.Intn(len(charset))] //nolint:gosec
 	}
-	if err := os.WriteFile(constants.PasswdFilePath, b, 0600); err != nil {
+	if err := os.WriteFile(constants.PasswdFilePath, b, 0o600); err != nil {
 		return err
 	}
 	logging.Infof("Emergency login password for core user is stored to %s", constants.PasswdFilePath)
@@ -777,7 +777,7 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	}
 
 	logging.Info("Updating authorized keys...")
-	err = sshRunner.CopyData(publicKey, "/home/core/.ssh/authorized_keys", 0644)
+	err = sshRunner.CopyData(publicKey, "/home/core/.ssh/authorized_keys", 0o644)
 	if err != nil {
 		return err
 	}
@@ -876,10 +876,10 @@ func startMicroshift(ctx context.Context, sshRunner *crcssh.Runner, ocConfig oc.
 	if _, _, err := sshRunner.RunPrivileged("Starting microshift service", "systemctl", "start", "microshift"); err != nil {
 		return err
 	}
-	if err := sshRunner.CopyFileFromVM(fmt.Sprintf("/var/lib/microshift/resources/kubeadmin/api%s/kubeconfig", constants.ClusterDomain), constants.KubeconfigFilePath, 0600); err != nil {
+	if err := sshRunner.CopyFileFromVM(fmt.Sprintf("/var/lib/microshift/resources/kubeadmin/api%s/kubeconfig", constants.ClusterDomain), constants.KubeconfigFilePath, 0o600); err != nil {
 		return err
 	}
-	if err := sshRunner.CopyFile(constants.KubeconfigFilePath, "/opt/kubeconfig", 0644); err != nil {
+	if err := sshRunner.CopyFile(constants.KubeconfigFilePath, "/opt/kubeconfig", 0o644); err != nil {
 		return err
 	}
 
@@ -897,5 +897,5 @@ func ensurePullSecretPresentInVM(sshRunner *crcssh.Runner, pullSec cluster.PullS
 	if err != nil {
 		return err
 	}
-	return sshRunner.CopyDataPrivileged([]byte(content), "/etc/crio/openshift-pull-secret", 0600)
+	return sshRunner.CopyDataPrivileged([]byte(content), "/etc/crio/openshift-pull-secret", 0o600)
 }

--- a/pkg/crc/services/dns/dns_darwin.go
+++ b/pkg/crc/services/dns/dns_darwin.go
@@ -33,8 +33,12 @@ type resolverFileValues struct {
 
 func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
 	// Update /etc/hosts file for host
-	if err := addOpenShiftHosts(serviceConfig); err != nil {
-		return err
+	if serviceConfig.ModifyHostsFile {
+		if err := addOpenShiftHosts(serviceConfig); err != nil {
+			return err
+		}
+	} else {
+		logging.Infof("Skipping hosts file modification because 'modify-hosts-file' is set to false")
 	}
 
 	if serviceConfig.NetworkMode == network.UserNetworkingMode {
@@ -86,7 +90,7 @@ func createResolverFile(instanceIP string, domain string, filename string) (bool
 	}
 
 	path := filepath.Join("/", "etc", "resolver", filename)
-	return crcos.WriteFileIfContentChanged(path, resolverFile.Bytes(), 0644)
+	return crcos.WriteFileIfContentChanged(path, resolverFile.Bytes(), 0o644)
 }
 
 // restartNetwork is required to update the resolver file on OSx.

--- a/pkg/crc/services/dns/dns_linux.go
+++ b/pkg/crc/services/dns/dns_linux.go
@@ -1,11 +1,18 @@
 package dns
 
 import (
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/services"
 )
 
 func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
 	// We might need to set the firewall here to forward
 	// Update /etc/hosts file for host
-	return addOpenShiftHosts(serviceConfig)
+	if serviceConfig.ModifyHostsFile {
+		return addOpenShiftHosts(serviceConfig)
+	}
+
+	logging.Infof("Skipping hosts file modification because 'modify-hosts-file' is set to false")
+
+	return nil
 }

--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"fmt"
 
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/network"
 	"github.com/crc-org/crc/v2/pkg/crc/services"
 )
@@ -11,5 +12,12 @@ func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
 	if serviceConfig.NetworkMode != network.UserNetworkingMode {
 		return fmt.Errorf("only user-mode networking is supported on Windows")
 	}
-	return addOpenShiftHosts(serviceConfig)
+
+	if serviceConfig.ModifyHostsFile {
+		return addOpenShiftHosts(serviceConfig)
+	}
+
+	logging.Infof("Skipping hosts file modification because 'modify-hosts-file' is set to false")
+
+	return nil
 }

--- a/pkg/crc/services/services.go
+++ b/pkg/crc/services/services.go
@@ -7,9 +7,10 @@ import (
 )
 
 type ServicePostStartConfig struct {
-	Name           string
-	SSHRunner      *ssh.Runner
-	BundleMetadata bundle.CrcBundleInfo
-	IP             string
-	NetworkMode    network.Mode
+	Name            string
+	SSHRunner       *ssh.Runner
+	BundleMetadata  bundle.CrcBundleInfo
+	IP              string
+	NetworkMode     network.Mode
+	ModifyHostsFile bool
 }


### PR DESCRIPTION
## Description

This change introduces a new configuration setting `modify-hosts-file` that allows users to disable CRC's automatic modification of the /etc/hosts file. The setting defaults to true to maintain backward compatibility with existing installations.

When set to false, CRC will skip adding OpenShift hostnames to the system's hosts file during cluster startup. This is particularly useful for systems like NixOS where the hosts file is managed declaratively and cannot be modified by applications, or for users who prefer to manage DNS resolution through other means.

The implementation adds the configuration option to all platform-specific DNS modules (Linux, macOS, Windows) and includes the setting in the service configuration passed to DNS setup routines.

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing

I tested this e2e on my NixOS machine by manually setting the needed host file entries: `api.crc.testing, canary-openshift-ingress-canary.apps-crc.testing, ...` and with the new config  `modify-hosts-file = false`.
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-configurable setting to control whether CRC updates the system hosts file during start and via API endpoints (default: enabled). When disabled, CRC skips modifying hosts on Linux, macOS, and Windows and logs the skip.

* **Documentation / Messaging**
  * Improved post-start DNS error guidance advising verification of system DNS/hosts when hosts modification is disabled.

* **Tests**
  * Extended tests to cover the new setting's default and provided values and API behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->