### PR TITLE
Add disk space cleanup to RPM build workflow

### DIFF
--- a/.github/workflows/make-rpm.yml
+++ b/.github/workflows/make-rpm.yml
@@ -15,6 +15,8 @@ jobs:
         go:
           - '1.24'
     steps:
+      - name: Free disk space
+        uses: palmsoftware/quick-cleanup@v0
       - name: Check out repository code
         uses: actions/checkout@v6
       - name: Set up Go


### PR DESCRIPTION
## Summary
- The `build (ubuntu-latest, 1.24)` job in the RPM build workflow has been failing due to disk space exhaustion during the `Build rpm` step
- Adds [`palmsoftware/quick-cleanup@v0`](https://github.com/palmsoftware/quick-cleanup) as the first step to free disk space before the build begins
- The action automatically detects available space and performs adaptive cleanup, including removing unused SDKs, package caches, and optionally relocating Docker storage
- Note: `quick-cleanup` is my own action, built specifically for this type of runner disk space issue 😄 

## Test plan
- [x] Verify `build (ubuntu-latest, 1.24)` job passes in CI
- [x] Confirm no regression on RPM build output or uploaded artifacts