### PR TITLE
PoC: Add bundle download cmd

### DIFF
--- a/cmd/crc/cmd/bundle/bundle.go
+++ b/cmd/crc/cmd/bundle/bundle.go
@@ -9,11 +9,15 @@ func GetBundleCmd(config *config.Config) *cobra.Command {
 	bundleCmd := &cobra.Command{
 		Use:   "bundle SUBCOMMAND [flags]",
 		Short: "Manage CRC bundles",
-		Long:  "Manage CRC bundles",
+		Long:  "Manage CRC bundles, including downloading, listing, and cleaning up cached bundles.",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
 	}
 	bundleCmd.AddCommand(getGenerateCmd(config))
+	bundleCmd.AddCommand(getDownloadCmd(config))
+	bundleCmd.AddCommand(getListCmd(config))
+	bundleCmd.AddCommand(getClearCmd())
+	bundleCmd.AddCommand(getPruneCmd())
 	return bundleCmd
 }

--- a/cmd/crc/cmd/bundle/clear.go
+++ b/cmd/crc/cmd/bundle/clear.go
@@ -1,0 +1,65 @@
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/spf13/cobra"
+)
+
+var bundleDirPattern = regexp.MustCompile(`^crc_\w+_\d+\.\d+\.\d+_\w+$`)
+
+func isBundleDir(name string) bool {
+	return bundleDirPattern.MatchString(name)
+}
+
+func getClearCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clear",
+		Short: "Clear cached CRC bundles",
+		Long:  "Delete all downloaded CRC bundles from the cache directory.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runClear()
+		},
+	}
+}
+
+func runClear() error {
+	cacheDir := constants.MachineCacheDir
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		logging.Infof("Cache directory %s does not exist", cacheDir)
+		return nil
+	}
+
+	files, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return err
+	}
+
+	cleared := false
+	var lastErr error
+	for _, file := range files {
+		name := file.Name()
+		if strings.HasSuffix(name, ".crcbundle") || isBundleDir(name) {
+			filePath := filepath.Join(cacheDir, name)
+			logging.Infof("Deleting %s", filePath)
+			if err := os.RemoveAll(filePath); err != nil {
+				logging.Errorf("failed to remove %s: %v", filePath, err)
+				lastErr = err
+			} else {
+				cleared = true
+			}
+		}
+	}
+
+	if !cleared && lastErr == nil {
+		logging.Infof("No bundles found in %s", cacheDir)
+	} else if cleared {
+		logging.Infof("Cleared cached bundles in %s", cacheDir)
+	}
+	return lastErr
+}

--- a/cmd/crc/cmd/bundle/download.go
+++ b/cmd/crc/cmd/bundle/download.go
@@ -1,0 +1,154 @@
+package bundle
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	crcConfig "github.com/crc-org/crc/v2/pkg/crc/config"
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/gpg"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/bundle"
+	crcPreset "github.com/crc-org/crc/v2/pkg/crc/preset"
+	"github.com/crc-org/crc/v2/pkg/download"
+	"github.com/spf13/cobra"
+)
+
+func getDownloadCmd(config *crcConfig.Config) *cobra.Command {
+	downloadCmd := &cobra.Command{
+		Use:   "download [version] [architecture]",
+		Short: "Download a specific CRC bundle",
+		Long:  "Download a specific CRC bundle from the mirrors. If no version or architecture is specified, the bundle for the current CRC version will be downloaded.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			force, _ := cmd.Flags().GetBool("force")
+			presetStr, _ := cmd.Flags().GetString("preset")
+
+			var preset crcPreset.Preset
+			if presetStr != "" {
+				var err error
+				preset, err = crcPreset.ParsePresetE(presetStr)
+				if err != nil {
+					return err
+				}
+			} else {
+				preset = crcConfig.GetPreset(config)
+			}
+
+			return runDownload(cmd.Context(), args, preset, force)
+		},
+	}
+	downloadCmd.Flags().BoolP("force", "f", false, "Overwrite existing bundle if present")
+	downloadCmd.Flags().StringP("preset", "p", "", "Target preset (openshift, okd, microshift)")
+
+	return downloadCmd
+}
+
+func runDownload(ctx context.Context, args []string, preset crcPreset.Preset, force bool) error {
+	if len(args) > 2 {
+		return fmt.Errorf("too many arguments: expected at most 2 (version, architecture), got %d", len(args))
+	}
+
+	// If no args, use default bundle path
+	if len(args) == 0 {
+		defaultBundlePath := constants.GetDefaultBundlePath(preset)
+		if !force {
+			if _, err := os.Stat(defaultBundlePath); err == nil {
+				logging.Infof("Bundle %s already exists. Use --force to overwrite.", defaultBundlePath)
+				return nil
+			}
+		}
+
+		logging.Debugf("Source: %s", constants.GetDefaultBundleDownloadURL(preset))
+		logging.Debugf("Destination: %s", defaultBundlePath)
+		// For default bundle, we use the existing logic which handles verification internally
+		_, err := bundle.Download(ctx, preset, defaultBundlePath, false)
+		return err
+	}
+
+	// If args provided, we are constructing a URL
+	version := args[0]
+
+	// Check if version is partial (Major.Minor) and resolve it if necessary
+	resolvedVersion, err := resolveOpenShiftVersion(preset, version)
+	if err != nil {
+		return fmt.Errorf("failed to resolve version %s: %w", version, err)
+	}
+	if resolvedVersion != version {
+		logging.Debugf("Resolved version %s to %s", version, resolvedVersion)
+		version = resolvedVersion
+	}
+
+	architecture := runtime.GOARCH
+	if len(args) > 1 {
+		architecture = args[1]
+	}
+
+	bundleName := constants.BundleName(preset, version, architecture)
+	bundlePath := filepath.Join(constants.MachineCacheDir, bundleName)
+
+	if !force {
+		if _, err := os.Stat(bundlePath); err == nil {
+			logging.Infof("Bundle %s already exists. Use --force to overwrite.", bundleName)
+			return nil
+		}
+	}
+
+	// Base URL for the directory containing the bundle and signature
+	baseVersionURL := fmt.Sprintf("%s/%s/%s/", constants.DefaultMirrorURL, preset.String(), version)
+	bundleURL := fmt.Sprintf("%s%s", baseVersionURL, bundleName)
+	sigURL := fmt.Sprintf("%s%s", baseVersionURL, "sha256sum.txt.sig")
+
+	logging.Infof("Downloading bundle: %s", bundleName)
+	logging.Debugf("Source: %s", bundleURL)
+	logging.Debugf("Destination: %s", constants.MachineCacheDir)
+
+	// Implement verification logic
+	logging.Infof("Verifying signature for %s...", version)
+	sha256sum, err := getVerifiedHashForCustomVersion(sigURL, bundleName)
+	if err != nil {
+		return fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	sha256bytes, err := hex.DecodeString(sha256sum)
+	if err != nil {
+		return fmt.Errorf("failed to decode sha256sum: %w", err)
+	}
+
+	_, err = download.Download(ctx, bundleURL, bundlePath, 0664, sha256bytes)
+	return err
+}
+
+func getVerifiedHashForCustomVersion(sigURL string, bundleName string) (string, error) {
+	res, err := download.InMemory(sigURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch signature file: %w", err)
+	}
+	defer res.Close()
+
+	signedHashes, err := io.ReadAll(res)
+	if err != nil {
+		return "", fmt.Errorf("failed to read signature file: %w", err)
+	}
+
+	verifiedHashes, err := gpg.GetVerifiedClearsignedMsgV3(constants.RedHatReleaseKey, string(signedHashes))
+	if err != nil {
+		return "", fmt.Errorf("invalid signature: %w", err)
+	}
+
+	lines := strings.Split(verifiedHashes, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, bundleName) {
+			sha256sum := strings.TrimSuffix(line, "  "+bundleName)
+			sha256sum = strings.TrimSpace(sha256sum)
+			return sha256sum, nil
+		}
+	}
+	return "", fmt.Errorf("hash for %s not found in signature file", bundleName)
+}

--- a/cmd/crc/cmd/bundle/list.go
+++ b/cmd/crc/cmd/bundle/list.go
@@ -1,0 +1,69 @@
+package bundle
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/Masterminds/semver/v3"
+	crcConfig "github.com/crc-org/crc/v2/pkg/crc/config"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/spf13/cobra"
+)
+
+func getListCmd(config *crcConfig.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list [version]",
+		Short: "List available CRC bundles",
+		Long:  "List available CRC bundles from the mirrors. Optionally filter by major.minor version (e.g. 4.19).",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(args, config)
+		},
+	}
+}
+
+func runList(args []string, config *crcConfig.Config) error {
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments: expected at most 1 version filter, got %d", len(args))
+	}
+
+	preset := crcConfig.GetPreset(config)
+	versions, err := fetchAvailableVersions(preset)
+	if err != nil {
+		return err
+	}
+
+	if len(versions) == 0 {
+		logging.Infof("No bundles found for preset %s", preset)
+		return nil
+	}
+
+	var filter *semver.Version
+	if len(args) > 0 {
+		v, err := semver.NewVersion(args[0] + ".0") // Treat 4.19 as 4.19.0 for partial matching
+		if err == nil {
+			filter = v
+		} else {
+			// Try parsing as full version just in case
+			v, err = semver.NewVersion(args[0])
+			if err == nil {
+				filter = v
+			}
+		}
+	}
+
+	logging.Infof("Available bundles for %s:", preset)
+	for _, v := range versions {
+		if filter != nil {
+			if v.Major() != filter.Major() || v.Minor() != filter.Minor() {
+				continue
+			}
+		}
+
+		cachedStr := ""
+		if isBundleCached(preset, v.String(), runtime.GOARCH) {
+			cachedStr = " (cached)"
+		}
+		fmt.Printf("%s%s\n", v.String(), cachedStr)
+	}
+	return nil
+}

--- a/cmd/crc/cmd/bundle/prune.go
+++ b/cmd/crc/cmd/bundle/prune.go
@@ -1,0 +1,139 @@
+package bundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/spf13/cobra"
+)
+
+func getPruneCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "prune",
+		Short: "Prune old CRC bundles",
+		Long:  "Keep only the most recent bundles and delete older ones to save space.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Default keep 2 most recent
+			return runPrune(2)
+		},
+	}
+}
+
+type bundleVersionInfo struct {
+	name  string
+	major int
+	minor int
+	patch int
+	arch  string
+}
+
+var bundleVersionRegex = regexp.MustCompile(`^crc(?:_okd|_microshift)?_(?:vfkit|libvirt|hyperv)_(\d+)\.(\d+)\.(\d+)_([a-z0-9]+)\.crcbundle$`)
+
+// parseBundleVersion parses a bundle filename like "crc_vfkit_4.19.13_arm64.crcbundle"
+// and extracts the version parts and architecture.
+func parseBundleVersion(filename string) (bundleVersionInfo, error) {
+	matches := bundleVersionRegex.FindStringSubmatch(filename)
+	if matches == nil {
+		return bundleVersionInfo{}, fmt.Errorf("filename %q does not match expected bundle pattern", filename)
+	}
+
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return bundleVersionInfo{}, fmt.Errorf("invalid major version in %q: %w", filename, err)
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return bundleVersionInfo{}, fmt.Errorf("invalid minor version in %q: %w", filename, err)
+	}
+	patch, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return bundleVersionInfo{}, fmt.Errorf("invalid patch version in %q: %w", filename, err)
+	}
+
+	return bundleVersionInfo{
+		name:  filename,
+		major: major,
+		minor: minor,
+		patch: patch,
+		arch:  matches[4],
+	}, nil
+}
+
+func runPrune(keep int) error {
+	cacheDir := constants.MachineCacheDir
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		logging.Infof("Cache directory %s does not exist", cacheDir)
+		return nil
+	}
+
+	files, err := os.ReadDir(cacheDir)
+	if err != nil {
+		return err
+	}
+
+	// Group bundles by major.minor + arch
+	type groupKey struct {
+		major int
+		minor int
+		arch  string
+	}
+	groups := make(map[groupKey][]bundleVersionInfo)
+
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name(), ".crcbundle") {
+			continue
+		}
+		info, err := parseBundleVersion(file.Name())
+		if err != nil {
+			logging.Debugf("Skipping unrecognized bundle file: %s", file.Name())
+			continue
+		}
+		key := groupKey{major: info.major, minor: info.minor, arch: info.arch}
+		groups[key] = append(groups[key], info)
+	}
+
+	pruned := false
+	var lastErr error
+	for _, bundles := range groups {
+		if len(bundles) <= keep {
+			continue
+		}
+
+		// Sort by patch version descending (newest first)
+		sort.Slice(bundles, func(i, j int) bool {
+			return bundles[i].patch > bundles[j].patch
+		})
+
+		for i := keep; i < len(bundles); i++ {
+			filePath := filepath.Join(cacheDir, bundles[i].name)
+			logging.Infof("Pruning old bundle: %s", bundles[i].name)
+			if err := os.Remove(filePath); err != nil {
+				logging.Errorf("failed to remove %s: %v", filePath, err)
+				lastErr = err
+			} else {
+				pruned = true
+				// Also remove extracted bundle directory if it exists
+				dirPath := strings.TrimSuffix(filePath, ".crcbundle")
+				if _, err := os.Stat(dirPath); err == nil {
+					if err := os.RemoveAll(dirPath); err != nil {
+						logging.Errorf("failed to remove extracted bundle %s: %v", dirPath, err)
+						lastErr = err
+					}
+				}
+			}
+		}
+	}
+
+	if !pruned && lastErr == nil {
+		logging.Infof("Nothing to prune")
+	}
+
+	return lastErr
+}

--- a/cmd/crc/cmd/bundle/util.go
+++ b/cmd/crc/cmd/bundle/util.go
@@ -1,0 +1,123 @@
+package bundle
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/crc/network/httpproxy"
+	crcPreset "github.com/crc-org/crc/v2/pkg/crc/preset"
+)
+
+var (
+	// versionHrefPattern matches version strings in HTML href attributes.
+	versionHrefPattern = regexp.MustCompile(`href=["']?\.?/?(\d+\.\d+\.\d+)/?["']?`)
+	// versionTextPattern matches version strings in bare HTML text.
+	versionTextPattern = regexp.MustCompile(`>(\d+\.\d+\.\d+)/?<`)
+	// fullVersionRegex matches a complete Major.Minor.Patch version string.
+	fullVersionRegex = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	// partialVersionRegex matches a Major.Minor version string.
+	partialVersionRegex = regexp.MustCompile(`^\d+\.\d+$`)
+)
+
+func fetchAvailableVersions(preset crcPreset.Preset) ([]*semver.Version, error) {
+	// Base URL for the preset
+	baseURL := fmt.Sprintf("%s/%s/", constants.DefaultMirrorURL, preset.String())
+
+	client := &http.Client{
+		Transport: httpproxy.HTTPTransport(),
+		Timeout:   10 * time.Second,
+	}
+
+	req, err := http.NewRequest("GET", baseURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req) // nolint:gosec // G704: URL is constructed from constant base URL and validated preset enum
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch versions from mirror: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the HTML directory listing to find version directories.
+	// Try the href pattern first, fall back to bare text pattern.
+	versionPatterns := []*regexp.Regexp{versionHrefPattern, versionTextPattern}
+
+	var versions []*semver.Version
+	seen := make(map[string]bool)
+
+	for _, pattern := range versionPatterns {
+		for _, match := range pattern.FindAllStringSubmatch(string(body), -1) {
+			if len(match) > 1 && !seen[match[1]] {
+				v, err := semver.NewVersion(match[1])
+				if err == nil {
+					versions = append(versions, v)
+					seen[match[1]] = true
+				}
+			}
+		}
+		if len(versions) > 0 {
+			break
+		}
+	}
+
+	// Sort reverse (newest first)
+	sort.Sort(sort.Reverse(semver.Collection(versions)))
+	return versions, nil
+}
+
+func resolveOpenShiftVersion(preset crcPreset.Preset, inputVersion string) (string, error) {
+	// If input already looks like a full version (Major.Minor.Patch), return as is
+	if fullVersionRegex.MatchString(inputVersion) {
+		return inputVersion, nil
+	}
+
+	// If not Major.Minor, return as is (could be a tag or other format user intends)
+	if !partialVersionRegex.MatchString(inputVersion) {
+		return inputVersion, nil
+	}
+
+	logging.Debugf("Resolving latest version for %s...", inputVersion)
+
+	versions, err := fetchAvailableVersions(preset)
+	if err != nil {
+		return "", err
+	}
+
+	inputVer, err := semver.NewVersion(inputVersion + ".0")
+	if err != nil {
+		return "", fmt.Errorf("invalid input version format: %v", err)
+	}
+
+	for _, v := range versions {
+		if v.Major() == inputVer.Major() && v.Minor() == inputVer.Minor() {
+			return v.String(), nil
+		}
+	}
+
+	return "", fmt.Errorf("no matching versions found for %s", inputVersion)
+}
+
+func isBundleCached(preset crcPreset.Preset, version string, arch string) bool {
+	bundlePath := filepath.Join(constants.MachineCacheDir, constants.BundleName(preset, version, arch))
+	_, err := os.Stat(bundlePath)
+	return err == nil
+}

--- a/cmd/crc/cmd/root_test.go
+++ b/cmd/crc/cmd/root_test.go
@@ -23,7 +23,11 @@ func TestCrcManPageGenerator_WhenInvoked_GeneratesManPagesForAllCrcSubCommands(t
 		manPagesFiles = append(manPagesFiles, manPage.Name())
 	}
 	assert.ElementsMatch(t, []string{
+		"crc-bundle-clear.1",
+		"crc-bundle-download.1",
 		"crc-bundle-generate.1",
+		"crc-bundle-list.1",
+		"crc-bundle-prune.1",
 		"crc-bundle.1",
 		"crc-cleanup.1",
 		"crc-config-get.1",

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -30,7 +30,8 @@ const (
 	CrcLandingPageURL         = "https://console.redhat.com/openshift/create/local" // #nosec G101
 	DefaultAdminHelperURLBase = "https://github.com/crc-org/admin-helper/releases/download/v%s/%s"
 	BackgroundLauncherURL     = "https://github.com/crc-org/win32-background-launcher/releases/download/v%s/win32-background-launcher.exe"
-	DefaultBundleURLBase      = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/%s/%s/%s"
+	DefaultMirrorURL          = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles"
+	DefaultBundleURLBase      = DefaultMirrorURL + "/%s/%s/%s"
 	DefaultContext            = "admin"
 	DefaultDeveloperPassword  = "developer"
 	DaemonHTTPEndpoint        = "http://unix/api"
@@ -81,6 +82,10 @@ func GetAdminHelperURL() string {
 }
 
 func BundleForPreset(preset crcpreset.Preset, version string) string {
+	return BundleName(preset, version, runtime.GOARCH)
+}
+
+func BundleName(preset crcpreset.Preset, version string, arch string) string {
 	var bundleName strings.Builder
 
 	bundleName.WriteString("crc")
@@ -101,7 +106,7 @@ func BundleForPreset(preset crcpreset.Preset, version string) string {
 		bundleName.WriteString("_hyperv")
 	}
 
-	fmt.Fprintf(&bundleName, "_%s_%s.crcbundle", version, runtime.GOARCH)
+	fmt.Fprintf(&bundleName, "_%s_%s.crcbundle", version, arch)
 	return bundleName.String()
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -31,7 +31,8 @@ const (
 	CrcLandingPageURL         = "https://console.redhat.com/openshift/create/local" // #nosec G101
 	DefaultAdminHelperURLBase = "https://github.com/crc-org/admin-helper/releases/download/v%s/%s"
 	BackgroundLauncherURL     = "https://github.com/crc-org/win32-background-launcher/releases/download/v%s/win32-background-launcher.exe"
-	DefaultBundleURLBase      = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/%s/%s/%s"
+	DefaultMirrorURL          = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles"
+	DefaultBundleURLBase      = DefaultMirrorURL + "/%s/%s/%s"
 	DefaultContext            = "admin"
 	DefaultDeveloperPassword  = "developer"
 	DaemonHTTPEndpoint        = "http://unix/api"
@@ -106,6 +107,10 @@ func GetAdminHelperURL() string {
 }
 
 func BundleForPreset(preset crcpreset.Preset, version string) string {
+	return BundleName(preset, version, runtime.GOARCH)
+}
+
+func BundleName(preset crcpreset.Preset, version string, arch string) string {
 	var bundleName strings.Builder
 
 	bundleName.WriteString("crc")
@@ -126,7 +131,7 @@ func BundleForPreset(preset crcpreset.Preset, version string) string {
 		bundleName.WriteString("_hyperv")
 	}
 
-	fmt.Fprintf(&bundleName, "_%s_%s.crcbundle", version, runtime.GOARCH)
+	fmt.Fprintf(&bundleName, "_%s_%s.crcbundle", version, arch)
 	return bundleName.String()
 }
 


### PR DESCRIPTION
Expanding on the already existing `crc bundle` command with some exciting new functionality.  I wanted to be able to download/manipulate the bundles available either locally or on the mirror website from the CRC client.  I also wanted to be able to download bundles for different architectures if needed (will be used in [quick-ocp](https://github.com/palmsoftware/quick-ocp) more than likely).

Example commands:

- `./crc bundle download` this is just the default command, and it'll download the bundle belonging to your crc release.
- `./crc bundle download 4.19 -v` this will download the latest available 4.19 bundle (similar to the way quick-ocp [does it](https://github.com/palmsoftware/quick-ocp/blob/main/scripts/fetch-ocp-crc-version.sh)) where it will determine what the latest patch version is, and download it.  You can also just supply an exact patch version that works as well.  By default, it will check the downloaded bundle against the hash signature to make sure you have downloaded it correctly.  Even thought `crc` won't be able to directly use the old bundles, its already been helpful for me to be able to download these bundles directly.
- `./crc bundle download 4.19 amd64 -v` will download a specific architecture version.
- `./crc bundle download list` will show you a list of all of the available versions of CRC/OCP available from the mirror website and whether or not you already have the bundle downloaded on your system already.
- `./crc bundle download clear` will clear all of your bundles out of your cache.
- `./crc bundle download prune` will clear all but the latest two patch versions belonging to a major version out of your cache.  Like a watered down version of `clear`.

Real output:
```
bpalm at bpalm-mac in ~/Repositories/go/src/github.com/crc-org/crc on add_bundle_download_cmd [!?]
$ ./crc bundle download 4.19 -v
INFO Resolving latest version for 4.19...         
INFO Resolved version 4.19 to 4.19.13             
INFO Downloading bundle: crc_vfkit_4.19.13_arm64.crcbundle 
INFO Source: https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/openshift/4.19.13/crc_vfkit_4.19.13_arm64.crcbundle 
INFO Destination: /Users/bpalm/.crc/cache         
INFO Verifying signature for 4.19.13...           
6.01 GiB / 6.01 GiB [-----------------------------------------------] 100.00% 7.73 MiB/s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle command adds download, list, clear, and prune subcommands.
  * Download supports preset/version/architecture selection, mirror-based resolution, signature-verified retrieval, and force overwrite.
  * List shows available bundle versions (supports partial-version resolution) and marks cached items.
  * Clear removes cached bundles; Prune deletes older bundles, retaining recent ones by default.

* **Tests**
  * Manpage generation test updated to include the new bundle subcommands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->