### PR TITLE
Manage vmstate between stopped and started

### DIFF
--- a/pkg/drivers/libhvee/libhvee_windows.go
+++ b/pkg/drivers/libhvee/libhvee_windows.go
@@ -113,16 +113,26 @@ func (d *Driver) GetState() (state.State, error) {
 	log.Debugf("Machine: libhvee -> state: get")
 	vmState := vm.State()
 	switch vmState {
-	case hypervctl.Enabled:
-		log.Debugf("Machine: libhvee -> state: running")
+	case hypervctl.Enabled,
+		hypervctl.Starting,
+		hypervctl.ShuttingDown,
+		hypervctl.EnabledButOffline,
+		hypervctl.InTest,
+		hypervctl.Deferred,
+		hypervctl.Quiesce:
+		log.Debugf("Machine: libhvee -> state: running (%s)", vmState.String())
 		return state.Running, nil
 	case hypervctl.Disabled:
 		log.Debugf("Machine: libhvee -> state: stopped")
 		return state.Stopped, nil
+	case hypervctl.Unknown, hypervctl.Other, hypervctl.NotApplicable:
+		log.Debugf("Machine: libhvee -> state: error (%s)", vmState.String())
+		return state.Error, fmt.Errorf("unknown libhvee -> state: %s", vmState.String())
+	default:
+		vmStateName := fmt.Sprint(vmState) // guard if vmState is nil
+		log.Debugf("Machine: libhvee -> state: unexpected (%s)", vmStateName)
+		return state.Error, fmt.Errorf("not identified state (%s)", vmStateName)
 	}
-
-	log.Debugf("Machine: libhvee -> state: unknown")
-	return state.Error, fmt.Errorf("unknown state")
 }
 
 // PreCreateCheck checks that the machine creation process can be started safely.


### PR DESCRIPTION
Add more info on unmanaged status


## Description

Basically recover old implementation on hyper-v where intermediate status between stopped/started/stopped are managed as running state.

Relates to: #5222


## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes

Stop should not break on unknown state

## Testing

Start and stop crc on windows

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [x] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Hyper‑V VM state detection to treat several intermediate and transitional states as running, reducing false "stopped" reports during normal VM lifecycle changes.
  * Unexpected or unknown VM states now produce an explicit error status with clearer diagnostic text to aid troubleshooting.
  * Reduces noisy alerts and improves overall VM health reporting accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->