### PR TITLE
Add e2e-test skill for running CRC end-to-end tests

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make cross:*)",
+      "Bash(crc status:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make cross:*)",
+      "Bash(make e2e:*)",
+      "Bash(crc status:*)",
+      "Bash(out/*/crc cleanup:*)"
+    ]
+  }
+}

--- a/.claude/skills/e2e-test/EXAMPLES.md
+++ b/.claude/skills/e2e-test/EXAMPLES.md
@@ -1,0 +1,256 @@
+# E2E Test Skill Examples
+
+## Interactive Mode (Recommended)
+
+Simply invoke the skill without arguments:
+
+```bash
+/e2e-test
+```
+
+The skill will:
+1. Ask you to select features (multi-select enabled)
+2. Ask you to select OS platform
+3. Ask for bundle location (~/.crc/cache, ~/Downloads, or custom)
+4. Ask for pull secret location (~/Downloads or custom)
+5. Build CRC from source using `make cross` (~5-10 minutes)
+6. Verify prerequisites
+7. Build and execute the test command with the built binary
+8. Show results
+
+### Example Interactive Flow
+
+```
+User: /e2e-test
+
+Claude: Which e2e test feature(s) do you want to run?
+[✓] basic - Core CRC lifecycle tests
+[ ] config - Configuration management tests
+[✓] minimal - Quick minimal test suite
+[ ] ...
+
+Claude: Which OS platform do you want to test?
+( ) linux
+(•) darwin (current)
+( ) windows
+
+Claude: Running: make e2e GODOG_OPTS="--godog.tags=\"darwin && (@basic || @minimal)\""
+...
+```
+
+## With Arguments
+
+### Single Feature, Current OS
+
+```bash
+/e2e-test basic
+```
+
+Runs basic tests on current platform.
+
+### Single Feature, Specific OS
+
+```bash
+/e2e-test config linux
+```
+
+Runs config tests on Linux platform.
+
+### Multiple Features
+
+```bash
+/e2e-test basic,minimal,config
+```
+
+Prompts for OS selection, then runs all three features.
+
+### Multiple Features with OS
+
+```bash
+/e2e-test basic,config darwin
+```
+
+Runs basic and config tests on macOS.
+
+## Common Scenarios
+
+### Quick Validation
+
+Run minimal tests on current platform:
+```bash
+/e2e-test minimal
+```
+~10 minutes
+
+### Core Feature Testing
+
+Run basic lifecycle tests:
+```bash
+/e2e-test basic linux
+```
+~30 minutes
+
+### OpenShift Story Validation
+
+```bash
+/e2e-test story_openshift
+```
+~45 minutes, tests OpenShift-specific features
+
+### Configuration Testing
+
+```bash
+/e2e-test config
+```
+~15 minutes, validates configuration management
+
+### Multi-Feature Test Run
+
+```bash
+/e2e-test basic,config,minimal linux
+```
+~55 minutes combined
+
+## Advanced Usage
+
+### Testing on Running Cluster
+
+For tests that require an existing running cluster:
+
+```bash
+# First, ensure cluster is running
+crc start
+
+# Then run tests that don't manage lifecycle
+/e2e-test running_cluster_tests
+```
+
+### Cleanup After Tests
+
+```bash
+# After running tests, cleanup
+crc delete -f
+crc cleanup
+```
+
+## Expected Output
+
+### Successful Test Run
+
+```
+Building CRC from source...
+Running: make cross
+
+Building binaries for all platforms...
+✓ out/linux-amd64/crc
+✓ out/linux-arm64/crc
+✓ out/macos-amd64/crc
+✓ out/macos-arm64/crc
+✓ out/windows-amd64/crc.exe
+
+Build completed in 6m32s
+
+Checking prerequisites...
+✓ Pull secret found at ~/pull-secret
+✓ Bundle found at ~/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle
+✓ CRC binary built at out/linux-amd64/crc
+
+Running e2e tests:
+  Features: basic, config
+  Platform: linux
+  
+Command: CRC_BINARY=--crc-binary=out/linux-amd64/ BUNDLE_LOCATION=--bundle-location=~/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle PULL_SECRET_FILE=--pull-secret-file=~/pull-secret make e2e GODOG_OPTS="--godog.tags=\"linux && (@basic || @config)\""
+
+=== Test Output ===
+go test --timeout=180m github.com/crc-org/crc/v2/test/e2e -tags "containers_image_openpgp" ...
+
+Feature: Basic test
+  Scenario: CRC version                    # test/e2e/features/basic.feature:8
+    ✓ crc version has expected output
+
+  Scenario: CRC help                       # test/e2e/features/basic.feature:12
+    ✓ executing crc help command succeeds
+    ✓ stdout should contain "Usage:"
+    ...
+
+Feature: Config test
+  Scenario: Get config value              # test/e2e/features/config.feature:10
+    ✓ executing "crc config get memory" succeeds
+    ...
+
+32 scenarios (32 passed)
+156 steps (156 passed)
+28m15.234s
+
+Tests completed successfully!
+```
+
+### Test Failure
+
+```
+...
+  Scenario: CRC start usecase              # test/e2e/features/basic.feature:31
+    ✓ executing "crc setup --check-only" fails
+    ✓ unsetting config property "developer-password" succeeds
+    ✓ setting config property "enable-cluster-monitoring" to value "true" succeeds
+    ✗ starting CRC with default bundle succeeds
+      Error: timeout waiting for cluster to start
+
+--- Failed scenarios:
+    test/e2e/features/basic.feature:31
+
+3 scenarios (2 passed, 1 failed)
+12 steps (11 passed, 1 failed)
+```
+
+## Troubleshooting
+
+### "Bundle not found"
+
+```bash
+# Check if bundle exists in CRC cache directory
+ls ~/.crc/cache/*.crcbundle
+
+# Or check Downloads folder
+ls ~/Downloads/*.crcbundle
+
+# Or download bundle and it will be stored in cache
+crc setup
+
+# Or specify custom path when prompted by the skill
+```
+
+### "Pull secret not found"
+
+```bash
+# Get pull secret from https://console.redhat.com/openshift/create/local
+# Save to ~/Downloads/crc-pull-secret or specify custom path when prompted
+# Example:
+# mv ~/Downloads/pull-secret.txt ~/Downloads/crc-pull-secret
+```
+
+### "CRC is already running"
+
+```bash
+# Stop and delete existing cluster
+crc stop
+crc delete -f
+```
+
+### Tests timeout
+
+- Increase system resources
+- Check network connectivity
+- Verify bundle is not corrupted
+- Try running fewer features at once
+
+## Tips
+
+1. **Start small**: Test with `minimal` or single features first
+2. **Build time**: First run takes ~5-10 minutes for `make cross`, subsequent runs reuse built binaries if source hasn't changed
+3. **Bundle location**: Use ~/.crc/cache for bundles (recommended) - this is where `crc setup` downloads them
+4. **Clean state**: Most tests expect no running cluster - use `crc delete -f` before running
+5. **Monitor resources**: Watch system RAM and disk usage during tests (16GB+ RAM recommended)
+6. **Logs**: Check `~/.crc/crc.log` for detailed CRC logs if tests fail
+7. **Parallel testing**: Don't run multiple e2e test sessions simultaneously
+8. **Fresh build**: The skill always builds from current source, ensuring tests run against your latest changes

--- a/.claude/skills/e2e-test/EXAMPLES.md
+++ b/.claude/skills/e2e-test/EXAMPLES.md
@@ -1,0 +1,256 @@
+# E2E Test Skill Examples
+
+## Interactive Mode (Recommended)
+
+Simply invoke the skill without arguments:
+
+```bash
+/e2e-test
+```
+
+The skill will:
+1. Ask you to select features (multi-select enabled)
+2. Ask you to select OS platform
+3. Ask for bundle location (~/.crc/cache, ~/Downloads, or custom)
+4. Ask for pull secret location (~/Downloads or custom)
+5. Build CRC from source using `make cross` (~5-10 minutes)
+6. Verify prerequisites
+7. Build and execute the test command with the built binary
+8. Show results
+
+### Example Interactive Flow
+
+```text
+User: /e2e-test
+
+Claude: Which e2e test feature(s) do you want to run?
+[✓] basic - Core CRC lifecycle tests
+[ ] config - Configuration management tests
+[✓] minimal - Quick minimal test suite
+[ ] ...
+
+Claude: Which OS platform do you want to test?
+( ) linux
+(•) darwin (current)
+( ) windows
+
+Claude: Running: make e2e GODOG_OPTS="--godog.tags=\"darwin && (@basic || @minimal)\""
+...
+```
+
+## With Arguments
+
+### Single Feature, Current OS
+
+```bash
+/e2e-test basic
+```
+
+Runs basic tests on current platform.
+
+### Single Feature, Specific OS
+
+```bash
+/e2e-test config linux
+```
+
+Runs config tests on Linux platform.
+
+### Multiple Features
+
+```bash
+/e2e-test basic,minimal,config
+```
+
+Prompts for OS selection, then runs all three features.
+
+### Multiple Features with OS
+
+```bash
+/e2e-test basic,config darwin
+```
+
+Runs basic and config tests on macOS.
+
+## Common Scenarios
+
+### Quick Validation
+
+Run minimal tests on current platform:
+```bash
+/e2e-test minimal
+```
+~10 minutes
+
+### Core Feature Testing
+
+Run basic lifecycle tests:
+```bash
+/e2e-test basic linux
+```
+~30 minutes
+
+### OpenShift Story Validation
+
+```bash
+/e2e-test story_openshift
+```
+~45 minutes, tests OpenShift-specific features
+
+### Configuration Testing
+
+```bash
+/e2e-test config
+```
+~15 minutes, validates configuration management
+
+### Multi-Feature Test Run
+
+```bash
+/e2e-test basic,config,minimal linux
+```
+~55 minutes combined
+
+## Advanced Usage
+
+### Testing on Running Cluster
+
+For tests that require an existing running cluster:
+
+```bash
+# First, ensure cluster is running
+crc start
+
+# Then run tests that don't manage lifecycle
+/e2e-test running_cluster_tests
+```
+
+### Cleanup After Tests
+
+```bash
+# After running tests, cleanup
+crc delete -f
+crc cleanup
+```
+
+## Expected Output
+
+### Successful Test Run
+
+```text
+Building CRC from source...
+Running: make cross
+
+Building binaries for all platforms...
+✓ out/linux-amd64/crc
+✓ out/linux-arm64/crc
+✓ out/macos-amd64/crc
+✓ out/macos-arm64/crc
+✓ out/windows-amd64/crc.exe
+
+Build completed in 6m32s
+
+Checking prerequisites...
+✓ Pull secret found at /home/user/pull-secret
+✓ Bundle found at /home/user/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle
+✓ CRC binary built at out/linux-amd64/crc
+
+Running e2e tests:
+  Features: basic, config
+  Platform: linux
+  
+Command: CRC_BINARY=--crc-binary=/home/user/crc/out/linux-amd64/ BUNDLE_LOCATION=--bundle-location=/home/user/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle PULL_SECRET_FILE=--pull-secret-file=/home/user/pull-secret make e2e GODOG_OPTS="--godog.tags=\"linux && (@basic || @config)\""
+
+=== Test Output ===
+go test --timeout=180m github.com/crc-org/crc/v2/test/e2e -tags "containers_image_openpgp" ...
+
+Feature: Basic test
+  Scenario: CRC version                    # test/e2e/features/basic.feature:8
+    ✓ crc version has expected output
+
+  Scenario: CRC help                       # test/e2e/features/basic.feature:12
+    ✓ executing crc help command succeeds
+    ✓ stdout should contain "Usage:"
+    ...
+
+Feature: Config test
+  Scenario: Get config value              # test/e2e/features/config.feature:10
+    ✓ executing "crc config get memory" succeeds
+    ...
+
+32 scenarios (32 passed)
+156 steps (156 passed)
+28m15.234s
+
+Tests completed successfully!
+```
+
+### Test Failure
+
+```text
+...
+  Scenario: CRC start usecase              # test/e2e/features/basic.feature:31
+    ✓ executing "crc setup --check-only" fails
+    ✓ unsetting config property "developer-password" succeeds
+    ✓ setting config property "enable-cluster-monitoring" to value "true" succeeds
+    ✗ starting CRC with default bundle succeeds
+      Error: timeout waiting for cluster to start
+
+--- Failed scenarios:
+    test/e2e/features/basic.feature:31
+
+3 scenarios (2 passed, 1 failed)
+12 steps (11 passed, 1 failed)
+```
+
+## Troubleshooting
+
+### "Bundle not found"
+
+```bash
+# Check if bundle exists in CRC cache directory
+ls ~/.crc/cache/*.crcbundle
+
+# Or check Downloads folder
+ls ~/Downloads/*.crcbundle
+
+# Or download bundle and it will be stored in cache
+crc setup
+
+# Or specify custom path when prompted by the skill
+```
+
+### "Pull secret not found"
+
+```bash
+# Get pull secret from https://console.redhat.com/openshift/create/local
+# Save to ~/Downloads/crc-pull-secret or specify custom path when prompted
+# Example:
+# mv ~/Downloads/pull-secret.txt ~/Downloads/crc-pull-secret
+```
+
+### "CRC is already running"
+
+```bash
+# Stop and delete existing cluster
+crc stop
+crc delete -f
+```
+
+### Tests timeout
+
+- Increase system resources
+- Check network connectivity
+- Verify bundle is not corrupted
+- Try running fewer features at once
+
+## Tips
+
+1. **Start small**: Test with `minimal` or single features first
+2. **Build time**: First run takes ~5-10 minutes for `make cross`, subsequent runs reuse built binaries if source hasn't changed
+3. **Bundle location**: Use ~/.crc/cache for bundles (recommended) - this is where `crc setup` downloads them
+4. **Clean state**: Most tests expect no running cluster - use `crc delete -f` before running
+5. **Monitor resources**: Watch system RAM and disk usage during tests (16GB+ RAM recommended)
+6. **Logs**: Check `~/.crc/crc.log` for detailed CRC logs if tests fail
+7. **Parallel testing**: Don't run multiple e2e test sessions simultaneously
+8. **Fresh build**: The skill always builds from current source, ensuring tests run against your latest changes

--- a/.claude/skills/e2e-test/REFERENCE.md
+++ b/.claude/skills/e2e-test/REFERENCE.md
@@ -1,0 +1,119 @@
+# E2E Test Reference
+
+## Feature Tags and Descriptions
+
+Based on the test/e2e/features directory:
+
+### Core Features
+
+| Feature Tag | File | Description | Platform Support |
+|------------|------|-------------|------------------|
+| `@basic` | basic.feature | Core CRC lifecycle (setup, start, stop, delete, version, help, status) | linux, darwin, windows |
+| `@config` | config.feature | Configuration property management and validation | linux, darwin, windows |
+| `@minimal` | minimal.feature | Minimal test suite for quick validation | linux, darwin, windows |
+
+### Story Features
+
+| Feature Tag | File | Description | Platform Support |
+|------------|------|-------------|------------------|
+| `@story_openshift` | story_openshift.feature | OpenShift-specific features and scenarios | linux, darwin, windows |
+| `@story_microshift` | story_microshift.feature | MicroShift-specific features and scenarios | linux, darwin, windows |
+| `@story_application_deployment` | application_deployment.feature | Application deployment workflows | linux, darwin, windows |
+| `@story_manpages` | manpages.feature | Man page generation and validation | linux, darwin, windows |
+
+### Specialized Tests
+
+| Feature Tag | File | Description | Platform Support |
+|------------|------|-------------|------------------|
+| `@running_cluster_tests` | running_cluster_tests.feature | Tests for operations on running clusters | linux, darwin, windows |
+| `@cert_rotation` | cert_rotation.feature | Certificate rotation scenarios | linux only |
+
+## Additional Tags
+
+### Platform Tags
+- `@darwin` - macOS tests
+- `@linux` - Linux tests  
+- `@windows` - Windows tests
+
+### Lifecycle Tags
+- `@startstop` - Tests that manage cluster start/stop
+- `@cleanup` - Tests that require cleanup
+- `@release` - Tests included in release validation
+
+## Makefile Targets
+
+### Main E2E Target
+```bash
+make e2e
+```
+
+**Default behavior:**
+- Runs with OS tag matching current platform (GOOS)
+- Uses pull secret from ~/Downloads/crc-pull-secret
+- Uses bundle from ~/Downloads/crc_libvirt_*.crcbundle (or ~/.crc/cache)
+- Uses CRC binary from $GOPATH/bin
+
+**E2E Test Skill behavior:**
+- Builds CRC from source using `make cross` before running tests
+- Uses built binary from `out/<platform>-<arch>/crc`
+- Prompts for bundle location (cache, downloads, or custom)
+- Prompts for pull secret location (downloads or custom)
+
+### Story-Specific Targets
+These run with `--cleanup-home=false` (cluster must already be running):
+
+```bash
+make e2e-story-health
+make e2e-story-marketplace  
+make e2e-story-registry
+make e2e-story-microshift
+```
+
+### Tag Filtering Examples
+
+Run specific feature on current OS:
+```bash
+make e2e GODOG_OPTS="--godog.tags=\"\$(GOOS) && @basic\""
+```
+
+Run multiple features:
+```bash
+make e2e GODOG_OPTS="--godog.tags=\"linux && (@basic || @config)\""
+```
+
+Exclude tags:
+```bash
+make e2e GODOG_OPTS="--godog.tags=\"linux && ~@startstop\""
+```
+
+## Environment Overrides
+
+```bash
+# Custom pull secret
+make e2e PULL_SECRET_FILE=--pull-secret-file=/custom/path/secret
+
+# Bundle from CRC cache directory (recommended)
+make e2e BUNDLE_LOCATION=--bundle-location=~/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle
+
+# Bundle from Downloads
+make e2e BUNDLE_LOCATION=--bundle-location=~/Downloads/crc_libvirt_4.21.8_amd64.crcbundle
+
+# Custom CRC binary from build output (directory path, not binary itself)
+make e2e CRC_BINARY=--crc-binary=out/linux-amd64/
+
+# Skip home cleanup
+make e2e CLEANUP_HOME=--cleanup-home=false
+
+# Test specific version
+make e2e VERSION_TO_TEST=--test-version=v2.58.0
+
+# E2E Test Skill automatically sets these (note: directory path for CRC_BINARY):
+CRC_BINARY=--crc-binary=out/linux-amd64/ BUNDLE_LOCATION=--bundle-location=~/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle PULL_SECRET_FILE=--pull-secret-file=~/pull-secret make e2e GODOG_OPTS="--godog.tags=\"linux && @minimal\""
+```
+
+## Test Execution Notes
+
+- **Timeout**: Tests use `--timeout=180m` (3 hours)
+- **Build tags**: Tests are built with container_image_openpgp tag
+- **Prerequisites**: CRC must be properly setup with required resources
+- **Clean state**: Most tests expect a clean starting state (no existing cluster)

--- a/.claude/skills/e2e-test/REFERENCE.md
+++ b/.claude/skills/e2e-test/REFERENCE.md
@@ -1,0 +1,119 @@
+# E2E Test Reference
+
+## Feature Tags and Descriptions
+
+Based on the test/e2e/features directory:
+
+### Core Features
+
+| Feature Tag | File | Description | Platform Support |
+|------------|------|-------------|------------------|
+| `@basic` | basic.feature | Core CRC lifecycle (setup, start, stop, delete, version, help, status) | linux, darwin, windows |
+| `@config` | config.feature | Configuration property management and validation | linux, darwin, windows |
+| `@minimal` | minimal.feature | Minimal test suite for quick validation | linux, darwin, windows |
+
+### Story Features
+
+| Feature Tag | File | Description | Platform Support |
+|------------|------|-------------|------------------|
+| `@story_openshift` | story_openshift.feature | OpenShift-specific features and scenarios | linux, darwin, windows |
+| `@story_microshift` | story_microshift.feature | MicroShift-specific features and scenarios | linux, darwin, windows |
+| `@story_application_deployment` | application_deployment.feature | Application deployment workflows | linux, darwin, windows |
+| `@story_manpages` | manpages.feature | Man page generation and validation | linux, darwin, windows |
+
+### Specialized Tests
+
+| Feature Tag | File | Description | Platform Support |
+|------------|------|-------------|------------------|
+| `@running_cluster_tests` | running_cluster_tests.feature | Tests for operations on running clusters | linux, darwin, windows |
+| `@cert_rotation` | cert_rotation.feature | Certificate rotation scenarios | linux only |
+
+## Additional Tags
+
+### Platform Tags
+- `@darwin` - macOS tests
+- `@linux` - Linux tests  
+- `@windows` - Windows tests
+
+### Lifecycle Tags
+- `@startstop` - Tests that manage cluster start/stop
+- `@cleanup` - Tests that require cleanup
+- `@release` - Tests included in release validation
+
+## Makefile Targets
+
+### Main E2E Target
+```bash
+make e2e
+```
+
+**Default behavior:**
+- Runs with OS tag matching current platform (GOOS)
+- Uses pull secret from ~/Downloads/crc-pull-secret
+- Uses bundle from ~/Downloads/crc_libvirt_*.crcbundle (or ~/.crc/cache)
+- Uses CRC binary from $GOPATH/bin
+
+**E2E Test Skill behavior:**
+- Builds CRC from source using `make cross` before running tests
+- Uses built binary from `out/<platform>-<arch>/crc`
+- Prompts for bundle location (cache, downloads, or custom)
+- Prompts for pull secret location (downloads or custom)
+
+### Story-Specific Targets
+These run with `--cleanup-home=false` (cluster must already be running):
+
+```bash
+make e2e-story-health
+make e2e-story-marketplace  
+make e2e-story-registry
+make e2e-story-microshift
+```
+
+### Tag Filtering Examples
+
+Run specific feature on current OS:
+```bash
+make e2e GODOG_OPTS="--godog.tags=\"\$(GOOS) && @basic\""
+```
+
+Run multiple features:
+```bash
+make e2e GODOG_OPTS="--godog.tags=\"linux && (@basic || @config)\""
+```
+
+Exclude tags:
+```bash
+make e2e GODOG_OPTS="--godog.tags=\"linux && ~@startstop\""
+```
+
+## Environment Overrides
+
+```bash
+# Custom pull secret
+make e2e PULL_SECRET_FILE=--pull-secret-file=/custom/path/secret
+
+# Bundle from CRC cache directory (recommended)
+make e2e BUNDLE_LOCATION=--bundle-location=/home/user/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle
+
+# Bundle from Downloads
+make e2e BUNDLE_LOCATION=--bundle-location=/home/user/Downloads/crc_libvirt_4.21.8_amd64.crcbundle
+
+# Custom CRC binary from build output (directory path, not binary itself)
+make e2e CRC_BINARY=--crc-binary=out/linux-amd64/
+
+# Skip home cleanup
+make e2e CLEANUP_HOME=--cleanup-home=false
+
+# Test specific version
+make e2e VERSION_TO_TEST=--test-version=v2.58.0
+
+# E2E Test Skill automatically sets these (note: directory path for CRC_BINARY):
+CRC_BINARY=--crc-binary=/home/user/crc/out/linux-amd64/ BUNDLE_LOCATION=--bundle-location=/home/user/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle PULL_SECRET_FILE=--pull-secret-file=/home/user/pull-secret make e2e GODOG_OPTS="--godog.tags=\"linux && @minimal\""
+```
+
+## Test Execution Notes
+
+- **Timeout**: Tests use `--timeout=180m` (3 hours)
+- **Build tags**: Tests are built with container_image_openpgp tag
+- **Prerequisites**: CRC must be properly setup with required resources
+- **Clean state**: Most tests expect a clean starting state (no existing cluster)

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: e2e-test
+description: Run CRC end-to-end tests for specific features and operating systems
+argument-hint: [feature] [os]
+allowed-tools: [AskUserQuestion, Bash, Read, Grep]
+---
+
+# CRC E2E Test Runner
+
+This skill runs CRC end-to-end tests with interactive feature and OS selection.
+
+## Arguments
+
+User provided arguments: $ARGUMENTS
+
+## Available Features
+
+The CRC e2e test suite includes these features:
+- **basic**: Core CRC lifecycle tests (version, help, setup, start, stop, delete)
+- **config**: Configuration management tests
+- **minimal**: Minimal feature set tests (requires MicroShift bundle)
+- **story_openshift**: OpenShift-specific story tests
+- **story_microshift**: MicroShift-specific story tests
+- **story_application_deployment**: Application deployment scenarios
+- **running_cluster_tests**: Tests for running cluster operations
+- **cert_rotation**: Certificate rotation tests (Linux only)
+- **story_manpages**: Man page generation tests
+
+## Available OS Platforms
+
+- **linux**: Linux platform tests
+- **darwin**: macOS platform tests
+- **windows**: Windows platform tests
+
+## Instructions
+
+When this skill is invoked:
+
+1. **Parse arguments** (if provided):
+   - If arguments include a feature name and/or OS, use those
+   - Otherwise, proceed to interactive selection
+
+2. **Interactive selection** (if no arguments or partial arguments):
+   
+   Use AskUserQuestion tool with these specific questions:
+   
+   **Question 1: Feature Selection**
+   - Header: "Feature"
+   - Question: "Which e2e test feature(s) do you want to run?"
+   - multiSelect: true (allow multiple features)
+   - Options:
+     * basic: "Core CRC lifecycle tests - setup, start, stop, delete, version, status (~30 min)"
+     * config: "Configuration management and property validation tests (~15 min)"
+     * minimal: "Quick minimal test suite for fast validation (~10 min, requires MicroShift bundle)"
+     * story_openshift: "OpenShift-specific features and scenarios (~45 min)"
+     * story_microshift: "MicroShift-specific features and scenarios (~45 min)"
+     * story_application_deployment: "Application deployment workflows (~30 min)"
+     * running_cluster_tests: "Tests for running cluster operations (~20 min, requires running cluster)"
+     * cert_rotation: "Certificate rotation scenarios (~25 min, Linux only)"
+     * story_manpages: "Man page generation and validation (~10 min)"
+   
+   **Question 2: OS Platform Selection**
+   - Header: "Platform"
+   - Question: "Which OS platform do you want to test?"
+   - multiSelect: false (single selection)
+   - Options:
+     * current: "Use current platform ($(GOOS)) - Recommended"
+     * linux: "Linux platform (most features supported)"
+     * darwin: "macOS platform (arm64 and amd64)"
+     * windows: "Windows platform (amd64 only)"
+   
+   **Question 3: Bundle Location**
+   - Header: "Bundle"
+   - Question: "Where is the CRC bundle located?"
+   - multiSelect: false (single selection)
+   - Options:
+     * cache: "~/.crc/cache/crc_*.crcbundle (CRC cache directory) - Recommended"
+     * downloads: "~/Downloads/crc_*.crcbundle"
+     * custom: "Specify custom path"
+   
+   **Question 4: Pull Secret Location**
+   - Header: "Pull Secret"
+   - Question: "Where is the pull secret file located?"
+   - multiSelect: false (single selection)
+   - Options:
+     * downloads: "~/Downloads/crc-pull-secret (default) - Recommended"
+     * custom: "Specify custom path"
+
+3. **Handle custom paths** (if user selected "custom" for any location):
+   - For each "custom" selection, the user will provide the path via "Other" option
+   - Extract the custom path from the user's response
+   - Validate that custom paths exist before proceeding
+   - Store paths for use in environment variables
+
+4. **Build CRC from source**:
+   - Run `make cross` to build CRC binaries for all platforms
+   - This will create platform-specific binaries in the `out/` directory:
+     * Linux AMD64: `out/linux-amd64/crc`
+     * Linux ARM64: `out/linux-arm64/crc`
+     * macOS AMD64: `out/macos-amd64/crc`
+     * macOS ARM64: `out/macos-arm64/crc`
+     * Windows AMD64: `out/windows-amd64/crc.exe`
+   - Display build progress to user
+   - Verify the binary was built successfully for the target platform
+
+5. **Determine CRC binary directory**:
+   - Based on the selected platform, set the binary directory:
+     * If platform is "current": detect using `go env GOOS` and `go env GOARCH`
+     * If platform is "linux": use `--crc-binary=out/linux-amd64/`
+     * If platform is "darwin": detect arch with `uname -m` (arm64 or amd64) and use `--crc-binary=out/macos-<arch>/`
+     * If platform is "windows": use `--crc-binary=out/windows-amd64/`
+   - Note: CRC_BINARY should be the directory path, not including the binary name itself
+   - Verify the binary exists in the determined directory (e.g., `out/linux-amd64/crc` or `out/windows-amd64/crc.exe`)
+
+6. **Prepare test environment**:
+   - Based on bundle location selection:
+     * If "cache": list available bundles in ~/.crc/cache and let user select or provide path
+     * If "downloads": list available bundles in ~/Downloads and let user select or provide path
+     * If "custom": ask user for the path
+   - Verify the bundle file exists at the specified location
+   - Verify the pull secret file exists at the specified location
+   - Inform user about any missing prerequisites
+
+7. **Clean CRC state** (IMPORTANT - Required for most tests):
+   - Run `crc cleanup` using the built binary (e.g., `out/linux-amd64/crc cleanup`)
+   - This ensures tests start with a clean state (no existing VM, no stale configuration)
+   - **Critical for @basic tests** which expect an unconfigured system
+   - Note: Cleanup may require sudo password for removing system files:
+     * `/etc/udev/rules.d/99-crc-vsock.rules` (udev rules)
+     * `/etc/modules-load.d/vhost_vsock.conf` (vsock module config)
+   - If cleanup fails due to missing sudo access at the end of test run, it's acceptable (cleanup failure in tests is cosmetic)
+   - Use absolute paths (not tilde) for bundle and pull secret locations to avoid path expansion issues
+
+8. **Build test command**:
+   
+   Construct the make command as follows:
+   
+   a. Start with base: `make e2e`
+   
+   b. Build tag filter:
+   - If platform is "current": use `$(GOOS)` or detect with `go env GOOS`
+   - If single feature: `--godog.tags="<os> && @<feature>"`
+   - If multiple features: `--godog.tags="<os> && (@feature1 || @feature2 || @feature3)"`
+   - Always include OS tag AND feature tag(s)
+   
+   c. Build environment variables based on user selections:
+   - Always set `CRC_BINARY` to the platform-specific binary directory from step 5 (format: `--crc-binary=/absolute/path/to/out/<platform>-<arch>/`)
+   - For bundle location:
+     * IMPORTANT: Use absolute paths (not tilde ~) to avoid path expansion issues
+     * If "cache": prompt user to select specific bundle from ~/.crc/cache or set `BUNDLE_LOCATION=--bundle-location=/absolute/path/to/.crc/cache/<bundle_file>`
+     * If "downloads": prompt user to select specific bundle from ~/Downloads or set `BUNDLE_LOCATION=--bundle-location=/absolute/path/to/Downloads/<bundle_file>`
+     * If "custom": set `BUNDLE_LOCATION=--bundle-location=<absolute_custom_path>`
+   - For pull secret location:
+     * IMPORTANT: Use absolute paths (not tilde ~)
+     * If "downloads": set `PULL_SECRET_FILE=--pull-secret-file=/absolute/path/to/Downloads/crc-pull-secret`
+     * If "custom": set `PULL_SECRET_FILE=--pull-secret-file=<absolute_custom_path>`
+   - Note: All environment variables must include their flag prefix and use absolute paths
+   
+   d. Combine into final command:
+   ```bash
+   CRC_BINARY=--crc-binary=<binary_dir> [OTHER_ENV_VARS] make e2e GODOG_OPTS="--godog.tags=\"<constructed_tags>\""
+   ```
+   
+   Note: `<binary_dir>` is the absolute directory path (e.g., `/home/user/crc/out/linux-amd64/`), not the full binary path
+   
+   e. Example commands:
+   ```bash
+   # Single feature on Linux with built binary and bundle from cache (using absolute paths)
+   CRC_BINARY=--crc-binary=/home/user/crc/out/linux-amd64/ BUNDLE_LOCATION=--bundle-location=/home/user/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle PULL_SECRET_FILE=--pull-secret-file=/home/user/pull-secret make e2e GODOG_OPTS="--godog.tags=\"linux && @basic\""
+   
+   # Multiple features on macOS with built binary
+   CRC_BINARY=--crc-binary=/Users/user/crc/out/macos-arm64/ BUNDLE_LOCATION=--bundle-location=/Users/user/.crc/cache/crc_vfkit_4.21.8_arm64.crcbundle make e2e GODOG_OPTS="--godog.tags=\"darwin && (@basic || @config || @minimal)\""
+   ```
+
+9. **Execute tests**:
+   - Run the test command
+   - Display progress and results to user
+   - Provide clear feedback on pass/fail status
+   - Note: If the final test cleanup step fails due to sudo password requirement, this is acceptable
+     * The test suite runs its own cleanup at the end which may fail in non-interactive environments
+     * Focus on the actual test results (scenarios/steps passed), not cleanup failure
+     * A test is considered successful if all scenarios passed, even if final cleanup failed
+
+## Environment Variables
+
+These are set automatically by the skill:
+- `CRC_BINARY`: Directory path to platform-specific CRC binary built from source (e.g., `--crc-binary=out/linux-amd64/`)
+- `PULL_SECRET_FILE`: Path to pull secret (e.g., `--pull-secret-file=~/pull-secret` or default if not specified)
+- `BUNDLE_LOCATION`: Path to CRC bundle (e.g., `--bundle-location=~/.crc/cache/crc_*.crcbundle`)
+- `CLEANUP_HOME`: Whether to cleanup home directory (default: not set)
+
+Note: All environment variables include the flag prefix (e.g., `--crc-binary=`, `--bundle-location=`, `--pull-secret-file=`)
+
+## Example Usage
+
+```bash
+# Interactive mode
+/e2e-test
+
+# With feature argument
+/e2e-test basic
+
+# With feature and OS
+/e2e-test config linux
+
+# Multiple features
+/e2e-test basic,config darwin
+```
+
+## Important Notes
+
+### Test Duration
+- Tests can take 10-180 minutes depending on feature selection
+- Full test suite (@basic) typically takes ~30 minutes
+- Multiple features will run sequentially
+
+### Prerequisites
+- **Build environment**: Go toolchain and build dependencies for `make cross`
+- **Pull secret**: Required at ~/Downloads/crc-pull-secret (or custom path)
+- **CRC bundle**: Required at ~/.crc/cache/crc_*.crcbundle, ~/Downloads/crc_*.crcbundle, or custom path
+- **Clean state**: Most tests expect no existing CRC cluster
+- **System resources**: Ensure adequate RAM (16GB+ recommended for monitoring tests)
+- **Build time**: `make cross` takes ~5-10 minutes to compile binaries for all platforms
+
+### Platform-Specific Considerations
+- `@cert_rotation` only runs on Linux
+- `@running_cluster_tests` requires a cluster to already be running
+- Windows tests require `.exe` extension handling
+- macOS supports both arm64 and amd64 architectures
+- `@minimal` test requires MicroShift bundle (crc_microshift_*.crcbundle), not OpenShift bundle
+
+### Key Technical Notes
+- **Path Expansion**: Always use absolute paths (e.g., `/home/user/.crc/cache/...`) instead of tilde paths (`~/.crc/cache/...`) to avoid shell expansion issues in the test framework
+- **Cleanup Requirements**: Running `crc cleanup` before tests ensures clean state, especially critical for `@basic` tests that check for unconfigured system
+- **Sudo Access**: Cleanup operations require sudo to remove system files (udev rules, vsock config); have password ready
+- **Test Cleanup Failures**: If the test suite's final cleanup step fails due to sudo, it's cosmetic - focus on scenario/step pass rates
+
+### Before Running
+The skill will automatically:
+1. Build CRC from source using `make cross`
+2. Verify the binary exists for the target platform
+3. Check that bundle and pull secret files exist
+4. **Run `crc cleanup`** to ensure clean state (may require sudo password)
+
+The user should ensure:
+1. **Sudo access available** (cleanup requires sudo to remove system files like udev rules)
+2. Pull secret and bundle files are available (check ~/.crc/cache or ~/Downloads)
+3. Adequate disk space for build artifacts (~500MB in `out/` directory)
+4. **No active CRC cluster** is running (will be cleaned up automatically)
+
+### Execution Behavior
+- **Build phase**: `make cross` compiles binaries for all platforms (~5-10 minutes)
+- **Cleanup phase**: `crc cleanup` removes existing CRC state (may prompt for sudo password)
+- **Test phase**: Tests run with `--timeout=180m` (3 hours max)
+- Output is verbose (`-v` flag enabled)
+- Tests may modify CRC configuration
+- Some tests require internet connectivity
+- Failed tests will show detailed error output
+- The skill always uses the freshly built binary from the `out/` directory
+- **IMPORTANT**: Always use absolute paths (not `~`) for bundle and pull secret locations to avoid path expansion issues

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: e2e-test
+description: Run CRC end-to-end tests for specific features and operating systems
+argument-hint: [feature] [os]
+allowed-tools: [AskUserQuestion, Bash, Read, Grep]
+---
+
+# CRC E2E Test Runner
+
+This skill runs CRC end-to-end tests with interactive feature and OS selection.
+
+## Arguments
+
+User provided arguments: $ARGUMENTS
+
+## Available Features
+
+The CRC e2e test suite includes these features:
+- **basic**: Core CRC lifecycle tests (version, help, setup, start, stop, delete)
+- **config**: Configuration management tests
+- **minimal**: Minimal feature set tests (requires MicroShift bundle)
+- **story_openshift**: OpenShift-specific story tests
+- **story_microshift**: MicroShift-specific story tests
+- **story_application_deployment**: Application deployment scenarios
+- **running_cluster_tests**: Tests for running cluster operations
+- **cert_rotation**: Certificate rotation tests (Linux only)
+- **story_manpages**: Man page generation tests
+
+## Available OS Platforms
+
+- **linux**: Linux platform tests
+- **darwin**: macOS platform tests
+- **windows**: Windows platform tests
+
+## Instructions
+
+When this skill is invoked:
+
+1. **Parse arguments** (if provided):
+   - If arguments include a feature name and/or OS, use those
+   - Otherwise, proceed to interactive selection
+
+2. **Interactive selection** (if no arguments or partial arguments):
+   
+   Use AskUserQuestion tool with these specific questions:
+   
+   **Question 1: Feature Selection**
+   - Header: "Feature"
+   - Question: "Which e2e test feature(s) do you want to run?"
+   - multiSelect: true (allow multiple features)
+   - Options:
+     * basic: "Core CRC lifecycle tests - setup, start, stop, delete, version, status (~30 min)"
+     * config: "Configuration management and property validation tests (~15 min)"
+     * minimal: "Quick minimal test suite for fast validation (~10 min, requires MicroShift bundle)"
+     * story_openshift: "OpenShift-specific features and scenarios (~45 min)"
+     * story_microshift: "MicroShift-specific features and scenarios (~45 min)"
+     * story_application_deployment: "Application deployment workflows (~30 min)"
+     * running_cluster_tests: "Tests for running cluster operations (~20 min, requires running cluster)"
+     * cert_rotation: "Certificate rotation scenarios (~25 min, Linux only)"
+     * story_manpages: "Man page generation and validation (~10 min)"
+   
+   **Question 2: OS Platform Selection**
+   - Header: "Platform"
+   - Question: "Which OS platform do you want to test?"
+   - multiSelect: false (single selection)
+   - Options:
+     * current: "Use current platform ($(GOOS)) - Recommended"
+     * linux: "Linux platform (most features supported)"
+     * darwin: "macOS platform (arm64 and amd64)"
+     * windows: "Windows platform (amd64 only)"
+   
+   **Question 3: Bundle Location**
+   - Header: "Bundle"
+   - Question: "Where is the CRC bundle located?"
+   - multiSelect: false (single selection)
+   - Options:
+     * cache: "~/.crc/cache/crc_*.crcbundle (CRC cache directory) - Recommended"
+     * downloads: "~/Downloads/crc_*.crcbundle"
+     * custom: "Specify custom path"
+   
+   **Question 4: Pull Secret Location**
+   - Header: "Pull Secret"
+   - Question: "Where is the pull secret file located?"
+   - multiSelect: false (single selection)
+   - Options:
+     * downloads: "~/Downloads/crc-pull-secret (default) - Recommended"
+     * custom: "Specify custom path"
+
+3. **Handle custom paths** (if user selected "custom" for any location):
+   - For each "custom" selection, the user will provide the path via "Other" option
+   - Extract the custom path from the user's response
+   - Validate that custom paths exist before proceeding
+   - Store paths for use in environment variables
+
+4. **Build CRC from source**:
+   - Run `make cross` to build CRC binaries for all platforms
+   - This will create platform-specific binaries in the `out/` directory:
+     * Linux AMD64: `out/linux-amd64/crc`
+     * Linux ARM64: `out/linux-arm64/crc`
+     * macOS AMD64: `out/macos-amd64/crc`
+     * macOS ARM64: `out/macos-arm64/crc`
+     * Windows AMD64: `out/windows-amd64/crc.exe`
+   - Display build progress to user
+   - Verify the binary was built successfully for the target platform
+
+5. **Determine CRC binary directory**:
+   - Based on the selected platform, set the binary directory:
+     * If platform is "current": detect using `go env GOOS` and `go env GOARCH`
+     * If platform is "linux": use `--crc-binary=out/linux-amd64/`
+     * If platform is "darwin": detect arch with `uname -m` (returns `arm64` or `x86_64`); normalize `x86_64` to `amd64` and use `--crc-binary=out/macos-<arch>/`
+     * If platform is "windows": use `--crc-binary=out/windows-amd64/`
+   - Note: CRC_BINARY should be the directory path, not including the binary name itself
+   - Verify the binary exists in the determined directory (e.g., `out/linux-amd64/crc` or `out/windows-amd64/crc.exe`)
+
+6. **Prepare test environment**:
+   - Based on bundle location selection:
+     * If "cache": list available bundles in ~/.crc/cache and let user select or provide path
+     * If "downloads": list available bundles in ~/Downloads and let user select or provide path
+     * If "custom": ask user for the path
+   - Verify the bundle file exists at the specified location
+   - Verify the pull secret file exists at the specified location
+   - Inform user about any missing prerequisites
+
+7. **Clean CRC state** (IMPORTANT - Required for most tests):
+   - If selected features include `running_cluster_tests`, skip `crc cleanup` and verify the cluster is running (`crc status`) instead.
+   - Otherwise, run `crc cleanup` using the built binary (e.g., `out/linux-amd64/crc cleanup`)
+   - This ensures tests start with a clean state (no existing VM, no stale configuration)
+   - **Critical for @basic tests** which expect an unconfigured system
+   - Note: Cleanup may require sudo password for removing system files:
+     * `/etc/udev/rules.d/99-crc-vsock.rules` (udev rules)
+     * `/etc/modules-load.d/vhost_vsock.conf` (vsock module config)
+   - If cleanup fails due to missing sudo access at the end of test run, it's acceptable (cleanup failure in tests is cosmetic)
+   - Use absolute paths (not tilde) for bundle and pull secret locations to avoid path expansion issues
+
+8. **Build test command**:
+   
+   Construct the make command as follows:
+   
+   a. Start with base: `make e2e`
+   
+   b. Build tag filter:
+   - If platform is "current": use `$(GOOS)` or detect with `go env GOOS`
+   - If single feature: `--godog.tags="<os> && @<feature>"`
+   - If multiple features: `--godog.tags="<os> && (@feature1 || @feature2 || @feature3)"`
+   - Always include OS tag AND feature tag(s)
+   
+   c. Build environment variables based on user selections:
+   - Always set `CRC_BINARY` to the platform-specific binary directory from step 5 (format: `--crc-binary=/absolute/path/to/out/<platform>-<arch>/`)
+   - For bundle location:
+     * IMPORTANT: Use absolute paths (not tilde ~) to avoid path expansion issues
+     * If "cache": prompt user to select specific bundle from ~/.crc/cache or set `BUNDLE_LOCATION=--bundle-location=/absolute/path/to/.crc/cache/<bundle_file>`
+     * If "downloads": prompt user to select specific bundle from ~/Downloads or set `BUNDLE_LOCATION=--bundle-location=/absolute/path/to/Downloads/<bundle_file>`
+     * If "custom": set `BUNDLE_LOCATION=--bundle-location=<absolute_custom_path>`
+   - For pull secret location:
+     * IMPORTANT: Use absolute paths (not tilde ~)
+     * If "downloads": set `PULL_SECRET_FILE=--pull-secret-file=/absolute/path/to/Downloads/crc-pull-secret`
+     * If "custom": set `PULL_SECRET_FILE=--pull-secret-file=<absolute_custom_path>`
+   - Note: All environment variables must include their flag prefix and use absolute paths
+   
+   d. Combine into final command:
+   ```bash
+   CRC_BINARY=--crc-binary=<binary_dir> [OTHER_ENV_VARS] make e2e GODOG_OPTS="--godog.tags=\"<constructed_tags>\""
+   ```
+   
+   Note: `<binary_dir>` is the absolute directory path (e.g., `/home/user/crc/out/linux-amd64/`), not the full binary path
+   
+   e. Example commands:
+   ```bash
+   # Single feature on Linux with built binary and bundle from cache (using absolute paths)
+   CRC_BINARY=--crc-binary=/home/user/crc/out/linux-amd64/ BUNDLE_LOCATION=--bundle-location=/home/user/.crc/cache/crc_libvirt_4.21.8_amd64.crcbundle PULL_SECRET_FILE=--pull-secret-file=/home/user/pull-secret make e2e GODOG_OPTS="--godog.tags=\"linux && @basic\""
+   
+   # Multiple features on macOS with built binary
+   CRC_BINARY=--crc-binary=/Users/user/crc/out/macos-arm64/ BUNDLE_LOCATION=--bundle-location=/Users/user/.crc/cache/crc_vfkit_4.21.8_arm64.crcbundle make e2e GODOG_OPTS="--godog.tags=\"darwin && (@basic || @config || @minimal)\""
+   ```
+
+9. **Execute tests**:
+   - Run the test command
+   - Display progress and results to user
+   - Provide clear feedback on pass/fail status
+   - Note: If the final test cleanup step fails due to sudo password requirement, this is acceptable
+     * The test suite runs its own cleanup at the end which may fail in non-interactive environments
+     * Focus on the actual test results (scenarios/steps passed), not cleanup failure
+     * A test is considered successful if all scenarios passed, even if final cleanup failed
+
+## Environment Variables
+
+These are set automatically by the skill:
+- `CRC_BINARY`: Directory path to platform-specific CRC binary built from source (e.g., `--crc-binary=/home/user/crc/out/linux-amd64/`)
+- `PULL_SECRET_FILE`: Required path to pull secret (e.g., `--pull-secret-file=/home/user/pull-secret`)
+- `BUNDLE_LOCATION`: Path to CRC bundle (e.g., `--bundle-location=/home/user/.crc/cache/crc_*.crcbundle`)
+- `CLEANUP_HOME`: Whether to cleanup home directory (default: not set)
+
+Note: All environment variables include the flag prefix (e.g., `--crc-binary=`, `--bundle-location=`, `--pull-secret-file=`)
+
+## Example Usage
+
+```bash
+# Interactive mode
+/e2e-test
+
+# With feature argument
+/e2e-test basic
+
+# With feature and OS
+/e2e-test config linux
+
+# Multiple features
+/e2e-test basic,config darwin
+```
+
+## Important Notes
+
+### Test Duration
+- Tests can take 10-180 minutes depending on feature selection
+- Full test suite (@basic) typically takes ~30 minutes
+- Multiple features will run sequentially
+
+### Prerequisites
+- **Build environment**: Go toolchain and build dependencies for `make cross`
+- **Pull secret**: Required at ~/Downloads/crc-pull-secret (or custom path)
+- **CRC bundle**: Required at ~/.crc/cache/crc_*.crcbundle, ~/Downloads/crc_*.crcbundle, or custom path
+- **Clean state**: Most tests expect no existing CRC cluster
+- **System resources**: Ensure adequate RAM (16GB+ recommended for monitoring tests)
+- **Build time**: `make cross` takes ~5-10 minutes to compile binaries for all platforms
+
+### Platform-Specific Considerations
+- `@cert_rotation` only runs on Linux
+- `@running_cluster_tests` requires a cluster to already be running
+- Windows tests require `.exe` extension handling
+- macOS supports both arm64 and amd64 architectures
+- `@minimal` test requires MicroShift bundle (crc_microshift_*.crcbundle), not OpenShift bundle
+
+### Key Technical Notes
+- **Path Expansion**: Always use absolute paths (e.g., `/home/user/.crc/cache/...`) instead of tilde paths (`~/.crc/cache/...`) to avoid shell expansion issues in the test framework
+- **Cleanup Requirements**: Running `crc cleanup` before tests ensures clean state, especially critical for `@basic` tests that check for unconfigured system
+- **Sudo Access**: Cleanup operations require sudo to remove system files (udev rules, vsock config); have password ready
+- **Test Cleanup Failures**: If the test suite's final cleanup step fails due to sudo, it's cosmetic - focus on scenario/step pass rates
+
+### Before Running
+The skill will automatically:
+1. Build CRC from source using `make cross`
+2. Verify the binary exists for the target platform
+3. Check that bundle and pull secret files exist
+4. **Run `crc cleanup`** to ensure clean state (may require sudo password)
+
+The user should ensure:
+1. **Sudo access available** (cleanup requires sudo to remove system files like udev rules)
+2. Pull secret and bundle files are available (check ~/.crc/cache or ~/Downloads)
+3. Adequate disk space for build artifacts (~500MB in `out/` directory)
+4. **No active CRC cluster** is running (will be cleaned up automatically)
+
+### Execution Behavior
+- **Build phase**: `make cross` compiles binaries for all platforms (~5-10 minutes)
+- **Cleanup phase**: `crc cleanup` removes existing CRC state (may prompt for sudo password)
+- **Test phase**: Tests run with `--timeout=180m` (3 hours max)
+- Output is verbose (`-v` flag enabled)
+- Tests may modify CRC configuration
+- Some tests require internet connectivity
+- Failed tests will show detailed error output
+- The skill always uses the freshly built binary from the `out/` directory
+- **IMPORTANT**: Always use absolute paths (not `~`) for bundle and pull secret locations to avoid path expansion issues


### PR DESCRIPTION
Introduces a new Claude Code skill that provides an interactive interface for running CRC end-to-end tests with automatic build, prerequisite verification, and test execution. Includes comprehensive examples and reference documentation.

how to test this skill
----------------------------

- Open Claude using this PR
- Run `/skill` which should detect this e2e skill
- Run `/e2e-test`  and it will ask required question before running the test, for any failure you can ask why it is failed.

This skill is generated using claude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive end-to-end testing docs: usage examples, reference guide, expected outputs, troubleshooting, and advanced scenarios.

* **New Features**
  * Added an interactive and non-interactive E2E test skill to select features, platforms, and run tests with examples and environment overrides.

* **Chores**
  * Added local settings to allow specific command patterns used by the testing workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crc-org/crc/pull/5208)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->