### PR TITLE
[WIP] Experimental krunkit support

### DIFF
--- a/pkg/crc/cache/cache_darwin.go
+++ b/pkg/crc/cache/cache_darwin.go
@@ -7,11 +7,11 @@ import (
 )
 
 func NewVfkitCache() *Cache {
-	return newCache(vfkit.ExecutablePath(), vfkit.VfkitDownloadURL, vfkit.VfkitVersion, getVfkitVersion)
+	return newCache(vfkit.ExecutablePath(), vfkit.DownloadURL(), vfkit.Version(), getVfkitVersion)
 }
 
 func getVfkitVersion(executablePath string) (string, error) {
-	version, err := getVersionGeneric(executablePath, "-v")
+	version, err := getVersionGeneric(executablePath, "--version")
 	if err != nil {
 		return version, err
 	}

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -143,7 +143,7 @@ func GetDefaultBundleSignedHashURL(preset crcpreset.Preset) string {
 }
 
 func ResolveHelperPath(executableName string) string {
-	if version.IsInstaller() {
+	if version.IsInstaller() && executableName != KrunkitCommand {
 		return filepath.Join(version.InstallPath(), executableName)
 	}
 	return filepath.Join(CrcBinDir, executableName)

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -1,6 +1,10 @@
+//go:build darwin
+
 package constants
 
 import (
+	"log"
+	"os"
 	"path/filepath"
 )
 
@@ -9,7 +13,26 @@ const (
 	PodmanRemoteExecutableName = "podman"
 	DaemonAgentLabel           = "com.redhat.crc.daemon"
 	QemuGuestAgentPort         = 1234
+
+	VfkitCommand   = "vfkit"
+	KrunkitCommand = "krunkit"
 )
+
+func Provider() string {
+	provider := os.Getenv("CRC_PROVIDER")
+	if provider == "" {
+		provider = VfkitCommand
+	}
+	switch provider {
+	case VfkitCommand:
+		return VfkitCommand
+	case KrunkitCommand:
+		return KrunkitCommand
+	default:
+		log.Fatalf("Invalid provider: %s. Choose between %s or %s", provider, VfkitCommand, KrunkitCommand)
+		return ""
+	}
+}
 
 var (
 	TapSocketPath        = filepath.Join(CrcBaseDir, "tap.sock")

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -8,6 +8,11 @@ const (
 	OcExecutableName           = "oc"
 	PodmanRemoteExecutableName = "podman-remote"
 	TapSocketPath              = ""
+	KrunkitCommand             = ""
 )
 
 var DaemonHTTPSocketPath = filepath.Join(CrcBaseDir, "crc-http.sock")
+
+func Provider() string {
+	return ""
+}

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -7,4 +7,9 @@ const (
 	DaemonHTTPNamedPipe        = `\\.\pipe\crc-http`
 	DaemonTaskName             = "crcDaemon"
 	AdminHelperServiceName     = "crcAdminHelper"
+	KrunkitCommand             = ""
 )
+
+func Provider() string {
+	return ""
+}

--- a/pkg/crc/machine/vfkit/constants.go
+++ b/pkg/crc/machine/vfkit/constants.go
@@ -4,6 +4,7 @@ package vfkit
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 )
@@ -22,7 +23,11 @@ var (
 )
 
 func ExecutablePath() string {
-	return constants.ResolveHelperPath(constants.Provider())
+	provider := constants.Provider()
+	if provider == KrunkitCommand {
+		return filepath.Join(constants.CrcBinDir, provider)
+	}
+	return constants.ResolveHelperPath(provider)
 }
 
 func DownloadURL() string {

--- a/pkg/crc/machine/vfkit/constants.go
+++ b/pkg/crc/machine/vfkit/constants.go
@@ -9,15 +9,40 @@ import (
 )
 
 const (
-	VfkitVersion = "0.6.1"
-	vfkitCommand = "vfkit"
+	VfkitVersion   = "0.6.1"
+	VfkitCommand   = "vfkit"
+	KrunkitVersion = "1.1.1"
+	KrunkitCommand = "krunkit"
 )
 
 var (
-	VfkitDownloadURL     = fmt.Sprintf("https://github.com/crc-org/vfkit/releases/download/v%s/%s", VfkitVersion, vfkitCommand)
+	VfkitDownloadURL     = fmt.Sprintf("https://github.com/crc-org/vfkit/releases/download/v%s/%s", VfkitVersion, VfkitCommand)
 	VfkitEntitlementsURL = fmt.Sprintf("https://raw.githubusercontent.com/crc-org/vfkit/v%s/vf.entitlements", VfkitVersion)
+	KrunkitDownloadURL   = fmt.Sprintf("https://github.com/containers/krunkit/releases/download/v%s/krunkit-podman-unsigned-%s.tgz", KrunkitVersion, KrunkitVersion)
 )
 
 func ExecutablePath() string {
-	return constants.ResolveHelperPath(vfkitCommand)
+	return constants.ResolveHelperPath(constants.Provider())
+}
+
+func DownloadURL() string {
+	switch constants.Provider() {
+	case VfkitCommand:
+		return VfkitDownloadURL
+	case KrunkitCommand:
+		return KrunkitDownloadURL
+	default:
+		return ""
+	}
+}
+
+func Version() string {
+	switch constants.Provider() {
+	case VfkitCommand:
+		return VfkitVersion
+	case KrunkitCommand:
+		return KrunkitVersion
+	default:
+		return ""
+	}
 }

--- a/pkg/crc/machine/vfkit/driver_darwin.go
+++ b/pkg/crc/machine/vfkit/driver_darwin.go
@@ -11,11 +11,9 @@ import (
 )
 
 func CreateHost(machineConfig config.MachineConfig) *vfkit.Driver {
-	vfDriver := vfkit.NewDriver(machineConfig.Name, constants.MachineBaseDir)
+	vfDriver := vfkit.NewDriver(machineConfig.Name, constants.MachineBaseDir, VfkitCommand)
 
 	config.InitVMDriverFromMachineConfig(machineConfig, vfDriver.VMDriver)
-
-	vfDriver.VfkitPath = ExecutablePath()
 
 	vfDriver.VirtioNet = machineConfig.NetworkMode == network.SystemNetworkingMode
 

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -162,7 +162,10 @@ func killVfkitProcess() error {
 func getDaemonConfig() (*launchd.AgentConfig, error) {
 	logFilePath := filepath.Join(constants.CrcBaseDir, ".launchd-crcd.log")
 
-	env := map[string]string{"Version": version.GetCRCVersion()}
+	env := map[string]string{
+		"Version":      version.GetCRCVersion(),
+		"CRC_PROVIDER": constants.Provider(),
+	}
 	daemonConfig := launchd.AgentConfig{
 		Label:          constants.DaemonAgentLabel,
 		ExecutablePath: constants.CrcSymlinkPath,

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -33,15 +33,15 @@ var vfkitPreflightChecks = []Check{
 	},
 	{
 		configKeySuffix:  "check-vfkit-installed",
-		checkDescription: "Checking if vfkit is installed",
+		checkDescription: "Checking if " + constants.Provider() + " is installed",
 		check:            checkVfkitInstalled,
-		fixDescription:   "Setting up virtualization with vfkit",
+		fixDescription:   "Setting up virtualization with " + constants.Provider(),
 		fix:              fixVfkitInstallation,
 
 		labels: labels{Os: Darwin},
 	},
 	{
-		cleanupDescription: "Stopping CRC vfkit process",
+		cleanupDescription: "Stopping CRC " + constants.Provider() + " process",
 		cleanup:            killVfkitProcess,
 		flags:              CleanUpOnly,
 

--- a/pkg/libmachine/load_darwin.go
+++ b/pkg/libmachine/load_darwin.go
@@ -3,12 +3,13 @@ package libmachine
 import (
 	"encoding/json"
 
-	"github.com/crc-org/crc/v2/pkg/drivers/vfkit"
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	vfkitDriver "github.com/crc-org/crc/v2/pkg/drivers/vfkit"
 	"github.com/crc-org/crc/v2/pkg/libmachine/host"
 )
 
 func (api *Client) NewHost(_ string, driverPath string, rawDriver []byte) (*host.Host, error) {
-	driver := vfkit.NewDriver("", "")
+	driver := vfkitDriver.NewDriver("", "", constants.Provider())
 	if err := json.Unmarshal(rawDriver, &driver); err != nil {
 		return nil, err
 	}
@@ -29,10 +30,11 @@ func (api *Client) Load(name string) (*host.Host, error) {
 		return nil, err
 	}
 
-	driver := vfkit.NewDriver("", "")
+	driver := vfkitDriver.NewDriver("", "", constants.Provider())
 	if err := json.Unmarshal(h.RawDriver, &driver); err != nil {
 		return nil, err
 	}
+	driver.VfkitPath = constants.ResolveHelperPath(constants.Provider())
 	h.Driver = driver
 	return h, nil
 }


### PR DESCRIPTION
## Description

Add experimental krunkit provider support for macOS
Add CRC_PROVIDER env var to switch between vfkit and krunkit.

Default provider: vfkit
Set the env var to use krunkit

Usage:
    
```
export CRC_PROVIDER=krunkit
crc setup
crc start
```
Note: Krunkit binary is signed with embedded hypervisor entitlements at cache time.

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: https://github.com/crc-org/crc/issues/4341

Relates to:  https://github.com/crc-org/crc/issues/4233, https://github.com/crc-org/crc/issues/4980

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing

1. Ensure krunkit binary location is the same as the hardcoded path
2. `setup` should succeed.
3. `start` should create a krunkit process
4. `ssh` should work
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
5. stdout contains ... if `start` succeeded
6. stderr contains ... after `start` failed
7. `status` returns ... if `start` succeeded
8. `status` returns ... if `start` failed
9. `start` fails after `start` succeeded or after `status` says CRC is `Running`
10. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Krunkit as an alternative macOS virtualization provider (selectable via CRC_PROVIDER)
  * Support for .tgz tarballs
  * Automatic code signing of the Krunkit executable on macOS after installation

* **Refactor**
  * Generalized provider abstraction and resolution across macOS flows (drivers, preflight, helper resolution)
  * Provider-aware runtime and daemon configuration adjustments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->