### PR TITLE
Issue #4752 Add generate-kubeconfig command

### DIFF
--- a/cmd/crc/cmd/generate_kubeconfig.go
+++ b/cmd/crc/cmd/generate_kubeconfig.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(generateKubeconfigCmd)
+}
+
+var generateKubeconfigCmd = &cobra.Command{
+	Use:   "generate-kubeconfig",
+	Short: "Generate a kubeconfig file for the CRC instance",
+	Long:  "Output the kubeconfig file for the CRC instance to stdout",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return runGenerateKubeconfig()
+	},
+}
+
+func runGenerateKubeconfig() error {
+	client := newMachine()
+	if err := checkIfMachineMissing(client); err != nil {
+		return err
+	}
+
+	running, err := client.IsRunning()
+	if err != nil {
+		return err
+	}
+	if !running {
+		return fmt.Errorf("the CRC instance is not running, cannot retrieve kubeconfig")
+	}
+
+	data, err := os.ReadFile(constants.KubeconfigFilePath)
+	if err != nil {
+		return fmt.Errorf("Error reading kubeconfig: %v", err)
+	}
+	fmt.Print(string(data))
+	return nil
+}

--- a/cmd/crc/cmd/root_test.go
+++ b/cmd/crc/cmd/root_test.go
@@ -33,6 +33,7 @@ func TestCrcManPageGenerator_WhenInvoked_GeneratesManPagesForAllCrcSubCommands(t
 		"crc-config.1",
 		"crc-console.1",
 		"crc-delete.1",
+		"crc-generate-kubeconfig.1",
 		"crc-ip.1",
 		"crc-oc-env.1",
 		"crc-podman-env.1",


### PR DESCRIPTION
## Summary

- Adds a new `crc generate-kubeconfig` command that outputs the kubeconfig for the CRC instance to stdout
- Checks that the CRC VM exists before attempting to read the kubeconfig
- Updates man page test expectations for the new command

## Usage Examples

```bash
# Print kubeconfig to terminal
crc generate-kubeconfig

# Save to a file
crc generate-kubeconfig > ~/my-kubeconfig.yaml

# Use with kubectl
crc generate-kubeconfig > /tmp/crc-kubeconfig
kubectl --kubeconfig /tmp/crc-kubeconfig get nodes

# Set KUBECONFIG in one line
export KUBECONFIG=$(mktemp) && crc generate-kubeconfig > "$KUBECONFIG"
```

## Test plan

- [x] `make test` passes (including updated man page expectations)
- [x] `make lint` passes
- [ ] Manual test: run `crc generate-kubeconfig` with a running instance
- [ ] Manual test: run `crc generate-kubeconfig` without an instance (should error)
- [ ] Manual test: pipe output to `kubectl --kubeconfig /dev/stdin get nodes`

Resolves #4752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command, generate-kubeconfig, which prints the cluster kubeconfig to stdout. It validates that a CRC instance exists and is running and surfaces errors if the instance is not running or the kubeconfig cannot be read.

* **Tests**
  * Updated tests to include the new generate-kubeconfig subcommand in generated man page checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->