### PR TITLE
use OpenRoot API to fix issues raised by golangci-lint

### DIFF
--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -125,18 +125,31 @@ func ensureConfigFileExists(file string) error {
 func atomicWrite(bin []byte, configFile string) error {
 	ext := filepath.Ext(configFile)
 	pattern := fmt.Sprintf("%s*%s", strings.TrimSuffix(filepath.Base(configFile), ext), ext)
-	tmpFile, err := os.CreateTemp(filepath.Dir(configFile), pattern)
+
+	rootDir, err := os.OpenRoot(filepath.Dir(configFile))
 	if err != nil {
 		return err
 	}
+	defer rootDir.Close()
+
+	tmpFile, err := os.CreateTemp(rootDir.Name(), pattern)
+	if err != nil {
+		return err
+	}
+
+	// make sure paths are not absolute
+	tmpFileFilename := filepath.Base(tmpFile.Name())
+	configFileFilename := filepath.Base(configFile)
+
 	defer func() {
-		_ = os.Remove(tmpFile.Name()) // nolint:gosec // G703: paths from CreateTemp
+		_ = rootDir.Remove(tmpFileFilename)
 	}()
-	if err := tmpFile.Close(); err != nil {
+
+	_, err = tmpFile.Write(bin)
+	_ = tmpFile.Close()
+	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(tmpFile.Name(), bin, 0600); err != nil { // nolint:gosec // G703: paths from CreateTemp
-		return err
-	}
-	return os.Rename(tmpFile.Name(), configFile) // nolint:gosec // G703: paths from CreateTemp and caller
+
+	return rootDir.Rename(tmpFileFilename, configFileFilename)
 }

--- a/pkg/crc/machine/kubeconfig_test.go
+++ b/pkg/crc/machine/kubeconfig_test.go
@@ -89,15 +89,22 @@ func TestUpdateUserCaAndKeyToKubeconfig(t *testing.T) {
 }
 
 func createTempKubeConfig(config *api.Config) (string, error) {
-	tempFile, err := os.CreateTemp("", "kubeconfig-")
+	tempDirRoot, err := os.OpenRoot(os.TempDir())
+	if err != nil {
+		return "", err
+	}
+	defer tempDirRoot.Close()
+
+	tempFile, err := os.CreateTemp(tempDirRoot.Name(), "kubeconfig-")
 	if err != nil {
 		return "", err
 	}
 	path := tempFile.Name()
+	tempFileFilename := filepath.Base(path)
 
 	err = clientcmd.WriteToFile(*config, path)
 	if err != nil {
-		os.Remove(path) // nolint:gosec // G703: paths from CreateTemp and caller
+		_ = tempDirRoot.Remove(tempFileFilename)
 		return "", err
 	}
 

--- a/pkg/crc/ssh/keys.go
+++ b/pkg/crc/ssh/keys.go
@@ -86,13 +86,20 @@ func RemoveCRCHostEntriesFromKnownHosts() error {
 	}
 	defer f.Close()
 
-	tempHostsFile, err := os.CreateTemp(filepath.Join(constants.GetHomeDir(), ".ssh"), "crc")
+	sshDirRoot, err := os.OpenRoot(filepath.Join(constants.GetHomeDir(), ".ssh"))
+	if err != nil {
+		return err
+	}
+	defer sshDirRoot.Close()
+
+	tempHostsFile, err := os.CreateTemp(sshDirRoot.Name(), "crc")
 	if err != nil {
 		return fmt.Errorf("Unable to create temp file: %w", err)
 	}
+	tempHostsFilename := filepath.Base(tempHostsFile.Name())
 	defer func() {
-		tempHostsFile.Close()
-		os.Remove(tempHostsFile.Name()) //nolint:gosec // G703: paths from CreateTemp
+		_ = tempHostsFile.Close()
+		_ = sshDirRoot.Remove(tempHostsFilename)
 	}()
 
 	if err := tempHostsFile.Chmod(0600); err != nil {
@@ -142,7 +149,9 @@ func RemoveCRCHostEntriesFromKnownHosts() error {
 		if err := tempHostsFile.Close(); err != nil {
 			return fmt.Errorf("Error closing temp file: %w", err)
 		}
-		return os.Rename(tempHostsFile.Name(), knownHostsPath) //nolint:gosec // G703: paths from CreateTemp
+		// we need a path relative to the .ssh directory and the 'known_hosts'
+		// filename is known beforehand
+		return sshDirRoot.Rename(tempHostsFilename, "known_hosts")
 	}
 	return nil
 }

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -98,6 +98,7 @@ func Download(ctx context.Context, uri, destination string, mode os.FileMode, sh
 // InMemory takes a URL and returns a ReadCloser object to the downloaded file
 // or the file itself if the URL is a file:// URL. In case of failure it returns
 // the respective error.
+// nolint:gosec // G703 - root directory needed for path traversal check
 func InMemory(uri string) (io.ReadCloser, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
@@ -108,7 +109,7 @@ func InMemory(uri string) (io.ReadCloser, error) {
 		if err != nil {
 			return nil, err
 		}
-		return os.Open(filePath) // nolint:gosec
+		return os.Open(filePath)
 	}
 	client := grab.NewClient()
 	client.HTTPClient = &http.Client{Transport: httpproxy.HTTPTransport()}

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -90,6 +90,15 @@ func untar(ctx context.Context, reader io.Reader, targetDir string, fileFilter f
 	var extractedFiles []string
 	tarReader := tar.NewReader(reader)
 
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return nil, err
+	}
+	targetDirRoot, err := os.OpenRoot(targetDir)
+	if err != nil {
+		return nil, err
+	}
+	defer targetDirRoot.Close()
+
 	for {
 		header, err := tarReader.Next()
 		switch {
@@ -107,10 +116,9 @@ func untar(ctx context.Context, reader io.Reader, targetDir string, fileFilter f
 		}
 
 		// the target location where the dir/file should be created
-		path, err := BuildPathChecked(targetDir, header.Name)
-		if err != nil {
-			return nil, err
-		}
+		// path must not be absolute, so it is not joined to targetDir
+		// and the filename is just cleaned
+		path := filepath.Clean(header.Name)
 
 		if fileFilter != nil && !fileFilter(path) {
 			logging.Debugf("untar: Skipping %s", path)
@@ -119,31 +127,31 @@ func untar(ctx context.Context, reader io.Reader, targetDir string, fileFilter f
 
 		// check the file type
 		switch header.Typeflag {
-
 		// if it's a dir, and it doesn't exist, create it
 		case tar.TypeDir:
-			if err := os.MkdirAll(path, header.FileInfo().Mode()); err != nil { // nolint:gosec // G703: paths from header.FileInfo()
+			if err := targetDirRoot.MkdirAll(path, header.FileInfo().Mode().Perm()); err != nil {
 				return nil, err
 			}
 
 		// if it's a file, create it
 		case tar.TypeReg, tar.TypeGNUSparse:
 			// tar.Next() will externally only iterate files, so we might have to create intermediate directories here
-			if err := uncompressFile(ctx, tarReader, header.FileInfo(), path, showProgress); err != nil {
+			if err := uncompressFile(ctx, tarReader, header.FileInfo(), targetDirRoot, path, showProgress); err != nil {
 				return nil, err
 			}
-			extractedFiles = append(extractedFiles, path)
+			// return full paths
+			extractedFiles = append(extractedFiles, filepath.Join(targetDirRoot.Name(), path))
 		}
 	}
 }
 
-func uncompressFile(ctx context.Context, tarReader io.Reader, fileInfo os.FileInfo, path string, showProgress bool) error {
+func uncompressFile(ctx context.Context, tarReader io.Reader, fileInfo os.FileInfo, rootDir *os.Root, path string, showProgress bool) error {
 	// with a file filter, we may have skipped the intermediate directories, make sure they exist
-	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil { // nolint:gosec // G703: paths from filepath.Dir
+	if err := rootDir.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
 
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fileInfo.Mode()) // nolint:gosec // G703: paths from filepath.Dir
+	file, err := rootDir.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fileInfo.Mode().Perm())
 	if err != nil {
 		return err
 	}
@@ -178,46 +186,51 @@ func unzip(ctx context.Context, archive, target string, fileFilter func(string) 
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
 
-	if err := os.MkdirAll(target, 0750); err != nil {
+	if err := os.MkdirAll(target, 0o750); err != nil {
 		return nil, err
 	}
+	targetDirRoot, err := os.OpenRoot(target)
+	if err != nil {
+		return nil, err
+	}
+	defer targetDirRoot.Close()
 
 	for _, file := range reader.File {
-		path, err := BuildPathChecked(target, file.Name)
-		if err != nil {
-			return nil, err
-		}
+		// path must not be absolute, so it is not joined to targetDir
+		// and the filename is just cleaned
+		path := filepath.Clean(file.Name)
 
 		if fileFilter != nil && !fileFilter(path) {
 			logging.Debugf("untar: Skipping %s", path)
 			continue
 		}
 		if file.FileInfo().IsDir() {
-			err = os.MkdirAll(path, file.Mode())
-			if err != nil {
+			if err = targetDirRoot.MkdirAll(path, file.Mode().Perm()); err != nil {
 				return nil, err
 			}
 			continue
 		}
 
-		if err := unzipFile(ctx, file, filepath.Clean(path), showProgress); err != nil {
+		if err := unzipFile(ctx, file, targetDirRoot, path, showProgress); err != nil {
 			return nil, err
 		}
-		extractedFiles = append(extractedFiles, path)
+		// return full paths
+		extractedFiles = append(extractedFiles, filepath.Join(targetDirRoot.Name(), path))
 	}
 
 	return extractedFiles, nil
 }
 
-func unzipFile(ctx context.Context, file *zip.File, path string, showProgress bool) error {
+func unzipFile(ctx context.Context, file *zip.File, rootDir *os.Root, path string, showProgress bool) error {
 	fileReader, err := file.Open()
 	if err != nil {
 		return err
 	}
 	defer fileReader.Close()
 
-	return uncompressFile(ctx, fileReader, file.FileInfo(), path, showProgress)
+	return uncompressFile(ctx, fileReader, file.FileInfo(), rootDir, path, showProgress)
 }
 
 func progressBarReader(reader io.Reader, info os.FileInfo, showProgress bool) (io.Reader, func()) {

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -62,7 +62,7 @@ func TestZipSlip(t *testing.T) {
 	archiveName := filepath.Join("testdata", "zipslip.tar.gz")
 	_, err := Uncompress(context.Background(), archiveName, t.TempDir())
 	logging.Infof("error: %v", err)
-	assert.ErrorContains(t, err, "illegal file path")
+	assert.ErrorContains(t, err, "path")
 }
 
 func TestBuildPathChecked(t *testing.T) {

--- a/pkg/libmachine/persist/filestore.go
+++ b/pkg/libmachine/persist/filestore.go
@@ -25,26 +25,33 @@ func (s Filestore) saveToFile(data []byte, file string) error {
 		return os.WriteFile(file, data, 0600)
 	}
 
-	tmpfi, err := os.CreateTemp(filepath.Dir(file), "config.json.tmp")
+	rootDir, err := os.OpenRoot(filepath.Dir(file))
 	if err != nil {
 		return err
 	}
-	defer os.Remove(tmpfi.Name())
+	defer rootDir.Close()
+	fileFilename := filepath.Base(file)
 
-	if err = os.WriteFile(tmpfi.Name(), data, 0600); err != nil { // nolint:gosec // G703: paths from CreateTemp
+	tmpFile, err := os.CreateTemp(rootDir.Name(), "config.json.tmp")
+	if err != nil {
+		return err
+	}
+	defer tmpFile.Close()
+	tmpFileFilename := filepath.Base(tmpFile.Name())
+
+	if err = rootDir.WriteFile(tmpFileFilename, data, 0600); err != nil {
 		return err
 	}
 
-	if err = tmpfi.Close(); err != nil {
+	if err = tmpFile.Close(); err != nil {
 		return err
 	}
 
-	if err = os.Remove(file); err != nil {
+	if err = rootDir.Rename(tmpFileFilename, fileFilename); err != nil {
 		return err
 	}
 
-	err = os.Rename(tmpfi.Name(), file) // nolint:gosec // G703: paths from CreateTemp and caller
-	return err
+	return nil
 }
 
 func (s Filestore) Save(host *host.Host) error {

--- a/pkg/os/copy.go
+++ b/pkg/os/copy.go
@@ -7,15 +7,17 @@ import (
 	"os"
 )
 
+// nolint:gosec // G703 - paths are supplied by calling functions,
+// this function is not supposed to check them for path traversal
 func copyFile(src, dst string, sparse bool) error {
-	in, err := os.Open(src) // nolint:gosec
+	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 
 	defer in.Close()
 
-	out, err := os.Create(dst) // nolint:gosec
+	out, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
@@ -32,12 +34,12 @@ func copyFile(src, dst string, sparse bool) error {
 		}
 	}
 
-	fi, err := os.Stat(src) // nolint:gosec
+	fi, err := os.Stat(src)
 	if err != nil {
 		return err
 	}
 
-	if err = os.Chmod(dst, fi.Mode()); err != nil { // nolint:gosec // G703: paths from Stat
+	if err = os.Chmod(dst, fi.Mode()); err != nil {
 		return err
 	}
 

--- a/pkg/os/copy_test.go
+++ b/pkg/os/copy_test.go
@@ -9,7 +9,7 @@ import (
 func TestCopyFile(t *testing.T) {
 	testStr := "test-machine"
 
-	srcFile, err := os.CreateTemp("", "machine-test-")
+	srcFile, err := os.CreateTemp(os.TempDir(), "machine-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,25 +23,29 @@ func TestCopyFile(t *testing.T) {
 
 	srcFilePath := filepath.Join(os.TempDir(), srcFi.Name())
 
-	destFile, err := os.CreateTemp("", "machine-copy-test-")
+	destFile, err := os.CreateTemp(os.TempDir(), "machine-copy-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	destFi, err := destFile.Stat()
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	destFile.Close()
 
-	destFilePath := filepath.Join(os.TempDir(), destFi.Name())
+	tempDirRoot, err := os.OpenRoot(os.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempDirRoot.Close()
+
+	destFilePath := filepath.Join(tempDirRoot.Name(), destFi.Name())
 
 	if err := CopyFile(srcFilePath, destFilePath); err != nil {
 		t.Fatal(err)
 	}
 
-	data, err := os.ReadFile(destFilePath) // nolint:gosec
+	data, err := tempDirRoot.ReadFile(destFi.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/os/shell/shell_test.go
+++ b/pkg/os/shell/shell_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type MockCommandRunner struct {
@@ -168,19 +169,20 @@ func TestIsWindowsSubsystemLinux_whenValidKernelInfoFile_thenReturnTrue(t *testi
 		t.Run(tt.name, func(t *testing.T) {
 			// Given
 			dir := t.TempDir()
-			wslVersionFilePath := filepath.Join(dir, "version")
-			wslVersionFile, err := os.Create(wslVersionFilePath)
-			assert.NoError(t, err)
+			rootDir, err := os.OpenRoot(dir)
+			require.NoError(t, err)
+			defer rootDir.Close()
+			wslVersionFilename := "version"
+			wslVersionFile, err := rootDir.Create(wslVersionFilename)
+			require.NoError(t, err)
 			defer func(wslVersionFile *os.File) {
-				err := wslVersionFile.Close()
-				assert.NoError(t, err)
-				err = os.Remove(wslVersionFile.Name()) // nolint:gosec // G703: paths from CreateTemp and caller
-				assert.NoError(t, err)
+				assert.NoError(t, wslVersionFile.Close())
+				assert.NoError(t, rootDir.Remove(wslVersionFilename))
 			}(wslVersionFile)
 			numberOfBytesWritten, err := wslVersionFile.WriteString(tt.versionFileContent)
 			assert.NoError(t, err)
 			assert.Greater(t, numberOfBytesWritten, 0)
-			WindowsSubsystemLinuxKernelMetadataFile = wslVersionFilePath
+			WindowsSubsystemLinuxKernelMetadataFile = filepath.Join(dir, wslVersionFilename)
 			// When
 			result := IsWindowsSubsystemLinux()
 


### PR DESCRIPTION
Fixes: #5184

Use the Go OpenRoot API to fix path-traversal potential issues reported by gosec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched many file and temp operations to directory-scoped handles to improve atomic writes and reliability across config, SSH, extraction, and persistence.
* **Bug Fixes / Security**
  * Hardened extraction and temp-file handling to reduce path traversal and improve atomicity when updating known_hosts and extracting archives.
* **Chores**
  * Standardized lint suppression placement and cleaned up temp-file semantics.
* **Tests**
  * Updated tests to use directory-scoped temp handling and tightened error assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->