### PR TITLE
ci: Add quick-cleanup to disk-intensive workflows

### DIFF
--- a/.github/workflows/qe-image.yml
+++ b/.github/workflows/qe-image.yml
@@ -19,6 +19,10 @@ jobs:
           - arch: 'arm64'
             os: 'windows'
     steps:
+      - name: Free disk space
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
       - name: Check out repository code
         uses: actions/checkout@v6
       - name: Log in to Quay.io

--- a/.github/workflows/test-okd-bundle.yml
+++ b/.github/workflows/test-okd-bundle.yml
@@ -33,18 +33,10 @@ jobs:
           sudo apt-get update
           sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system virtiofsd
           sudo usermod -a -G libvirt $USER
-      - name: Remove unwanted stuff to free up disk image
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-          sudo docker image prune --all --force
-
-          sudo swapoff -a
-          sudo rm -f /mnt/swapfile
+      - name: Free disk space
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
       - name: Set the crc config
         run: |
           crc config set preset okd

--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -58,6 +58,10 @@ jobs:
           - arch: 'arm64'
             os: 'windows'
     steps:
+      - name: Free disk space
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
       - name: Check out repository code
         uses: actions/checkout@v6
       - name: Build qe oci images ${{matrix.os}}-${{matrix.arch}}


### PR DESCRIPTION
## Summary

- Replace manual disk cleanup commands in `test-okd-bundle.yml` with `palmsoftware/quick-cleanup@v0` in aggressive mode, removing ad-hoc `rm -rf` commands for dotnet, Android SDK, GHC, boost, and CodeQL
- Add `palmsoftware/quick-cleanup@v0` to `windows-artifacts.yml` (build-qe job) which builds and saves large container images to tar files
- Add `palmsoftware/quick-cleanup@v0` to `qe-image.yml` which builds and pushes multiple QE container images across OS/arch combinations

Follows up on #5145 which first introduced `quick-cleanup` to the RPM build workflow. See also #5153 which adds it to the macOS installer workflow.

Jira: https://issues.redhat.com/browse/CNFCERT-1359

## Test plan

- [x] `test-okd-bundle.yml`: OKD bundle test completes with `crc setup` and `crc start` succeeding after cleanup
- [x] `windows-artifacts.yml`: build-qe job builds container images without running out of disk
- [x] `qe-image.yml`: QE image builds complete for all OS/arch matrix entries
