### PR TITLE
Force flag trigger kill command too

### DIFF
--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -37,12 +37,7 @@ func stopMachine(client machine.Client, interactive, force bool) (bool, error) {
 		if !interactive && !force {
 			return false, err
 		}
-		// Here we are checking the VM state and if it is still running then
-		// Ask user to forcefully power off it.
-		if vmState == state.Running {
-			// Most of the time force kill don't work and libvirt throw
-			// Device or resource busy error. To make sure we give some
-			// graceful time to cluster before kill it.
+		if vmState != state.Stopped {
 			yes := input.PromptUserForYesOrNo("Do you want to force power off", force)
 			if yes {
 				err := client.PowerOff()

--- a/cmd/crc/cmd/stop_test.go
+++ b/cmd/crc/cmd/stop_test.go
@@ -41,3 +41,9 @@ func TestStopWithForceJSONError(t *testing.T) {
 	assert.NoError(t, runStop(out, fakemachine.NewFailingClient(), false, true, jsonFormat))
 	assert.JSONEq(t, `{"success": false, "forced": true, "error": "poweroff failed"}`, out.String())
 }
+
+func TestStopWithForceWhenVMInErrorState(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, runStop(out, fakemachine.NewStopFailsInErrorStateClient(), false, true, jsonFormat))
+	assert.JSONEq(t, `{"success": false, "forced": true, "error": "poweroff failed"}`, out.String())
+}

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -20,8 +20,16 @@ func NewFailingClient() *Client {
 	}
 }
 
+func NewStopFailsInErrorStateClient() *Client {
+	return &Client{
+		Failing:      true,
+		StopRetState: state.Error,
+	}
+}
+
 type Client struct {
-	Failing bool
+	Failing      bool
+	StopRetState state.State
 }
 
 var DummyClusterConfig = types.ClusterConfig{
@@ -90,7 +98,11 @@ func (c *Client) Start(_ context.Context, _ types.StartConfig) (*types.StartResu
 
 func (c *Client) Stop() (state.State, error) {
 	if c.Failing {
-		return state.Running, errors.New("stop failed")
+		retState := state.Running
+		if c.StopRetState != "" {
+			retState = c.StopRetState
+		}
+		return retState, errors.New("stop failed")
 	}
 	return state.Stopped, nil
 }


### PR DESCRIPTION
## Description

command like crc stop -f might end into a suggestion to kill crc by user. Feels more natural that --force do that for user.

It does whenever vm state is not Stopped instead of only if vm status is Running, which ignores unknown status

Relates to: #5222 .

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [x] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved force shutdown behavior to handle VMs in any non-stopped state, not just running VMs.
  * Enhanced error handling when force stopping a VM that encounters errors during shutdown, providing clearer failure feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->