### PR TITLE
Update patch version of golang to 1.25.6 from 1.25.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ default: install
 # Create and update the vendor directory
 .PHONY: vendor
 vendor:
-	go mod tidy -go $(GOVERSION).0
+	go mod tidy -go $(GOVERSION).6
 	go mod vendor
 
 .PHONY: vendorcheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crc-org/crc/v2
 
-go 1.25.0
+go 1.25.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/crc-org/crc/tools
 
-go 1.25.0
+go 1.25.6
 
 require (
 	github.com/cfergeau/gomod2rpmdeps v0.0.0-20210223144124-2042c4850ca8

--- a/update-go-version.sh
+++ b/update-go-version.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 golang_base_version=$1
 echo "Updating golang version to $golang_base_version"
 
-go mod edit -go "${golang_base_version}.0"
-go mod edit -go "${golang_base_version}.0" tools/go.mod
+go mod edit -go "${golang_base_version}.6"
+go mod edit -go "${golang_base_version}.6" tools/go.mod
 
 sed -i "s,^GOVERSION = 1.[0-9]\+,GOVERSION = ${golang_base_version}," Makefile
 sed -i "s,^\(FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-\)1.[0-9]\+,\1${golang_base_version}," images/*/Dockerfile


### PR DESCRIPTION
Looks like images and common modules (go.podman.io/common) updated to use 1.25.6 as minimum version from 1.25.0 which break the updates of those modules. Currently ocp golang builder image have 1.25.7 which should work and able to update those modules.

```
$ podman run --rm registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.21 go version
go version go1.25.7 (Red Hat 1.25.7-1.el9_7) linux/amd64
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go toolchain requirement from version 1.25.0 to 1.25.6 across all project modules.
  * Build configuration and dependency management scripts updated to use the new Go version specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->