### PR TITLE
fix: log correct error variable in status event JSON marshalling

### DIFF
--- a/pkg/crc/api/events/status.go
+++ b/pkg/crc/api/events/status.go
@@ -57,7 +57,7 @@ func (s *TickListener) Start(publisher EventPublisher) {
 
 				bytes, marshallError := json.Marshal(data)
 				if marshallError != nil {
-					logging.Errorf("unexpected error during status object to JSON conversion: %v", err)
+					logging.Errorf("unexpected error during status object to JSON conversion: %v", marshallError)
 					continue
 				}
 				publisher.Publish(&sse.Event{Event: []byte("status"), Data: bytes})


### PR DESCRIPTION
## Summary

- Fix bug in `pkg/crc/api/events/status.go` where the JSON marshal error log referenced `err` (from the generator call, always `nil` at that point) instead of `marshallError`
- This caused JSON conversion failures to be silently misreported as `<nil>` in logs

## Test plan

- [ ] Verify the fix by inspecting the code change
- [ ] Confirm no regressions with `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting accuracy in status event logging to ensure the correct error message is displayed when data serialization fails, providing clearer diagnostics during troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->