### PR TITLE
verify-vendor.sh: fix early exit on non-zero exit code

### DIFF
--- a/verify-vendor.sh
+++ b/verify-vendor.sh
@@ -16,10 +16,8 @@ make vendor
 go mod verify
 
 echo "Diffing $(pwd)"
-git diff --exit-code vendor go.mod go.sum
 
-if [[ $? -eq 0 ]]
-then
+if git diff --exit-code vendor go.mod go.sum; then
   echo "$(pwd) up to date."
 else
   echo "$(pwd) is out of date. Please run make vendor"


### PR DESCRIPTION
If `git diff --exit-code vendor go.mod go.sum` found a difference, it exited with exit code 1 and caused the whole script to exit prematurely due to `set -o errexit`, skipping the printing of the final message to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified conditional logic in an internal verification script to reduce redundancy and improve readability. Behavior, messages, and exit codes remain unchanged.

* **Chores**
  * Maintenance updates to internal tooling to streamline developer workflows. No impact on user-facing functionality or production behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->