### PR TITLE
api: Log daemon API requests with structured fields

### DIFF
--- a/pkg/crc/api/helpers.go
+++ b/pkg/crc/api/helpers.go
@@ -84,24 +84,41 @@ func (s *server) DELETE(pattern string, handler func(c *context) error) {
 
 func (s *server) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		status := http.StatusOK
+		defer func() {
+			entry := logging.WithFields(map[string]interface{}{
+				"method": r.Method,
+				"path":   r.URL.Path,
+				"status": status,
+			})
+			if status >= http.StatusBadRequest {
+				entry.Warn("api request")
+				return
+			}
+			entry.Info("api request")
+		}()
+
 		s.routesLock.RLock()
 		route, ok := s.routes[r.URL.Path]
 		if !ok {
 			s.routesLock.RUnlock()
-			http.Error(w, "Not Found", http.StatusNotFound)
+			status = http.StatusNotFound
+			http.Error(w, "Not Found", status)
 			return
 		}
 		handler, ok := route[r.Method]
 		if !ok {
 			s.routesLock.RUnlock()
-			http.Error(w, "Not Found", http.StatusNotFound)
+			status = http.StatusNotFound
+			http.Error(w, "Not Found", status)
 			return
 		}
 		s.routesLock.RUnlock()
 
 		requestBody, err := io.ReadAll(r.Body)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			status = http.StatusInternalServerError
+			http.Error(w, err.Error(), status)
 			return
 		}
 		c := &context{
@@ -111,10 +128,12 @@ func (s *server) Handler() http.Handler {
 			url:         r.URL,
 		}
 		if err := handler(c); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			status = http.StatusInternalServerError
+			http.Error(w, err.Error(), status)
 			return
 		}
 
+		status = c.code
 		for k, v := range c.headers {
 			w.Header().Set(k, v)
 		}

--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -93,6 +93,10 @@ func Infof(s string, args ...interface{}) {
 	logrus.Infof(s, args...)
 }
 
+func WithFields(fields logrus.Fields) *logrus.Entry {
+	return logrus.WithFields(fields)
+}
+
 func Warn(args ...interface{}) {
 	logrus.Warn(args...)
 }


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

This PR adds structured request logs to crc daemon.

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
Sending http requests to the daemon should print the structured request in daemon:

```
INFO api request                                   method=GET path=/version remote= status=200
```

```
curl -s --unix-socket "$HOME/.crc/crc-http.sock"  http://localhost/api/version
```

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced HTTP request/response logging to reliably record method, path, remote address, and final status code for every request.
  * Improved error-status handling so responses set and log appropriate HTTP status codes (e.g., 404 for route/method issues, 500 for internal/read errors).
  * Added a helper to simplify adding structured fields to logs for clearer, consistent log entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->