### PR TITLE
Remove workaround as part of stop command

### DIFF
--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/state"
-	crcPreset "github.com/crc-org/crc/v2/pkg/crc/preset"
-	"github.com/crc-org/crc/v2/pkg/crc/systemd"
 	"github.com/pkg/errors"
 )
 
@@ -25,12 +23,6 @@ func (client *client) Stop() (state.State, error) {
 		return state.Error, errors.Wrap(err, "Cannot load machine")
 	}
 	defer vm.Close()
-	if client.GetPreset() == crcPreset.OpenShift {
-		if err := stopAllContainers(vm); err != nil {
-			logging.Warnf("Failed to stop all OpenShift containers.\nShutting down VM...")
-			logging.Debugf("%v", err)
-		}
-	}
 	logging.Info("Stopping the instance, this may take a few minutes...")
 	if err := vm.Stop(); err != nil {
 		status, stateErr := vm.State()
@@ -48,27 +40,4 @@ func (client *client) Stop() (state.State, error) {
 		return status, unexposePorts()
 	}
 	return status, nil
-}
-
-// This should be removed after https://bugzilla.redhat.com/show_bug.cgi?id=1965992
-// is fixed. We should also ignore the openshift specific errors because stop
-// operation shouldn't depend on the openshift side. Without this graceful shutdown
-// takes around 6-7 mins.
-func stopAllContainers(vm *virtualMachine) error {
-	logging.Info("Stopping kubelet and all containers...")
-	sshRunner, err := vm.SSHRunner()
-	if err != nil {
-		return errors.Wrapf(err, "Error creating the ssh client")
-	}
-	defer sshRunner.Close()
-
-	if err := systemd.NewInstanceSystemdCommander(sshRunner).Stop("kubelet"); err != nil {
-		return err
-	}
-	_, stderr, err := sshRunner.RunPrivileged("stopping all containers", `-- sh -c 'crictl stop $(crictl ps -q)'`)
-	if err != nil {
-		logging.Errorf("Failed to stop all containers: %v - %s", err, stderr)
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
Older version of OCP had issue which causing the issue for graceful shutdown to longer than usual. This was fixed on OCP side but we still carry workaround. Recently we observe that because of this workaround ssh connection also affected and stop process hangs.

My understanding is `crictl stop $(crictl ps -q)` command stop all the container which also include the ovn/network containers and because of that `br-ex` is removed (bridge network) and tap0 doesn't take ownership back from br-ex so might be that's the reason the ssh connection is broken. This is only happen sometime but when this happen it make all the process hang.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified machine stop operation by removing OpenShift-specific container shutdown handling that previously ran prior to VM termination. When stopping a machine, the VM now terminates directly without attempting to stop OpenShift containers via SSH. Kubeconfig cleanup and post-stop status reporting operations continue to function normally during the shutdown sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->