### PR TITLE
Update OCP to 4.21.10 (stable channel)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: install
 
 SHELL := /bin/bash -o pipefail
 
-OPENSHIFT_VERSION ?= 4.21.8
+OPENSHIFT_VERSION ?= 4.21.10
 OKD_VERSION ?= 4.21.0-okd-scos.8
 MICROSHIFT_VERSION ?= 4.21.7
 BUNDLE_EXTENSION = crcbundle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift version to 4.21.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->