### PR TITLE
CI: update mapt version to v0.12.1

### DIFF
--- a/.github/workflows/windows-qe-tpl.yml
+++ b/.github/workflows/windows-qe-tpl.yml
@@ -93,7 +93,7 @@ jobs:
           -e ARM_CLIENT_SECRET='${{secrets.ARM_CLIENT_SECRET}}' \
           -e AZURE_STORAGE_ACCOUNT='${{ secrets.AZURE_STORAGE_ACCOUNT }}' \
           -e AZURE_STORAGE_KEY='${{ secrets.AZURE_STORAGE_KEY }}' \
-          quay.io/redhat-developer/mapt:v0.9.9 azure \
+          quay.io/redhat-developer/mapt:v0.12.1 azure \
             windows create \
             --project-name 'windows-desktop-${{ env.windows-version }}-${{ env.windows-featurepack }}-${{inputs.qe-type}}-${{inputs.preset}}' \
             --backed-url azblob://crc-qenvs-state/${{ github.repository }}-${{ github.run_id }} \
@@ -211,7 +211,7 @@ jobs:
           -e ARM_CLIENT_SECRET='${{secrets.ARM_CLIENT_SECRET}}' \
           -e AZURE_STORAGE_ACCOUNT='${{ secrets.AZURE_STORAGE_ACCOUNT }}' \
           -e AZURE_STORAGE_KEY='${{ secrets.AZURE_STORAGE_KEY }}' \
-          quay.io/redhat-developer/mapt:v0.9.9 azure \
+          quay.io/redhat-developer/mapt:v0.12.1 azure \
             windows destroy \
             --project-name 'windows-desktop-${{ env.windows-version }}-${{ env.windows-featurepack }}-${{inputs.qe-type}}-${{inputs.preset}}' \
             --backed-url azblob://crc-qenvs-state/${{ github.repository }}-${{ github.run_id }}


### PR DESCRIPTION
Current used version of mapt have issue to provision the windows machine which is fixed by https://github.com/redhat-developer/mapt/pull/761 in v0.12.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image version used in Windows quality assurance workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->