### PR TITLE
refactor: replace adminhelper with local addHostsEntry in proxy tests

### DIFF
--- a/test/integration/hosts_unix.go
+++ b/test/integration/hosts_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package test_test
+
+import (
+	crcos "github.com/crc-org/crc/v2/pkg/os"
+)
+
+// addHostsEntry adds an entry to /etc/hosts using sudo tee.
+func addHostsEntry(ip, hostname string) error {
+	cmd := `printf '%s %s\n' "$1" "$2" | tee -a /etc/hosts > /dev/null`
+	_, _, err := crcos.RunPrivileged("adding hosts entry for proxy test", "sh", "-c", cmd, "addHostsEntry", ip, hostname)
+	return err
+}

--- a/test/integration/hosts_windows.go
+++ b/test/integration/hosts_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package test_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/crc-org/crc/v2/pkg/os/windows/powershell"
+)
+
+// addHostsEntry adds an entry to the Windows hosts file using ExecuteAsAdmin.
+func addHostsEntry(ip, hostname string) error {
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	hostsPath := filepath.Join(systemRoot, "System32", "drivers", "etc", "hosts")
+
+	entry := fmt.Sprintf("%s %s", ip, hostname)
+	cmd := fmt.Sprintf(`Add-Content -Path "%s" -Value "%s"`, hostsPath, entry)
+
+	_, _, err := powershell.ExecuteAsAdmin("adding hosts entry for proxy test", cmd)
+	return err
+}

--- a/test/integration/proxy_test.go
+++ b/test/integration/proxy_test.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/crc-org/crc/v2/pkg/crc/adminhelper"
 	crc "github.com/crc-org/crc/v2/test/extended/crc/cmd"
 	"github.com/crc-org/crc/v2/test/extended/util"
 	. "github.com/onsi/ginkgo/v2"
@@ -141,9 +140,8 @@ var _ = Describe("", Serial, Ordered, Label("openshift-preset", "goproxy"), func
 		})
 
 		It("add host.crc.testing to host's /etc/hosts", func() {
-			// After setup, adminhelper is available
 			// Add host.crc.testing -> 127.0.0.1 so host can resolve it to localhost proxy
-			err := adminhelper.AddToHostsFile("127.0.0.1", "host.crc.testing")
+			err := addHostsEntry("127.0.0.1", "host.crc.testing")
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
552bd4b2846bf5ca2a90de82c5cb3a3f82c23cfc added adminhelper implementation for integration test but it fails because admin helper path is depend on crc binary path and integration test is also standalone built and run in testing machine so it is not able to get right admin helper binary. This PR remove current implementation and add cross-platform hosts file modification directly in the test, supporting Windows, Linux, and macOS.

Note: It is assume that test on windows have admin rights, for mac/linux we are using sudo but in windows it might be problem to have UAC prompt.



## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for hosts file management by consolidating helper functions into local test utilities, with platform-specific implementations for Unix/Linux and Windows systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes #5124