### PR TITLE
Issue #2973 Return structured JSON errors from config API

### DIFF
--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/crc-org/crc/v2/pkg/crc/api/client"
 	crcConfig "github.com/crc-org/crc/v2/pkg/crc/config"
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	"github.com/crc-org/crc/v2/pkg/crc/machine/fakemachine"
@@ -301,6 +303,10 @@ var testCases = []testCase{
 		request:  get("config?cpus").withBody("xx"),
 		response: jSon(`{"Configs":{"cpus":4}}`),
 	},
+	{
+		request:  post("config").withBody(`{"properties":{"cpus":0}}`),
+		response: httpError(422).withBody("[{\"message\":\"Value '0' for configuration property 'cpus' is invalid, reason: requires CPUs \\u003e= 4\"}]\n"),
+	},
 
 	// logs
 	{
@@ -503,4 +509,31 @@ func TestRoutes(t *testing.T) {
 			assert.Contains(t, routes[pattern], method, "routes[%s][%s] is missing from the API testcases", pattern, method)
 		}
 	}
+}
+
+func TestSetConfigMultipleErrors(t *testing.T) {
+	pullSecretPath := createDummyPullSecret(t)
+	defer os.Remove(pullSecretPath)
+	server := newMockServer(pullSecretPath)
+
+	// Send a request with multiple invalid config values
+	req := post("config").withBody(`{"properties":{"cpus":0,"memory":1}}`)
+	resp := sendRequest(server.Handler(), &req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var validationErrors []client.ValidationError
+	require.NoError(t, json.Unmarshal(body, &validationErrors))
+	require.Len(t, validationErrors, 2)
+
+	// Map iteration order is non-deterministic, so check membership rather than order
+	messages := make([]string, len(validationErrors))
+	for i, ve := range validationErrors {
+		messages[i] = ve.Message
+	}
+	assert.Contains(t, messages, "Value '0' for configuration property 'cpus' is invalid, reason: requires CPUs >= 4")
+	assert.Contains(t, messages, "Value '1' for configuration property 'memory' is invalid, reason: requires memory in MiB >= 10752")
 }

--- a/pkg/crc/api/client/client.go
+++ b/pkg/crc/api/client/client.go
@@ -255,20 +255,21 @@ func (c *client) sendRequest(url string, method string, data io.Reader) ([]byte,
 	}
 	defer res.Body.Close()
 
-	switch method {
-	case http.MethodPost:
-		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-			return nil, fmt.Errorf("Error occurred sending POST request to : %s : %d", url, res.StatusCode)
-		}
-	case http.MethodDelete, http.MethodGet:
-		if res.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("Error occurred sending %s request to : %s : %d", method, url, res.StatusCode)
-		}
-	}
-
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Unknown error reading response: %w", err)
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
+
+	isError := false
+	switch method {
+	case http.MethodPost:
+		isError = res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated
+	case http.MethodDelete, http.MethodGet:
+		isError = res.StatusCode != http.StatusOK
+	}
+	if isError {
+		return nil, &HTTPError{URL: url, Method: method, StatusCode: res.StatusCode, Body: string(body)}
+	}
+
 	return body, nil
 }

--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -66,3 +66,8 @@ type TelemetryRequest struct {
 	Source string `json:"source"`
 	Status string `json:"status"`
 }
+
+// ValidationError represents a single validation error in a structured JSON error response.
+type ValidationError struct {
+	Message string `json:"message"`
+}

--- a/pkg/crc/api/helpers.go
+++ b/pkg/crc/api/helpers.go
@@ -2,11 +2,14 @@ package api
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"io"
 	"net/http"
 	"net/url"
 	"sync"
 
+	"github.com/crc-org/crc/v2/pkg/crc/api/client"
+	"github.com/crc-org/crc/v2/pkg/crc/errors"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 )
 
@@ -111,6 +114,11 @@ func (s *server) Handler() http.Handler {
 			url:         r.URL,
 		}
 		if err := handler(c); err != nil {
+			var multiErr errors.MultiError
+			if stderrors.As(err, &multiErr) {
+				writeMultiError(w, multiErr)
+				return
+			}
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -124,4 +132,21 @@ func (s *server) Handler() http.Handler {
 			logging.Error("Failed to send response: ", err)
 		}
 	})
+}
+
+func writeMultiError(w http.ResponseWriter, multiErr errors.MultiError) {
+	validationErrors := make([]client.ValidationError, 0, len(multiErr.Errors))
+	for _, e := range multiErr.Errors {
+		if e == nil {
+			continue
+		}
+		validationErrors = append(validationErrors, client.ValidationError{
+			Message: e.Error(),
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	if err := json.NewEncoder(w).Encode(validationErrors); err != nil {
+		logging.Error("Failed to write error response: ", err)
+	}
 }

--- a/pkg/crc/api/helpers.go
+++ b/pkg/crc/api/helpers.go
@@ -2,11 +2,14 @@ package api
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"io"
 	"net/http"
 	"net/url"
 	"sync"
 
+	"github.com/crc-org/crc/v2/pkg/crc/api/client"
+	"github.com/crc-org/crc/v2/pkg/crc/errors"
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 )
 
@@ -128,6 +131,11 @@ func (s *server) Handler() http.Handler {
 			url:         r.URL,
 		}
 		if err := handler(c); err != nil {
+			var multiErr errors.MultiError
+			if stderrors.As(err, &multiErr) {
+				writeMultiError(w, multiErr)
+				return
+			}
 			status = http.StatusInternalServerError
 			http.Error(w, err.Error(), status)
 			return
@@ -143,4 +151,21 @@ func (s *server) Handler() http.Handler {
 			logging.Error("Failed to send response: ", err)
 		}
 	})
+}
+
+func writeMultiError(w http.ResponseWriter, multiErr errors.MultiError) {
+	validationErrors := make([]client.ValidationError, 0, len(multiErr.Errors))
+	for _, e := range multiErr.Errors {
+		if e == nil {
+			continue
+		}
+		validationErrors = append(validationErrors, client.ValidationError{
+			Message: e.Error(),
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	if err := json.NewEncoder(w).Encode(validationErrors); err != nil {
+		logging.Error("Failed to write error response: ", err)
+	}
 }


### PR DESCRIPTION
## Summary

- When setting config via the API with invalid values, errors were returned as concatenated plain text, making them unparseable by API clients (e.g. the Electron tray app)
- Detect `MultiError` at the HTTP response layer and return a JSON array of structured `ValidationError` objects with `Content-Type: application/json`
- Preserve error response body in the API client's `sendRequest()` via `HTTPError` (previously discarded)

Resolves #2973

Jira: https://issues.redhat.com/browse/CNFCERT-1343

## Examples

**Single invalid value:**
```bash
curl -s -X POST -H 'Content-Type: application/json' \
  -d '{"properties":{"cpus":0}}' \
  http://localhost/api/config
```
```json
[{"message":"Value '0' for configuration property 'cpus' is invalid, reason: requires CPUs >= 4"}]
```

**Multiple invalid values:**
```bash
curl -s -X POST -H 'Content-Type: application/json' \
  -d '{"properties":{"cpus":0,"memory":1}}' \
  http://localhost/api/config
```
```json
[
  {"message":"Value '0' for configuration property 'cpus' is invalid, reason: requires CPUs >= 4"},
  {"message":"Value '1' for configuration property 'memory' is invalid, reason: requires memory in MiB >= 10752"}
]
```

**Non-validation errors remain plain text (unchanged):**
```bash
curl -s -X POST -H 'Content-Type: application/json' \
  -d 'not-json' http://localhost/api/config
# → invalid character 'o' in literal null (expecting 'u')
```

## Test plan

- [x] Unit tests pass (`go test -race --tags "build containers_image_openpgp" ./pkg/crc/api/...`)
- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [x] Built binary, started daemon locally, verified JSON responses via curl
- [ ] Verify Electron tray app can parse error responses




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors now return all configuration issues together as a JSON array with clearer, per-property messages (e.g., CPU, memory).
  * Error responses from the server include returned error details so clients receive the response body for diagnostics and clearer status handling.

* **Tests**
  * Added tests verifying multiple validation errors are returned and parsed correctly (422 responses with structured messages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->