### PR TITLE
Issue #5088 Add developer-password cleanup to @cleanup tag handler

### DIFF
--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -305,6 +305,12 @@ func InitializeScenario(s *godog.ScenarioContext) {
 					os.Exit(1)
 				}
 
+				err = crcCmd.UnsetConfigPropertySucceedsOrFails("developer-password", "succeeds") // unsetting property that is not set gives 0 exitcode, so this works
+				if err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+
 				if runtime.GOOS == "linux" {
 					err = crcCmd.UnsetConfigPropertySucceedsOrFails("network-mode", "succeeds") // unsetting property that is not set gives 0 exitcode, so this works
 					if err != nil {


### PR DESCRIPTION
## Summary

- Add `developer-password` config unset to the `@cleanup` tag handler in the e2e test suite
- The scenario at `running_cluster_tests.feature:23` sets `developer-password` to `"secret-dev"` but the cleanup handler never unsets it, potentially leaking the custom password into subsequent test scenarios
- Follows the existing pattern used for `enable-cluster-monitoring`, `memory`, and `preset`

Fixes #5088

## Test plan

- [x] `go build` of `./test/e2e/...` succeeds
- [x] Change follows the identical pattern of the surrounding unset calls
- [ ] Run e2e suite and verify `developer-password` is unset after `@cleanup` tagged scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cleanup step to ensure proper test environment reset between test runs, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->