### PR TITLE
msi: use posh command to add user to hyperv group 

### DIFF
--- a/packaging/windows/product.wxs
+++ b/packaging/windows/product.wxs
@@ -1,4 +1,5 @@
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
     <?ifndef Version?>
         <?error Version must be defined via command line argument?>
@@ -36,6 +37,9 @@
 
         <Property Id="SHAREDDIRNAME" Secure="yes" Value="crc-dir0" />
 
+        <SetProperty Action="CAAddUserToHypervAdmins" Id="AddUserToHypervAdmins" Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Add-LocalGroupMember -SID 'S-1-5-32-578' -Member '[%USERDOMAIN]\[LogonUser]'&quot;" Before="AddUserToHypervAdmins" Sequence="execute" />
+        <CustomAction Id="AddUserToHypervAdmins" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" />
+
         <SetProperty Action="CACreateCrcUsersGroup" Id="CreateCrcGroup" Value='"[System64Folder]cmd.exe" /c net localgroup crc-users /comment:"Group for Red Hat OpenShift Local users" /add' Before="CreateCrcGroup" Sequence="execute"/>
         <CustomAction Id="CreateCrcGroup" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" />
 
@@ -55,6 +59,7 @@
         <CustomAction Id="RemoveSMBShare" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" />
 
         <InstallExecuteSequence>
+            <Custom Action="AddUserToHypervAdmins" Before="Wix4ConfigureUsers_$(sys.BUILDARCHSHORT)" Condition="NOT Installed AND NOT REMOVE~=&quot;ALL&quot; AND NOT WIX_UPGRADE_DETECTED" />
             <Custom Action="CreateCrcGroup" Before="Wix4ConfigureUsers_$(sys.BUILDARCHSHORT)" Condition="NOT Installed AND NOT REMOVE~=&quot;ALL&quot; AND NOT WIX_UPGRADE_DETECTED" />
             <Custom Action="RemoveCrcGroup" After="RemoveFolders" Condition="Installed AND NOT PATCH AND REMOVE~=&quot;ALL&quot; AND NOT UPGRADINGPRODUCTCODE" />
             <Custom Action="InstallHyperv" After="InstallFiles" Condition="NOT Installed AND NOT REMOVE~=&quot;ALL&quot; AND NOT WIX_UPGRADE_DETECTED" />
@@ -71,7 +76,6 @@
             <ComponentRef Id="VsockRegistryEntry" />
             <ComponentRef Id="Hvsock9pRegistryEntry" />
             <ComponentRef Id="CreateCrcUsersGroupAddUser" />
-            <ComponentRef Id="AddUserToHypervAdminsGroup" />
         </Feature>
         <UI>
             <UIRef Id="WixUI_ErrorProgressText" />
@@ -84,7 +88,6 @@
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
         <!-- this should help to propagate env var changes -->
         <util:BroadcastEnvironmentChange />
-        <util:Group Id="HypervAdminsGroup" Name="Hyper-V Administrators" />
         <util:Group Id="CrcUsersGroup" Name="crc-users" />
         <StandardDirectory Id="ProgramFiles64Folder">
             <Directory Id="INSTALLDIR" Name="Red Hat OpenShift Local">
@@ -117,11 +120,6 @@
                 <Component Id="CreateCrcUsersGroupAddUser" Guid="12DCE321-8645-43ED-9059-3DC5828A3B13">
                     <util:User Id="CurrentUserCrcUsers" Name="[LogonUser]" Domain="[%USERDOMAIN]" CreateUser="no" FailIfExists="no">
                         <util:GroupRef Id="CrcUsersGroup" />
-                    </util:User>
-                </Component>
-                <Component Id="AddUserToHypervAdminsGroup" Guid="CEE06E47-C46E-410E-9951-C5A4004198E6">
-                    <util:User Id="CurrentUserHypervAdmins" Name="[LogonUser]" Domain="[%USERDOMAIN]" CreateUser="no" FailIfExists="no" >
-                        <util:GroupRef Id="HypervAdminsGroup" />
                     </util:User>
                 </Component>
             </Directory>


### PR DESCRIPTION
With the recent update to Wix v5 the "Hyper-V Administrators" group name
was hardcoded in English, causing installation failures on   non-English
Windows systems where the group name is localized. This change uses  the
well-known SID S-1-5-32-578 to dynamically get the localized group  name
at install time using a PowerShell custom action

Assisted-By: Claude <noreply@anthropic.com>

## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #N

Relates to: #N, PR #N, ...

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer will add the current user to the Hyper‑V Administrators group during a fresh install so Hyper‑V management permissions are configured automatically.

* **Chores**
  * Removed legacy installer group/component entries related to Hyper‑V admin setup and cleaned up installer sequencing and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->