### PR TITLE
bump admin-helper to 0.5.7

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -32,7 +32,7 @@ var (
 )
 
 const (
-	crcAdminHelperVersion          = "0.5.5"
+	crcAdminHelperVersion          = "0.5.7"
 	win32BackgroundLauncherVersion = "0.0.0.1"
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CRC admin helper version from 0.5.5 to 0.5.7.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->