### PR TITLE
CI: Replace macOS-13 runner with supported one

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-13
           - macOS-14
+          - macOS-15
         go:
           - '1.24'
     steps:

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macOS-13
           - macOS-14
+          - macOS-15
           - ubuntu-latest
           - ubuntu-22.04
         go:


### PR DESCRIPTION
Mac 13 runner is deprecated and now unsupported on github
- https://github.com/actions/runner-images/issues/13046

This PR replace those with supported runners.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build environments in continuous integration pipelines, removing support for macOS 13 and adding macOS 15 while maintaining macOS 14.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->