### PR TITLE
chore: Update the macOS installer with an informative end dialog and a clickable link

### DIFF
--- a/packaging/darwin/Resources/conclusion.html
+++ b/packaging/darwin/Resources/conclusion.html
@@ -7,7 +7,7 @@
 <div align="left" style="font-family: Helvetica; padding-left: 10px;">
     <br/>
     <p style="color: #020202; font-size: 12px;">Thanks for installing Red Hat OpenShift Local!</p>
-    <p style="color: #020202; font-size: 12px;">You can now open OpenShift Local from the Applications folder.</b>.</p>
+    <p style="color: #020202; font-size: 12px;">You can now run OpenShift Local following the directions at <a href="https://crc.dev/docs/using/">https://crc.dev/docs/using/</a></p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Description

Update the macOS installer to include a more meaningful end dialog

Fixes: #4939

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase; test, version modification, documentation, etc.)

## Proposed changes
Original macOS installer end dialog: You can now open OpenShift Local from the Applications folder.

Updated macOS installer end dialog: You can now run OpenShift Local following the directions at https://crc.dev/docs/using/

## Testing

Install OpenShift Local on macOS and check for the installer end dialog

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on?
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the macOS post-installation message to direct users to the “Using OpenShift Local” documentation (https://crc.dev/docs/using/) for run instructions instead of instructing to open the app from the Applications folder.
  * Fixed wording/formatting in that message for clearer, more consistent onboarding guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->