### PR TITLE
CI: add --skip-guest-setup arg for testing-farm cli

### DIFF
--- a/.github/workflows/linux-qe-template.yml
+++ b/.github/workflows/linux-qe-template.yml
@@ -91,7 +91,7 @@ jobs:
 
           # reserve machine from testing farm
           export TESTING_FARM_API_TOKEN=${TESTING_FARM_API_TOKEN}
-          testing-farm reserve --compose Fedora-latest-aarch64 --duration 480 --arch aarch64 --hardware memory='>= 16 GB' --hardware virtualization.is-supported='true' --no-autoconnect | tee info
+          testing-farm reserve --skip-guest-setup --compose Fedora-latest-aarch64 --duration 480 --arch aarch64 --hardware memory='>= 16 GB' --hardware virtualization.is-supported='true' --no-autoconnect | tee info
           machine=`tail -n 1 info`
           echo ${machine##*@} > host
           echo crctest > username


### PR DESCRIPTION
During the discussion with testing-farm team looks like they added flag --skip-guest-setup which improve the provision time.

- https://gitlab.com/testing-farm/cli/-/merge_requests/211



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Testing Farm machine reservation configuration to optimize the testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->