### PR TITLE
update OpenShift bundle to v4.21.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: install
 
 SHELL := /bin/bash -o pipefail
 
-OPENSHIFT_VERSION ?= 4.21.0
+OPENSHIFT_VERSION ?= 4.21.4
 OKD_VERSION ?= 4.21.0-okd-scos.5
 MICROSHIFT_VERSION ?= 4.21.0
 BUNDLE_EXTENSION = crcbundle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default OpenShift version from 4.21.0 to 4.21.4, ensuring the project references the newer platform release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->