### PR TITLE
Add dependabot dependency groups to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,39 @@ updates:
   ignore:
     - dependency-name: "github.com/openshift/*"
     - dependency-name: "k8s.io/*"
+  groups:
+    golang-x:
+      patterns:
+        - "golang.org/x/*"
+    sigstore:
+      patterns:
+        - "github.com/sigstore/*"
+    containers:
+      patterns:
+        - "github.com/containers/*"
+    podman:
+      patterns:
+        - "go.podman.io/*"
+    google-grpc:
+      patterns:
+        - "google.golang.org/*"
+    testing:
+      patterns:
+        - "github.com/onsi/*"
+        - "github.com/cucumber/*"
+        - "github.com/stretchr/testify"
+    spf13-cli:
+      patterns:
+        - "github.com/spf13/*"
 - package-ecosystem: gomod
   directory: "/tools"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    golang-x:
+      patterns:
+        - "golang.org/x/*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
## Summary

- Group related Go module dependencies in dependabot config so updates arrive as single PRs instead of flooding the repo with individual PRs
- Groups added: `golang-x`, `sigstore`, `containers`, `podman`, `google-grpc`, `testing`, `spf13-cli`
- Also adds `golang-x` grouping for the `/tools` directory

This addresses the current situation where 6 separate `golang.org/x/*` PRs (#5135, #5136, #5138, #5139, #5140, #5137) were opened simultaneously.

## References

- https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1297
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2888

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Confirm dependabot closes existing individual PRs and opens grouped ones on next scheduled run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency management configuration to add grouped Go module updates, introducing targeted groups for common module namespaces and a tools-specific group to better organize update notices.
  * Preserve existing ignore rules and schedules; no removals—only additive grouping to improve tracking and review of dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->