### PR TITLE
e2e: disable color output of test results

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -25,7 +25,7 @@ func init() {
 	pflag.StringVar(&opts.Tags, "godog.tags", "", "Tags for godog test")
 	pflag.BoolVar(&opts.ShowStepDefinitions, "godog.definitions", false, "")
 	pflag.BoolVar(&opts.StopOnFailure, "godog.stop-on-failure", false, "Stop when failure is found")
-	pflag.BoolVar(&opts.NoColors, "godog.no-colors", false, "Disable colors in godog output")
+	pflag.BoolVar(&opts.NoColors, "godog.no-colors", true, "Disable colors in godog output")
 
 	testsuite.ParseFlags()
 }


### PR DESCRIPTION
Improves readability of logs from pipelines.

Example - [log](https://storage.googleapis.com/test-platform-results/pr-logs/pull/crc-org_crc/4866/pull-ci-crc-org-crc-main-e2e-crc/1990624616791412736/build-log.txt) with color enabled:
```
features/proxy.feature:9[0m
      [31mError: [0m[1;31mCRC_DISABLE_UPDATE_CHECK=true crc setup -b /home/packer/crc_libvirt_4.20.1_amd64.crcbundle expected succeeds but it did not[0m

  [31mScenario: Overall cluster health[0m [1;30m# test/e2e/features/story_openshift.feature:13[0m
    [31mAnd ensuring CRC cluster is running[0m [1;30m# test/e2e/features/story_openshift.feature:6[0m
      [31mError: [0m[1;31mCRC_DISABLE_UPDATE_CHECK=true crc setup -b /home/packer/crc_libvirt_4.20.1_amd64.crcbundle expected succeeds but it did not[0m

  [31mScenario: Install new operator[0m [1;30m# test/e2e/features/story_openshift.feature:77[0m
    [31mAnd ensuring CRC cluster is running[0m [1;30m# test/e2e/features/story_openshift.feature:6[0m
      [31mError: [0m[1;31mCRC_DISABLE_UPDATE_CHECK=true crc setup -b /home/packer/crc_libvirt_4.20.1_amd64.crcbundle expected succeeds but it did not[0m


72 scenarios ([32m31 passed[0m, [31m41 failed[0m)
398 steps ([32m136 passed[0m, [31m41 failed[0m, [36m221 skipped[0m)
```

color disabled:
```
features/proxy.feature:9
      Error: CRC_DISABLE_UPDATE_CHECK=true crc setup -b /home/packer/crc_libvirt_4.20.1_amd64.crcbundle expected succeeds but it did not

  Scenario: Overall cluster health # test/e2e/features/story_openshift.feature:13
    And ensuring CRC cluster is running # test/e2e/features/story_openshift.feature:6
      Error: CRC_DISABLE_UPDATE_CHECK=true crc setup -b /home/packer/crc_libvirt_4.20.1_amd64.crcbundle expected succeeds but it did not

  Scenario: Install new operator # test/e2e/features/story_openshift.feature:77
    And ensuring CRC cluster is running # test/e2e/features/story_openshift.feature:6
      Error: CRC_DISABLE_UPDATE_CHECK=true crc setup -b /home/packer/crc_libvirt_4.20.1_amd64.crcbundle expected succeeds but it did not


72 scenarios (31 passed, 41 failed)
398 steps (136 passed, 41 failed, 221 skipped)
```