### PR TITLE
adminhelper: Pass a valid log file path to admin-helper for audit logging

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -86,6 +86,12 @@ func runPrerun(cmd *cobra.Command) error {
 	for _, str := range defaultVersion().lines() {
 		logging.Debugf("%s", str)
 	}
+
+	if cmd != daemonCmd {
+		if err := constants.EnsureAdminHelperLogFileExists(); err != nil {
+			logging.Warn("Error creating admin helper log file: ", err.Error())
+		}
+	}
 	return nil
 }
 

--- a/packaging/chocolatey/crc/tools/crcprerequisitesetup.ps1
+++ b/packaging/chocolatey/crc/tools/crcprerequisitesetup.ps1
@@ -54,7 +54,10 @@ function Install-AdminHelper([string]$AdminHelperPath) {
     if ($svc) {
         Write-Host "Red Hat OpenShift Local Admin Helper service is already installed"
     } else {
+        $logPath = Join-Path $env:USERPROFILE '.crc\admin-helper.log'
+        New-Item -ItemType File -Force -Path $logPath | Out-Null
         New-Service -Name 'crcAdminHelper' -DisplayName "Red Hat OpenShift Local Admin Helper" -Description "Perform administrative tasks for the user" -StartupType Automatic -BinaryPathName "$AdminHelperPath daemon" | Out-Null
+        New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\$CrcAdminHelperServiceName" -Name Environment -Value @("ADMIN_HELPER_LOG_FILE=$logPath") -PropertyType MultiString -Force | Out-Null
     }
     Start-Service -Name 'crcAdminHelper' -Confirm:$false -ErrorAction SilentlyContinue | Out-Null
 }

--- a/packaging/windows/product.wxs
+++ b/packaging/windows/product.wxs
@@ -98,6 +98,11 @@
                 <Component Id="AdminHelper">
                     <File Id="AdminHelper" Source=".\crc-admin-helper-windows.exe" KeyPath="yes" DiskId="1" />
                     <ServiceInstall Name="crcAdminHelper" Description="Perform administrative tasks for the user" Arguments="daemon" DisplayName="Red Hat OpenShift Local Admin Helper" ErrorControl="normal" Start="auto" Type="ownProcess" />
+                    <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\crcAdminHelper">
+                        <RegistryValue Type="multiString" Name="Environment">
+                            <MultiStringValue Value="ADMIN_HELPER_LOG_FILE=[USERFOLDER]\.crc\admin-helper.log" />
+                        </RegistryValue>
+                    </RegistryKey>
                     <ServiceControl Id="StartAdminHelperService" Name="crcAdminHelper" Start="install" Stop="both" Remove="uninstall" />
                 </Component>
                 <Component Id="BackgroundLauncher">

--- a/pkg/crc/adminhelper/hosts_unix.go
+++ b/pkg/crc/adminhelper/hosts_unix.go
@@ -9,7 +9,11 @@ import (
 )
 
 func execute(args ...string) error {
-	_, _, err := crcos.RunWithDefaultLocale(constants.AdminHelperPath(), args...)
+	adminHelperEnv := map[string]string{
+		// TODO: This should be replaced with a constant in the admin-helper package
+		"ADMIN_HELPER_LOG_FILE": constants.AdminHelperLogFilePath,
+	}
+	_, _, err := crcos.RunWithDefaultLocaleAndEnv(constants.AdminHelperPath(), adminHelperEnv, args...)
 	return err
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -27,6 +27,7 @@ const (
 	ConfigFile                = "crc.json"
 	LogFile                   = "crc.log"
 	DaemonLogFile             = "crcd.log"
+	AdminHelperLogFile        = "admin-helper.log"
 	CrcLandingPageURL         = "https://console.redhat.com/openshift/create/local" // #nosec G101
 	DefaultAdminHelperURLBase = "https://github.com/crc-org/admin-helper/releases/download/v%s/%s"
 	BackgroundLauncherURL     = "https://github.com/crc-org/win32-background-launcher/releases/download/v%s/win32-background-launcher.exe"
@@ -110,20 +111,21 @@ func GetDefaultBundle(preset crcpreset.Preset) string {
 }
 
 var (
-	CrcBaseDir         = filepath.Join(GetHomeDir(), ".crc")
-	CrcManPageDir      = filepath.Join(GetHomeDir(), ".local", "share", "man")
-	CrcBinDir          = filepath.Join(CrcBaseDir, "bin")
-	CrcOcBinDir        = filepath.Join(CrcBinDir, "oc")
-	CrcSymlinkPath     = filepath.Join(CrcBinDir, "crc")
-	ConfigPath         = filepath.Join(CrcBaseDir, ConfigFile)
-	LogFilePath        = filepath.Join(CrcBaseDir, LogFile)
-	DaemonLogFilePath  = filepath.Join(CrcBaseDir, DaemonLogFile)
-	MachineBaseDir     = CrcBaseDir
-	MachineCacheDir    = filepath.Join(MachineBaseDir, "cache")
-	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
-	DaemonSocketPath   = filepath.Join(CrcBaseDir, "crc.sock")
-	KubeconfigFilePath = filepath.Join(MachineInstanceDir, DefaultName, "kubeconfig")
-	PasswdFilePath     = filepath.Join(MachineInstanceDir, DefaultName, "passwd")
+	CrcBaseDir             = filepath.Join(GetHomeDir(), ".crc")
+	CrcManPageDir          = filepath.Join(GetHomeDir(), ".local", "share", "man")
+	CrcBinDir              = filepath.Join(CrcBaseDir, "bin")
+	CrcOcBinDir            = filepath.Join(CrcBinDir, "oc")
+	CrcSymlinkPath         = filepath.Join(CrcBinDir, "crc")
+	ConfigPath             = filepath.Join(CrcBaseDir, ConfigFile)
+	LogFilePath            = filepath.Join(CrcBaseDir, LogFile)
+	DaemonLogFilePath      = filepath.Join(CrcBaseDir, DaemonLogFile)
+	AdminHelperLogFilePath = filepath.Join(CrcBaseDir, AdminHelperLogFile)
+	MachineBaseDir         = CrcBaseDir
+	MachineCacheDir        = filepath.Join(MachineBaseDir, "cache")
+	MachineInstanceDir     = filepath.Join(MachineBaseDir, "machines")
+	DaemonSocketPath       = filepath.Join(CrcBaseDir, "crc.sock")
+	KubeconfigFilePath     = filepath.Join(MachineInstanceDir, DefaultName, "kubeconfig")
+	PasswdFilePath         = filepath.Join(MachineInstanceDir, DefaultName, "passwd")
 )
 
 func GetDefaultBundlePath(preset crcpreset.Preset) string {
@@ -178,6 +180,20 @@ func EnsureBaseDirectoriesExist() error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func EnsureAdminHelperLogFileExists() error {
+	info, err := os.Stat(AdminHelperLogFilePath)
+	if os.IsNotExist(err) {
+		return os.WriteFile(AdminHelperLogFilePath, []byte(""), 0600)
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("admin helper log path is not a regular file: %s", AdminHelperLogFilePath)
 	}
 	return nil
 }

--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -3,6 +3,7 @@ package os
 import (
 	"bytes"
 	"errors"
+	"maps"
 	"os"
 	"os/exec"
 	"strings"
@@ -62,6 +63,12 @@ var defaultLocaleEnv = map[string]string{"LC_ALL": "C", "LANG": "C"}
 
 func RunWithDefaultLocale(command string, args ...string) (string, string, error) {
 	return run(command, args, defaultLocaleEnv)
+}
+
+func RunWithDefaultLocaleAndEnv(command string, env map[string]string, args ...string) (string, string, error) {
+	localeEnv := maps.Clone(defaultLocaleEnv)
+	maps.Copy(localeEnv, env)
+	return run(command, args, localeEnv)
 }
 
 func RunWithDefaultLocalePrivate(command string, args ...string) (string, string, error) {


### PR DESCRIPTION


## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Relates to: https://github.com/crc-org/admin-helper/pull/108

This PR needs the above PR to be merged and released so CRC can use the correct env var constant from admin-helper (and a binary that writes audit logs to a file). 

On macOS/Linux, CRC doesn’t capture admin-helper stdout, so successful hosts operations produce no audit record. A dedicated log file fixes that. A separate file similar to `~/.crc/crcd.log` is needed to keep audit logs.

`crc` will create the log file, as admin-helper running with elevated permissions would create a file owned by root, which is incorrect/unhelpful.

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

#### macOS and Linux:
1. `start` succeeds after `setup`
2. `~/.crc/admin-helper.log` is created
3. `start` should emit the admin-helper logs to this file

```
cat ~/.crc/admin-helper.log
{"time":"2026-06-08T17:29:06.063571+05:30","level":"INFO","msg":"hosts modification","operation":"remove","caller":"cli:gvyas","hosts":["api.crc.testing","host.crc.testing","oauth-openshift.apps-crc.testing","console-openshift-console.apps-crc.testing","downloads-openshift-console.apps-crc.testing","canary-openshift-ingress-canary.apps-crc.testing","default-route-openshift-image-registry.apps-crc.testing"]}
{"time":"2026-06-08T17:29:06.085125+05:30","level":"INFO","msg":"hosts modification","operation":"add","caller":"cli:gvyas","ip":"127.0.0.1","hosts":["api.crc.testing","host.crc.testing","oauth-openshift.apps-crc.testing","console-openshift-console.apps-crc.testing","downloads-openshift-console.apps-crc.testing","canary-openshift-ingress-canary.apps-crc.testing","default-route-openshift-image-registry.apps-crc.testing"]}
```

#### Windows:
Tested by manually setting the environment variable for the admin-helper daemon:
```
Get-Content C:\Users\gvyas\.crc\admin-helper.log
{"time":"2026-06-08T22:01:59.6298416+05:30","level":"INFO","msg":"hosts modification","operation":"remove","caller":"\\\\.\\pipe\\crc-admin-helper","hosts":["api.crc.testing","host.crc.testing","oauth-openshift.apps-crc.testing","console-openshift-console.apps-crc.testing","downloads-openshift-console.apps-crc.testing","canary-openshift-ingress-canary.apps-crc.testing","default-route-openshift-image-registry.apps-crc.testing"]}
{"time":"2026-06-08T22:01:59.6515107+05:30","level":"INFO","msg":"hosts modification","operation":"add","caller":"\\\\.\\pipe\\crc-admin-helper","ip":"127.0.0.1","hosts":["api.crc.testing","host.crc.testing","oauth-openshift.apps-crc.testing","console-openshift-console.apps-crc.testing","downloads-openshift-console.apps-crc.testing","canary-openshift-ingress-canary.apps-crc.testing","default-route-openshift-image-registry.apps-crc.testing"]}
```


## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [x] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure a dedicated admin-helper log file is created before the helper runs.
  * Start the admin-helper with an environment variable directing logs to that file.
  * Initialization problems with the log file are now logged as warnings instead of aborting.
  * Added a utility to run commands with the default locale while allowing custom environment entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->