### PR TITLE
test: Force stop

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -63,7 +63,7 @@ Feature: Basic test
         And ensuring user is logged in succeeds
         Then with up to "12" retries with wait period of "30s" command "oc get pods -n openshift-monitoring" output matches ".*cluster-monitoring-operator-\w+-\w+\ *1/1\ *Running.*"
         # stop
-        When executing "crc stop"
+        When executing "crc stop -f"
         Then stdout should match "(.*)[Ss]topped the instance"
         And executing "oc whoami" fails
         And kubeconfig is cleaned up

--- a/test/e2e/features/running_cluster_tests.feature
+++ b/test/e2e/features/running_cluster_tests.feature
@@ -19,7 +19,7 @@ Feature: Test scenarios on a running cluster
 
     @linux @windows @darwin @cleanup
     Scenario: Override default developer password should be reflected during crc start
-        Given executing "crc stop" succeeds
+        Given executing "crc stop -f" succeeds
         And setting config property "developer-password" to value "secret-dev" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"

--- a/test/e2e/features/story_microshift.feature
+++ b/test/e2e/features/story_microshift.feature
@@ -38,7 +38,7 @@ Feature: Microshift test stories
 		Then executing "curl -s http://httpd-example-testproj.apps.crc.testing" succeeds
 		And stdout should contain "Hello CRC!"
 		And record timestamp "stop"
-		When executing "crc stop" succeeds
+		When executing "crc stop -f" succeeds
 		And get memory data "After stop"
 		And record timestamp "start again"
 		And starting CRC with default bundle succeeds

--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -30,7 +30,7 @@ Feature: 4 Openshift stories
 		And stdout should contain "Hello CRC!"
 		And get memory data "After deployment"
 		And record timestamp "stop"
-		When executing "crc stop" succeeds
+		When executing "crc stop -f" succeeds
 		And get memory data "After stop"
 		And record timestamp "start again"
 		And starting CRC with default bundle succeeds


### PR DESCRIPTION
## Description

crc stop might not finish gracefully (in 2 min), so force it to avoid unexpected errors.

If stop is not part of the test, we should just force it

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test scenarios to use the force flag when stopping the cluster, ensuring consistent test execution behavior across multiple test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->