### PR TITLE
feat: add crc image load command

### DIFF
--- a/cmd/crc/cmd/image/image.go
+++ b/cmd/crc/cmd/image/image.go
@@ -1,0 +1,19 @@
+package image
+
+import (
+	"github.com/crc-org/crc/v2/pkg/crc/config"
+	"github.com/spf13/cobra"
+)
+
+func GetImageCmd(config *config.Config) *cobra.Command {
+	imageCmd := &cobra.Command{
+		Use:   "image SUBCOMMAND [flags]",
+		Short: "Manage container images in the CRC cluster",
+		Long:  "Manage container images in the CRC cluster",
+		Run: func(cmd *cobra.Command, _ []string) {
+			_ = cmd.Help()
+		},
+	}
+	imageCmd.AddCommand(getLoadCmd(config))
+	return imageCmd
+}

--- a/cmd/crc/cmd/image/load.go
+++ b/cmd/crc/cmd/image/load.go
@@ -1,0 +1,92 @@
+package image
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/crc-org/crc/v2/pkg/crc/config"
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/crc/machine"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/types"
+	"github.com/spf13/cobra"
+)
+
+func getLoadCmd(config *config.Config) *cobra.Command {
+	var namespace string
+	var name string
+
+	loadCmd := &cobra.Command{
+		Use:   "load SOURCE",
+		Short: "Load a container image into the cluster's internal registry",
+		Long: `Load a container image into the OpenShift cluster's internal registry.
+
+SOURCE can be a tar file path or a container image reference:
+
+  # From a tar file:
+  crc image load myapp.tar
+  crc image load myapp.tar --namespace myproject --name myapp:v1
+
+  # From a local container image reference:
+  crc image load myapp:latest
+  crc image load docker.io/library/nginx:latest --namespace myproject`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runLoad(config, args[0], namespace, name)
+		},
+	}
+	loadCmd.Flags().StringVarP(&namespace, "namespace", "n", "openshift", "Target namespace in the internal registry")
+	loadCmd.Flags().StringVar(&name, "name", "", "Override the image name:tag in the registry (derived from source by default)")
+	return loadCmd
+}
+
+func runLoad(config *config.Config, source, namespace, name string) error {
+	isTar := isTarFile(source)
+
+	if name == "" {
+		name = deriveImageName(source, isTar)
+		if name == "" {
+			return fmt.Errorf("cannot derive image name from source %q, use --name to specify it", source)
+		}
+	}
+
+	client := machine.NewClient(constants.DefaultName, logging.IsDebug(), config)
+	return client.ImageLoad(types.ImageLoadConfig{
+		Source:    source,
+		IsTar:     isTar,
+		Namespace: namespace,
+		ImageName: name,
+	})
+}
+
+func isTarFile(source string) bool {
+	if _, err := os.Stat(source); err != nil {
+		return false
+	}
+	return strings.HasSuffix(source, ".tar") || strings.HasSuffix(source, ".tar.gz") || strings.HasSuffix(source, ".tgz")
+}
+
+func deriveImageName(source string, isTar bool) string {
+	if isTar {
+		base := filepath.Base(source)
+		base = strings.TrimSuffix(base, ".tar.gz")
+		base = strings.TrimSuffix(base, ".tgz")
+		base = strings.TrimSuffix(base, ".tar")
+		if base == "" {
+			return ""
+		}
+		return base + ":latest"
+	}
+
+	// For image references, extract the name:tag portion
+	ref := source
+	if idx := strings.LastIndex(ref, "/"); idx >= 0 {
+		ref = ref[idx+1:]
+	}
+	if !strings.Contains(ref, ":") {
+		ref += ":latest"
+	}
+	return ref
+}

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 	cmdBundle "github.com/crc-org/crc/v2/cmd/crc/cmd/bundle"
 	cmdConfig "github.com/crc-org/crc/v2/cmd/crc/cmd/config"
+	cmdImage "github.com/crc-org/crc/v2/cmd/crc/cmd/image"
 	crcConfig "github.com/crc-org/crc/v2/pkg/crc/config"
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
 	crcErr "github.com/crc-org/crc/v2/pkg/crc/errors"
@@ -71,6 +72,7 @@ func init() {
 	// subcommands
 	rootCmd.AddCommand(cmdConfig.GetConfigCmd(config))
 	rootCmd.AddCommand(cmdBundle.GetBundleCmd(config))
+	rootCmd.AddCommand(cmdImage.GetImageCmd(config))
 
 	logging.AddLogLevelFlag(rootCmd.PersistentFlags())
 }

--- a/cmd/crc/cmd/root_test.go
+++ b/cmd/crc/cmd/root_test.go
@@ -34,6 +34,8 @@ func TestCrcManPageGenerator_WhenInvoked_GeneratesManPagesForAllCrcSubCommands(t
 		"crc-console.1",
 		"crc-delete.1",
 		"crc-generate-kubeconfig.1",
+		"crc-image-load.1",
+		"crc-image.1",
 		"crc-ip.1",
 		"crc-oc-env.1",
 		"crc-podman-env.1",

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -26,6 +26,7 @@ type Client interface {
 	Stop() (state.State, error)
 	IsRunning() (bool, error)
 	GenerateBundle(forceStop bool) error
+	ImageLoad(cfg types.ImageLoadConfig) error
 	GetPreset() crcPreset.Preset
 }
 

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -123,6 +123,13 @@ func (c *Client) GetPreset() preset.Preset {
 	return preset.OpenShift
 }
 
+func (c *Client) ImageLoad(_ types.ImageLoadConfig) error {
+	if c.Failing {
+		return errors.New("image load failed")
+	}
+	return nil
+}
+
 func (c *Client) GetClusterLoad() (*types.ClusterLoadResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -135,6 +135,13 @@ func (c *Client) GetPreset() preset.Preset {
 	return preset.OpenShift
 }
 
+func (c *Client) ImageLoad(_ types.ImageLoadConfig) error {
+	if c.Failing {
+		return errors.New("image load failed")
+	}
+	return nil
+}
+
 func (c *Client) GetClusterLoad() (*types.ClusterLoadResult, error) {
 	return nil, errors.New("not implemented")
 }

--- a/pkg/crc/machine/image_load.go
+++ b/pkg/crc/machine/image_load.go
@@ -1,0 +1,204 @@
+package machine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/crc-org/crc/v2/pkg/crc/cluster"
+	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	"github.com/crc-org/crc/v2/pkg/crc/machine/types"
+	"github.com/crc-org/crc/v2/pkg/crc/oc"
+	"github.com/crc-org/crc/v2/pkg/crc/preset"
+	crcos "github.com/crc-org/crc/v2/pkg/os"
+)
+
+const registryHost = "default-route-openshift-image-registry" + constants.AppsDomain
+
+func (client *client) ImageLoad(cfg types.ImageLoadConfig) error {
+	if client.GetPreset() != preset.OpenShift && client.GetPreset() != preset.OKD {
+		return fmt.Errorf("image load is only supported for OpenShift clusters")
+	}
+
+	ocConfig := oc.UseOCWithConfig(client.name)
+
+	if err := checkRegistryRunning(ocConfig); err != nil {
+		return err
+	}
+
+	if err := ensureDefaultRoute(ocConfig); err != nil {
+		return err
+	}
+
+	runner := crcos.NewLocalCommandRunner()
+
+	if err := registryLogin(ocConfig, runner); err != nil {
+		return err
+	}
+
+	dest := fmt.Sprintf("%s/%s/%s", registryHost, cfg.Namespace, cfg.ImageName)
+
+	if cfg.IsTar {
+		return loadFromTar(ocConfig, runner, cfg.Source, dest)
+	}
+	return loadFromRef(ocConfig, runner, cfg.Source, dest)
+}
+
+func checkRegistryRunning(ocConfig oc.Config) error {
+	stdout, stderr, err := ocConfig.RunOcCommand(
+		"get", "pods",
+		"-n", "openshift-image-registry",
+		"-l", "docker-registry=default",
+		"-o", "jsonpath={.items[0].status.phase}",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to check image registry status: %s: %w", stderr, err)
+	}
+	if strings.TrimSpace(stdout) != "Running" {
+		return fmt.Errorf("openShift image registry is not running (status: %s)", strings.TrimSpace(stdout))
+	}
+	return nil
+}
+
+func ensureDefaultRoute(ocConfig oc.Config) error {
+	stdout, _, err := ocConfig.RunOcCommand(
+		"get", "configs.imageregistry.operator.openshift.io/cluster",
+		"-o", "jsonpath={.spec.defaultRoute}",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to check registry default route: %w", err)
+	}
+
+	if strings.TrimSpace(stdout) == "true" {
+		return nil
+	}
+
+	logging.Info("Enabling default route for the image registry...")
+	_, stderr, err := ocConfig.RunOcCommand(
+		"patch", "configs.imageregistry.operator.openshift.io/cluster",
+		"--type=merge",
+		"-p", `{"spec":{"defaultRoute":true}}`,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to enable registry default route: %s: %w", stderr, err)
+	}
+
+	logging.Info("Waiting for registry route to become available...")
+	_, stderr, err = ocConfig.RunOcCommand(
+		"wait", "--for=condition=Available",
+		"configs.imageregistry.operator.openshift.io/cluster",
+		"--timeout=120s",
+	)
+	if err != nil {
+		return fmt.Errorf("timed out waiting for registry route: %s: %w", stderr, err)
+	}
+
+	return nil
+}
+
+// registryLogin obtains an OAuth token by logging in as kubeadmin, then uses
+// that token to authenticate with the internal registry via podman login.
+func registryLogin(ocConfig oc.Config, runner crcos.CommandRunner) error {
+	password, err := cluster.GetUserPassword(constants.GetKubeAdminPasswordPath())
+	if err != nil {
+		return fmt.Errorf("failed to read kubeadmin password: %w", err)
+	}
+
+	// Login as kubeadmin using the CRC kubeconfig to get an OAuth token
+	_, stderr, err := runner.Run(
+		ocConfig.OcExecutablePath,
+		"login", "-u", "kubeadmin", "-p", password,
+		fmt.Sprintf("https://api%s:6443", constants.ClusterDomain),
+		"--insecure-skip-tls-verify=true",
+		"--kubeconfig="+ocConfig.KubeconfigPath,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to login as kubeadmin: %s: %w", stderr, err)
+	}
+
+	// Get the OAuth token
+	token, stderr, err := runner.RunPrivate(
+		ocConfig.OcExecutablePath, "whoami", "-t",
+		"--kubeconfig="+ocConfig.KubeconfigPath,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get OAuth token: %s: %w", stderr, err)
+	}
+	token = strings.TrimSpace(token)
+
+	// Login to registry with the OAuth token
+	_, stderr, err = runner.RunPrivate(
+		"podman", "login",
+		registryHost,
+		"-u", "kubeadmin",
+		"-p", token,
+		"--tls-verify=false",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to login to registry: %s: %w", stderr, err)
+	}
+
+	return nil
+}
+
+func loadFromTar(ocConfig oc.Config, runner crcos.CommandRunner, tarPath, dest string) error {
+	absPath, err := filepath.Abs(tarPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve tar path: %w", err)
+	}
+
+	logging.Infof("Loading image from %s ...", absPath)
+
+	stdout, stderr, err := runner.Run("podman", "load", "-i", absPath)
+	if err != nil {
+		return fmt.Errorf("failed to load tar into local podman: %s: %w", stderr, err)
+	}
+
+	loadedRef := parseLoadedImageRef(stdout)
+	if loadedRef == "" {
+		return fmt.Errorf("could not determine image reference from podman load output: %s", stdout)
+	}
+	logging.Infof("Loaded image %s, mirroring to %s ...", loadedRef, dest)
+
+	return mirrorAndReport(ocConfig, runner, loadedRef, dest)
+}
+
+func loadFromRef(ocConfig oc.Config, runner crcos.CommandRunner, source, dest string) error {
+	logging.Infof("Mirroring image %s to %s ...", source, dest)
+	return mirrorAndReport(ocConfig, runner, source, dest)
+}
+
+func mirrorAndReport(ocConfig oc.Config, runner crcos.CommandRunner, source, dest string) error {
+	_, stderr, err := runner.Run(
+		ocConfig.OcExecutablePath,
+		"image", "mirror",
+		"--insecure=true",
+		"--filter-by-os=.*",
+		fmt.Sprintf("%s=%s", source, dest),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to mirror image: %s: %w", stderr, err)
+	}
+
+	fmt.Fprintf(os.Stdout, "Image loaded successfully to image-registry.openshift-image-registry.svc:5000/%s\n", imageDest(dest))
+	return nil
+}
+
+func parseLoadedImageRef(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Loaded image") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				return strings.TrimSpace(parts[1])
+			}
+		}
+	}
+	return ""
+}
+
+func imageDest(dest string) string {
+	return strings.TrimPrefix(dest, registryHost+"/")
+}

--- a/pkg/crc/machine/sync.go
+++ b/pkg/crc/machine/sync.go
@@ -194,6 +194,10 @@ func (s *Synchronized) GenerateBundle(forceStop bool) error {
 	return s.underlying.GenerateBundle(forceStop)
 }
 
+func (s *Synchronized) ImageLoad(cfg types.ImageLoadConfig) error {
+	return s.underlying.ImageLoad(cfg)
+}
+
 func (s *Synchronized) GetPreset() crcPreset.Preset {
 	return s.underlying.GetPreset()
 }

--- a/pkg/crc/machine/sync_test.go
+++ b/pkg/crc/machine/sync_test.go
@@ -171,6 +171,10 @@ func (m *waitingMachine) GenerateBundle(_ bool) error {
 	return errors.New("not implemented")
 }
 
+func (m *waitingMachine) ImageLoad(_ types.ImageLoadConfig) error {
+	return errors.New("not implemented")
+}
+
 func (m *waitingMachine) GetPreset() crcPreset.Preset {
 	return crcPreset.OpenShift
 }

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -116,3 +116,10 @@ type ConnectionDetails struct {
 	SSHUsername string
 	SSHKeys     []string
 }
+
+type ImageLoadConfig struct {
+	Source    string // tar file path or image reference
+	IsTar     bool
+	Namespace string // target namespace in internal registry
+	ImageName string // target image name:tag
+}


### PR DESCRIPTION
## Summary

- Adds `crc image load` command to push container images into the CRC cluster's internal OpenShift registry
- Supports loading from tar files (`crc image load myapp.tar`) and registry references (`crc image load nginx:latest`)
- Automatically checks registry health, enables the default route if needed, and handles OAuth authentication

## Usage

```
crc image load <source> [flags]

# Load into the default "openshift" namespace (available cluster-wide)
crc image load myapp.tar
crc image load docker.io/library/nginx:latest

# Load into a specific project namespace
crc image load myapp.tar -n myproject
crc image load docker.io/library/nginx:latest -n myproject --name myapp:v1

Flags:
  -n, --namespace string   Target namespace (default "openshift")
      --name string        Override image name:tag in the registry
```

## Test plan

- [x] `make lint` passes
- [x] Unit tests pass (`go test ./cmd/crc/cmd/... ./pkg/crc/machine/...`)
- [x] Manual test: load from tar file with `--namespace` and `--name` flags
- [x] Manual test: load from registry reference
- [x] Verified images appear as imagestreams in cluster via `oc get is`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add crc image command with crc image load SOURCE to import images (tar or reference) into the cluster; supports namespace and explicit image name, and auto-derives names when possible. Errors with guidance when a name cannot be derived.
* **Documentation**
  * Man pages updated to include crc image and crc image load commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->