### PR TITLE
Fix Snyk SAST findings: path traversal and false positives

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -9,3 +9,10 @@ exclude:
     # our dependencies on each CI run.
     - 'vendor/**'
     - 'tools/vendor/**'
+  code:
+    # DefaultDeveloperPassword is the well-known default for a local-only dev
+    # cluster, not a secret.
+    - 'pkg/crc/constants/constants.go'
+    # file.Name() from os.ReadDir() cannot produce path traversal sequences;
+    # these are false positives.
+    - 'test/extended/**'

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -32,11 +33,17 @@ type Repository struct {
 }
 
 func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
-	path := filepath.Join(repo.CacheDir, GetBundleNameWithoutExtension(bundleName))
+	path, err := buildPath(repo.CacheDir, GetBundleNameWithoutExtension(bundleName))
+	if err != nil {
+		return nil, err
+	}
 	if _, err := os.Stat(path); err != nil {
 		return nil, errors.Wrapf(err, "could not find cached bundle info in %s", path)
 	}
-	jsonFilepath := filepath.Join(path, metadataFilename)
+	jsonFilepath, err := buildPath(path, metadataFilename)
+	if err != nil {
+		return nil, err
+	}
 	content, err := os.ReadFile(filepath.Clean(jsonFilepath))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %s file", jsonFilepath)
@@ -65,6 +72,17 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 	}
 
 	return &bundleInfo, nil
+}
+
+// buildPath safely joins baseDir and filename, returning an error if the
+// result would escape baseDir (ZipSlip-style path traversal).
+func buildPath(baseDir, filename string) (string, error) {
+	path := filepath.Join(baseDir, filename) // #nosec G305
+	baseDir = filepath.Clean(baseDir)
+	if path != baseDir && !strings.HasPrefix(path, baseDir+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%s: illegal file path (expected prefix: %s)", path, baseDir+string(os.PathSeparator))
+	}
+	return path, nil
 }
 
 func checkVersion(bundleInfo CrcBundleInfo) error {

--- a/pkg/crc/machine/bundle/repository_test.go
+++ b/pkg/crc/machine/bundle/repository_test.go
@@ -66,6 +66,14 @@ func testBundle(t *testing.T) string {
 	}
 }
 
+func TestGetRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	repo := &Repository{CacheDir: dir}
+
+	_, err := repo.Get("../../etc/passwd")
+	assert.ErrorContains(t, err, "illegal file path")
+}
+
 func TestVersionCheck(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- Add path traversal validation to `Repository.Get()` in `pkg/crc/machine/bundle/repository.go`, preventing ZipSlip-style directory escape. This mirrors the existing `buildPath()` pattern from `pkg/extract/extract.go`.
- Add `.snyk` code exclusions for false positives: `DefaultDeveloperPassword` (intentional local dev cluster default) and `test/extended/**` (`os.ReadDir` file names cannot traverse).

## Context

The `ci/prow/security` Snyk SAST job is failing across all open PRs due to 5 findings. Two are genuine (path traversal in `repository.go`) and three are false positives (hardcoded password in constants, path traversal in test utilities using `os.ReadDir`).

## Test plan

- [x] New `TestGetRejectsPathTraversal` test validates traversal attempts are rejected
- [x] All existing bundle package tests pass
- [x] Full `make test` passes
- [x] `make lint` reports 0 issues
- [ ] `ci/prow/security` passes after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened bundle file handling to prevent path traversal and disallow access outside intended directories, improving file operation security.

* **Tests**
  * Added automated test coverage to verify file access validation rejects malicious path traversal attempts.

* **Chores**
  * Updated security scan configuration to add targeted exclusions for specific internal test and constant files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->