### PR TITLE
Update OCP bundle to 4.20.5 (stable channel)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: install
 
 SHELL := /bin/bash -o pipefail
 
-OPENSHIFT_VERSION ?= 4.20.1
+OPENSHIFT_VERSION ?= 4.20.5
 OKD_VERSION ?= 4.20.0-okd-scos.7
 MICROSHIFT_VERSION ?= 4.20.0
 BUNDLE_EXTENSION = crcbundle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default OpenShift version from 4.20.1 to 4.20.5 in release builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->