### PR TITLE
lint: Remove usage of //+build, and some //nolint improvements

### DIFF
--- a/pkg/crc/adminhelper/hosts_unix.go
+++ b/pkg/crc/adminhelper/hosts_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package adminhelper
 

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -53,7 +53,7 @@ func (c *Cache) GetExecutableName() string {
  *
  * It returns <version> as a string
  */
-func getVersionGeneric(executablePath string, args ...string) (string, error) { //nolint:deadcode,unused
+func getVersionGeneric(executablePath string, args ...string) (string, error) { //nolint:unused
 	stdOut, _, err := crcos.RunWithDefaultLocale(executablePath, args...)
 	if err != nil {
 		logging.Debugf("failed to run executable %s: %v", executablePath, err)

--- a/pkg/crc/daemonclient/transport_unix.go
+++ b/pkg/crc/daemonclient/transport_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package daemonclient
 

--- a/pkg/crc/gpg/gpg.go
+++ b/pkg/crc/gpg/gpg.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
-	goOpenpgp "golang.org/x/crypto/openpgp"             //nolint
-	goClearsign "golang.org/x/crypto/openpgp/clearsign" //nolint
+	goOpenpgp "golang.org/x/crypto/openpgp"             //nolint:staticcheck
+	goClearsign "golang.org/x/crypto/openpgp/clearsign" //nolint:staticcheck
 )
 
 func Verify(filePath, signatureFilePath string) error {

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -65,7 +65,11 @@ func (client *client) GenerateBundle(forceStop bool) error {
 	if err != nil {
 		return err
 	}
-	defer copier.Cleanup() //nolint
+	defer func() {
+		if err := copier.Cleanup(); err != nil {
+			logging.Errorf("copier.Cleanup failed: %v", err)
+		}
+	}()
 	customBundleDir := copier.CachedPath()
 
 	if err := copier.CopyKubeConfig(); err != nil {

--- a/pkg/crc/machine/generate_bundle_nonlinux.go
+++ b/pkg/crc/machine/generate_bundle_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package machine
 

--- a/pkg/crc/machine/libvirt/constants.go
+++ b/pkg/crc/machine/libvirt/constants.go
@@ -1,5 +1,4 @@
 //go:build linux || build
-// +build linux build
 
 package libvirt
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -746,7 +746,7 @@ func enableEmergencyLogin(sshRunner *crcssh.Runner) error {
 	charset := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	b := make([]byte, 8)
 	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))] //nolint
+		b[i] = charset[rand.Intn(len(charset))] //nolint:gosec
 	}
 	if err := os.WriteFile(constants.PasswdFilePath, b, 0600); err != nil {
 		return err

--- a/pkg/crc/machine/vfkit/constants.go
+++ b/pkg/crc/machine/vfkit/constants.go
@@ -1,5 +1,4 @@
 //go:build darwin || build
-// +build darwin build
 
 package vfkit
 

--- a/pkg/crc/manpages/manpages_unix.go
+++ b/pkg/crc/manpages/manpages_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package manpages
 

--- a/pkg/crc/manpages/manpages_unix_test.go
+++ b/pkg/crc/manpages/manpages_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package manpages
 

--- a/pkg/crc/preflight/labels.go
+++ b/pkg/crc/preflight/labels.go
@@ -14,7 +14,7 @@ const (
 
 	// Keep it last
 	// will be used in OS-specific go files to extend LabelName
-	lastLabelName // nolint
+	lastLabelName //nolint:unused
 )
 
 type LabelValue uint32
@@ -31,7 +31,7 @@ const (
 
 	// Keep it last
 	// will be used in OS-specific go files to extend LabelValue
-	lastLabelValue // nolint
+	lastLabelValue //nolint:unused
 )
 
 var (

--- a/pkg/crc/preflight/preflight_checks_network_linux.go
+++ b/pkg/crc/preflight/preflight_checks_network_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package preflight
 

--- a/pkg/crc/preflight/preflight_checks_nonlinux.go
+++ b/pkg/crc/preflight/preflight_checks_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package preflight
 

--- a/pkg/crc/preflight/preflight_checks_unix.go
+++ b/pkg/crc/preflight/preflight_checks_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package preflight
 

--- a/pkg/crc/preflight/preflight_ubuntu_linux.go
+++ b/pkg/crc/preflight/preflight_ubuntu_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package preflight
 

--- a/pkg/crc/preflight/preflight_ubuntu_linux_test.go
+++ b/pkg/crc/preflight/preflight_ubuntu_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package preflight
 

--- a/pkg/crc/ssh/keys_unix.go
+++ b/pkg/crc/ssh/keys_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package ssh
 

--- a/pkg/os/linux/release_info.go
+++ b/pkg/os/linux/release_info.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package linux
 

--- a/pkg/os/linux/release_info_test.go
+++ b/pkg/os/linux/release_info_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package linux
 

--- a/pkg/os/shell/shell_unix.go
+++ b/pkg/os/shell/shell_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package shell
 

--- a/pkg/os/shell/shell_unix_test.go
+++ b/pkg/os/shell/shell_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package shell
 

--- a/pkg/os/util_unix.go
+++ b/pkg/os/util_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package os
 

--- a/pkg/os/windows/win32/domains_windows.go
+++ b/pkg/os/windows/win32/domains_windows.go
@@ -23,7 +23,7 @@ import (
 	"github.com/yusufpapurcu/wmi"
 )
 
-// nolint
+//nolint:staticcheck
 type Win32_ComputerSystem struct {
 	Partofdomain bool
 }

--- a/test/extended/os/applescript/applescript.go
+++ b/test/extended/os/applescript/applescript.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package applescript
 


### PR DESCRIPTION
Main goal is to fix the linting errors which appear with https://github.com/crc-org/crc/pull/4975