### PR TITLE
ai: add claude skill for release notes generation

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: release-notes
+description: Generate release notes for an OpenShift Local release in a text file following a pre-defined format
+disable-model-invocation: true
+argument-hint: [release-tag]
+effort: low
+---
+
+To prepare the release notes for an OpenShift Local (crc) release:
+
+## Pre-flight Checks
+
+1. Verify we are in the crc source code repository by checking:
+    ```bash
+    grep -q "github.com/crc-org/crc" go.mod
+    ```
+2. Verify `gh` CLI is available:
+    ```bash
+    command -v gh >/dev/null || { echo "ERROR: gh CLI not installed" >&2; exit 1; }
+    ```
+3. Ensure the tag for the release is checked out (e.g., tag name: v2.58.0):
+    ```bash
+    git describe --exact-match --tags
+    ```
+    If not on a release tag, abort with an error message.
+
+## Gather Release Information
+
+4. Determine the current release tag and automatically find the previous tag:
+    ```bash
+    CURRENT_TAG=$(git describe --exact-match --tags)
+    PREV_TAG=$(git describe --tags --abbrev=0 ${CURRENT_TAG}^)
+    ```
+
+5. Get all git logs between the previous tag and current tag:
+    ```bash
+    git log --pretty="%H %s" ${PREV_TAG}..${CURRENT_TAG}
+    ```
+
+6. From the commit descriptions, **ignore** commits that match these patterns:
+    - `build(deps):` - dependency updates
+    - `chore(deps):` - dependency updates
+    - `test:` or `^.*test.*$` - test-only changes
+    - `ci:` - CI/CD configuration changes
+    - `docs:` - documentation-only changes
+    - Any commit message indicating non-user-facing changes
+    
+    **Keep** commits that are user-facing, such as:
+    - `feat:` - new features
+    - `fix:` - bug fixes
+    - `perf:` - performance improvements
+    - `refactor:` - code refactoring with user impact
+
+7. For each relevant commit, get additional context from the associated Pull Request:
+    ```bash
+    PR_NUMBER=$(gh pr list --search "<COMMIT-SHA>" --state merged --json "number" --jq ".[].number")
+    ```
+    If no PR is found, try searching by commit message keywords or check if the commit was part of a squashed merge.
+
+8. Get PR details including title, body, and labels:
+    ```bash 
+    gh pr view ${PR_NUMBER} --json "title,body,labels" --jq '{title, body, labels: [.labels[].name]}'
+    ```
+    Use labels to identify breaking changes, features, or bug fixes if available.
+
+## Extract Version Information
+
+9. Extract the OpenShift and MicroShift bundle versions from the Makefile:
+    ```bash
+    OPENSHIFT_VERSION=$(grep "^OPENSHIFT_VERSION" Makefile | cut -d'=' -f2 | tr -d ' ')
+    MICROSHIFT_VERSION=$(grep "^MICROSHIFT_VERSION" Makefile | cut -d'=' -f2 | tr -d ' ')
+    ```
+
+10. Determine the semantic version number for the release:
+    ```bash
+    CRC_VERSION=${CURRENT_TAG#v}  # Remove 'v' prefix from tag
+    ```
+
+11. Validate all required template variables are available:
+    - `${CRC_VERSION}` - numeric version (e.g., 2.58.0)
+    - `${CURRENT_TAG}` - git tag with 'v' prefix (e.g., v2.58.0)
+    - `${OPENSHIFT_VERSION}` - OpenShift bundle version
+    - `${MICROSHIFT_VERSION}` - MicroShift bundle version
+
+## Generate Release Notes
+
+12. Create descriptive summaries for each user-facing change:
+    - Keep each summary between 10-15 words
+    - Focus on user impact, not implementation details
+    - Reference the issue number or PR number in brackets (e.g., `[4]`, `[5]`)
+
+13. Strictly follow the template format from [template.md](template.md) and write the release notes to:
+    ```
+    Output file: crc-release-notes-${CRC_VERSION}.txt
+    Example: crc-release-notes-2.58.0.txt
+    ```
+    Place the file in the repository root directory.
+
+## Validation
+
+14. Verify the generated release notes match the expected format in [sample.md](examples/sample.md):
+    - Check Subject line format
+    - Verify all version placeholders are replaced
+    - Ensure bullet points are properly formatted
+    - Confirm all reference links `[0]` through `[n]` are present and sequential
+
+15. Verify all URLs are valid and return HTTP 200:
+    ```bash
+    cat crc-release-notes-${CRC_VERSION}.txt | python3 .claude/skills/release-notes/scripts/verify.py
+    ```
+
+## Post-Generation Summary
+
+16. Provide a summary including:
+    - Total number of commits reviewed
+    - Number of user-facing changes included in release notes
+    - List of PRs/issues referenced
+    - Confirmation that all URLs are valid
+    - Output file location
+    - Next steps: "Review the release notes and send via email"
+

--- a/.agents/skills/release-notes/examples/sample.md
+++ b/.agents/skills/release-notes/examples/sample.md
@@ -1,0 +1,24 @@
+Subject: 2.53.0 Release of OpenShift Local based on OpenShift 4.19.3, MicroShift 4.19.0
+
+Hi All,
+
+We are pleased to announce the 2.53.0 [0] release of OpenShift Local
+which is based on OpenShift 4.19.3 and MicroShift 4.19.0.
+
+If you experience issues, please let us know on
+redhat-internal.slack.com (channel #forum-crc), or file an issue [1].
+
+Documentation for OpenShift Local can be found at [2] and full release
+notes can be found at [3].
+
+The most notable changes since the previous release are:
+- Improve logging level and clarify preflight check message [4]
+- In preflight checks don't error out when check fails [5]
+
+
+[0] https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/2.53.0
+[1] https://github.com/crc-org/crc/issues
+[2] https://crc.dev/docs
+[3] https://github.com/crc-org/crc/releases/tag/v2.53.0
+[4] https://github.com/crc-org/crc/issues/4794
+[5] https://github.com/crc-org/crc/pull/4803

--- a/.agents/skills/release-notes/scripts/verify.py
+++ b/.agents/skills/release-notes/scripts/verify.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Extract URLs from stdin and verify they all use HTTPS and return 200."""
+
+import ipaddress
+import re
+import socket
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+URL_PATTERN = re.compile(r'https?://[^\s\)\]\}>",]+')
+
+def extract_urls(content):
+    return URL_PATTERN.findall(content)
+
+def is_safe_host(url):
+    """
+    Validate that URL points to a safe, non-private destination.
+    Blocks private IPs, loopback, link-local, and similar unsafe targets.
+    Returns (is_safe, error_message).
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        hostname = parsed.hostname
+        if not hostname:
+            return False, "no hostname"
+
+        # Try to resolve hostname to IP and check if it's private/internal
+        try:
+            # Get all addresses for this hostname
+            addr_info = socket.getaddrinfo(hostname, None)
+            for info in addr_info:
+                ip_str = info[4][0]
+                try:
+                    ip = ipaddress.ip_address(ip_str)
+                    # Block private, loopback, link-local, multicast, and reserved ranges
+                    if (ip.is_private or ip.is_loopback or ip.is_link_local or
+                        ip.is_multicast or ip.is_reserved):
+                        return False, f"unsafe IP {ip_str} ({hostname})"
+                except ValueError:
+                    continue
+        except socket.gaierror:
+            return False, f"cannot resolve {hostname}"
+
+        return True, None
+    except Exception as e:
+        return False, f"validation error: {e}"
+
+def main():
+    content = sys.stdin.read()
+    urls = extract_urls(content)
+    if not urls:
+        print("No URLs found in input.")
+        sys.exit(1)
+
+    errors = []
+    for url in urls:
+        if not url.startswith("https://"):
+            errors.append(f"NOT HTTPS: {url}")
+            continue
+
+        # Validate host is safe before making any requests
+        is_safe, err_msg = is_safe_host(url)
+        if not is_safe:
+            errors.append(f"UNSAFE HOST ({err_msg}): {url}")
+            continue
+
+        try:
+            req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "url-verify/1.0"})
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                if resp.status != 200:
+                    errors.append(f"HTTP {resp.status}: {url}")
+                else:
+                    print(f"OK: {url}")
+        except urllib.error.HTTPError as e:
+            if e.code == 405:
+                try:
+                    req = urllib.request.Request(url, headers={"User-Agent": "url-verify/1.0"})
+                    with urllib.request.urlopen(req, timeout=10) as resp:
+                        if resp.status != 200:
+                            errors.append(f"HTTP {resp.status}: {url}")
+                        else:
+                            print(f"OK: {url}")
+                except Exception as e2:
+                    errors.append(f"FAILED ({e2}): {url}")
+            else:
+                errors.append(f"HTTP {e.code}: {url}")
+        except Exception as e:
+            errors.append(f"FAILED ({e}): {url}")
+    if errors:
+        print("\nErrors:")
+        for err in errors:
+            print(f"  {err}")
+        sys.exit(1)
+
+    print(f"\nAll {len(urls)} URLs are valid HTTPS and returned 200.")
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/release-notes/template.md
+++ b/.agents/skills/release-notes/template.md
@@ -1,0 +1,24 @@
+Subject: <crc-version> Release of OpenShift Local based on OpenShift <openshift-bundle-version>, MicroShift <microshift-bundle-version>
+
+Hi All,
+
+We are pleased to announce the <crc-version> [0] release of OpenShift Local
+which is based on OpenShift <openshift-bundle-version> and MicroShift <microshift-bundle-version>.
+
+If you experience issues, please let us know on
+redhat-internal.slack.com (channel #forum-crc), or file an issue [1].
+
+Documentation for OpenShift Local can be found at [2] and full release
+notes can be found at [3].
+
+The most notable changes since the previous release are:
+- <notable change 1>
+- <notable change 2>
+
+
+[0] https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/<crc-version>
+[1] https://github.com/crc-org/crc/issues
+[2] https://crc.dev/docs
+[3] https://github.com/crc-org/crc/releases/tag/<crc-tag>
+[4] https://github.com/crc-org/crc/issues/4794
+[5] https://github.com/crc-org/crc/pull/4803

--- a/.claude/skills/release-notes
+++ b/.claude/skills/release-notes
@@ -1,0 +1,1 @@
+../../.agents/skills/release-notes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a structured workflow to generate OpenShift Local (crc) release notes using a standardized email template and a formatted example.
  * Added automated validation for referenced links, including safety checks to prevent non-public/unsafe destinations and ensuring HTTP 200 responses.
* **Chores**
  * Consolidated release-notes skill assets into a shared location for simpler ongoing maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->