### PR TITLE
preflight: Grant admin-helper cap_dac_override instead of SUID on Linux

### DIFF
--- a/pkg/crc/preflight/preflight_admin_helper_darwin.go
+++ b/pkg/crc/preflight/preflight_admin_helper_darwin.go
@@ -1,0 +1,44 @@
+//go:build darwin
+
+package preflight
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	crcos "github.com/crc-org/crc/v2/pkg/os"
+)
+
+func checkAdminHelperPrivileges(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if fi.Mode()&os.ModeSetuid == 0 {
+		return fmt.Errorf("%s does not have the SUID bit set (%s)", path, fi.Mode().String())
+	}
+	if fi.Sys().(*syscall.Stat_t).Uid != 0 {
+		return fmt.Errorf("%s is not owned by root", path)
+	}
+
+	return nil
+}
+
+func configureAdminHelperPrivileges(path string) error {
+	logging.Debugf("Making %s suid", path)
+
+	stdOut, stdErr, err := crcos.RunPrivileged(fmt.Sprintf("Changing ownership of %s", path), "chown", "root", path)
+	if err != nil {
+		return fmt.Errorf("unable to set ownership of %s to root: %s: %s: %w",
+			path, stdOut, stdErr, err)
+	}
+
+	/* Can't do this before the chown as the chown will reset the suid bit */
+	stdOut, stdErr, err = crcos.RunPrivileged(fmt.Sprintf("Setting suid for %s", path), "chmod", "u+s,g+x", path)
+	if err != nil {
+		return fmt.Errorf("unable to set suid bit on %s: %s: %s: %w", path, stdOut, stdErr, err)
+	}
+	return nil
+}

--- a/pkg/crc/preflight/preflight_admin_helper_linux.go
+++ b/pkg/crc/preflight/preflight_admin_helper_linux.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package preflight
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
+	crcos "github.com/crc-org/crc/v2/pkg/os"
+)
+
+const adminHelperCapability = "cap_dac_override"
+
+func checkAdminHelperPrivileges(path string) error {
+	getcap, _, err := crcos.RunWithDefaultLocale("getcap", path)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(getcap, adminHelperCapability+"=ep") {
+		return fmt.Errorf("%s does not have the %s capability set (%s)", path, adminHelperCapability, strings.TrimSpace(getcap))
+	}
+	return nil
+}
+
+func configureAdminHelperPrivileges(path string) error {
+	logging.Debugf("Setting %s capability for %s", adminHelperCapability, path)
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if fi.Mode()&os.ModeSetuid != 0 {
+		_, _, err = crcos.RunPrivileged(fmt.Sprintf("Removing legacy SUID bit from %s", path), "chmod", "u-s", path)
+		if err != nil {
+			return fmt.Errorf("unable to remove SUID bit from %s: %w", path, err)
+		}
+	}
+
+	_, _, err = crcos.RunPrivileged(
+		fmt.Sprintf("Setting %s capability for %s", adminHelperCapability, path),
+		"setcap", adminHelperCapability+"=ep", path)
+	if err != nil {
+		return fmt.Errorf("unable to set %s capability on %s: %w", adminHelperCapability, path, err)
+	}
+	return nil
+}

--- a/pkg/crc/preflight/preflight_checks_unix.go
+++ b/pkg/crc/preflight/preflight_checks_unix.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"syscall"
 
 	"github.com/crc-org/crc/v2/pkg/crc/cache"
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
@@ -74,38 +73,6 @@ func checkIfRunningAsNormalUser() error {
 	return errors.New("crc should not be run as root")
 }
 
-func setSuid(path string) error {
-	logging.Debugf("Making %s suid", path)
-
-	stdOut, stdErr, err := crcos.RunPrivileged(fmt.Sprintf("Changing ownership of %s", path), "chown", "root", path)
-	if err != nil {
-		return fmt.Errorf("unable to set ownership of %s to root: %s: %s: %w",
-			path, stdOut, stdErr, err)
-	}
-
-	/* Can't do this before the chown as the chown will reset the suid bit */
-	stdOut, stdErr, err = crcos.RunPrivileged(fmt.Sprintf("Setting suid for %s", path), "chmod", "u+s,g+x", path)
-	if err != nil {
-		return fmt.Errorf("unable to set suid bit on %s: %s: %s: %w", path, stdOut, stdErr, err)
-	}
-	return nil
-}
-
-func checkSuid(path string) error {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if fi.Mode()&os.ModeSetuid == 0 {
-		return fmt.Errorf("%s does not have the SUID bit set (%s)", path, fi.Mode().String())
-	}
-	if fi.Sys().(*syscall.Stat_t).Uid != 0 {
-		return fmt.Errorf("%s is not owned by root", path)
-	}
-
-	return nil
-}
-
 // Check if helper executable is cached or not
 func checkAdminHelperExecutableCached() error {
 	if version.IsInstaller() {
@@ -120,7 +87,7 @@ func checkAdminHelperExecutableCached() error {
 		return errors.Wrap(err, "unexpected version of the crc-admin-helper executable")
 	}
 	logging.Debug("crc-admin-helper executable already cached")
-	return checkSuid(helper.GetExecutablePath())
+	return checkAdminHelperPrivileges(helper.GetExecutablePath())
 }
 
 func fixAdminHelperExecutableCached() error {
@@ -133,7 +100,7 @@ func fixAdminHelperExecutableCached() error {
 		return errors.Wrap(err, "Unable to download crc-admin-helper executable")
 	}
 	logging.Debug("crc-admin-helper executable cached")
-	return setSuid(helper.GetExecutablePath())
+	return configureAdminHelperPrivileges(helper.GetExecutablePath())
 }
 
 func checkSupportedCPUArch() error {


### PR DESCRIPTION
SUID root gave crc-admin-helper full root privileges whenever it ran, which is far broader than what is needed to update /etc/hosts. On Linux, configure the admin-helper binary with cap_dac_override=ep so it can bypass DAC checks for that purpose without running as UID 0.

Keep the existing SUID setup on macOS, where file capabilities are not available. During crc setup, strip a legacy SUID bit if present before applying the file capability. Users upgrading from an older install should re-run crc setup to migrate.

MacOS behavior is unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened preflight validation of admin helper privileges on macOS and Linux systems.
  * Refined privilege configuration checks during system setup to ensure proper elevation rights across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->