### PR TITLE
CI: Update macos workflow to latest macos

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-13
-          - macOS-14
+          - macOS-15-intel
+          - macOS-15
         go:
           - '1.24'
     steps:

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-13
-          - macOS-14
+          - macOS-15
+          - macOS-26
           - ubuntu-latest
           - ubuntu-22.04
         go:


### PR DESCRIPTION
Looks like macos-13 is now depricated so replace those with macos-15 and macos-26.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated macOS runner versions in CI/CD workflows to newer versions (macOS-15-intel, macOS-15, and macOS-26), ensuring builds run on current environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->