### PR TITLE
Implement logging middleware and enhance response handling

### DIFF
--- a/cmd/crc/cmd/custom_response_writer.go
+++ b/cmd/crc/cmd/custom_response_writer.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"io"
 	"net/http"
+
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
 )
 
 // CustomResponseWriter wraps the standard http.ResponseWriter and captures the response body
@@ -46,4 +49,52 @@ func interceptResponseBodyMiddleware(next http.Handler, bodyConsumer func(status
 		next.ServeHTTP(responseWriter, r)
 		bodyConsumer(responseWriter.statusCode, responseWriter.body, r)
 	})
+}
+
+// logRequestMiddleware logs every request to the daemon log file.
+func logRequestMiddleware(next http.Handler, label string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestBody, err := readRequestBodyForLogging(r)
+		if err != nil {
+			logging.Warnf("failed to read request body for %s %s: %v", r.Method, r.URL.Path, err)
+		}
+
+		var responseWriter *CustomResponseWriter
+		if crw, ok := w.(*CustomResponseWriter); ok {
+			responseWriter = crw
+		} else {
+			responseWriter = NewCustomResponseWriter(w)
+		}
+		next.ServeHTTP(responseWriter, r)
+		logRequest(label, responseWriter.statusCode, r, requestBody)
+	})
+}
+
+func readRequestBodyForLogging(r *http.Request) ([]byte, error) {
+	if r.Method != http.MethodPost || r.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return body, nil
+}
+
+func logRequest(label string, statusCode int, r *http.Request, requestBody []byte) {
+	fields := map[string]interface{}{
+		"method": r.Method,
+		"path":   r.URL.Path,
+		"status": statusCode,
+	}
+	if r.Method == http.MethodPost {
+		fields["body"] = string(requestBody)
+	}
+	entry := logging.WithFields(fields)
+	if statusCode >= http.StatusBadRequest {
+		entry.Warn(label)
+		return
+	}
+	entry.Info(label)
 }

--- a/cmd/crc/cmd/custom_response_writer_test.go
+++ b/cmd/crc/cmd/custom_response_writer_test.go
@@ -3,12 +3,38 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+type logrusCaptureHook struct {
+	entries []logrus.Entry
+}
+
+func (h *logrusCaptureHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *logrusCaptureHook) Fire(entry *logrus.Entry) error {
+	h.entries = append(h.entries, *entry)
+	return nil
+}
+
+func withLogrusCaptureHook(t *testing.T) *logrusCaptureHook {
+	t.Helper()
+	hook := &logrusCaptureHook{}
+	logrus.AddHook(hook)
+	t.Cleanup(func() {
+		logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
+	})
+	return hook
+}
 
 type TestHandler struct {
 }
@@ -48,4 +74,67 @@ func TestLogResponseBodyMiddlewareCapturesResponseAsExpected(t *testing.T) {
 	assert.Equal(t, int64(8), bytesRead)
 	assert.Equal(t, "Testing!", responseBody.String())
 	assert.Equal(t, "Testing!", interceptedResponseBody)
+}
+
+func TestLogRequestMiddlewareLogsSuccessfulRequests(t *testing.T) {
+	var logBuffer bytes.Buffer
+	logrus.SetOutput(&logBuffer)
+	defer logrus.SetOutput(os.Stdout)
+
+	handler := logRequestMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), "network request")
+
+	req := httptest.NewRequest(http.MethodGet, "/services/forwarder/all", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, logBuffer.String(), "network request")
+	assert.Contains(t, logBuffer.String(), "/services/forwarder/all")
+}
+
+func TestLogRequestMiddlewareLogsPostRequestBody(t *testing.T) {
+	hook := withLogrusCaptureHook(t)
+
+	var receivedBody string
+	handler := logRequestMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}), "network request")
+
+	reqBody := `{"local":"127.0.0.1:2224","remote":"192.168.127.2:22","protocol":"tcp"}`
+	req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose", bytes.NewBufferString(reqBody))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, reqBody, receivedBody)
+	assert.Len(t, hook.entries, 1)
+	entry := hook.entries[0]
+	assert.Equal(t, "network request", entry.Message)
+	assert.Equal(t, http.MethodPost, entry.Data["method"])
+	assert.Equal(t, "/services/forwarder/expose", entry.Data["path"])
+	assert.Equal(t, http.StatusOK, entry.Data["status"])
+	assert.Equal(t, reqBody, entry.Data["body"])
+}
+
+func TestLogRequestMiddlewareLogsFailedRequestsAsWarning(t *testing.T) {
+	var logBuffer bytes.Buffer
+	logrus.SetOutput(&logBuffer)
+	defer logrus.SetOutput(os.Stdout)
+
+	handler := logRequestMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}), "network request")
+
+	req := httptest.NewRequest(http.MethodPost, "/services/forwarder/expose", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, logBuffer.String(), "level=warning")
+	assert.Contains(t, logBuffer.String(), "network request")
 }

--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -166,7 +166,7 @@ func run(configuration *types.Configuration) error {
 			return
 		}
 		mux := http.NewServeMux()
-		mux.Handle("/network/", interceptResponseBodyMiddleware(http.StripPrefix("/network", vn.Mux()), logResponseBodyConditionally))
+		mux.Handle("/network/", interceptResponseBodyMiddleware(logRequestMiddleware(http.StripPrefix("/network", vn.Mux()), "network request"), logResponseBodyConditionally))
 		machineClient := newMachine()
 		mux.Handle("/api/", interceptResponseBodyMiddleware(http.StripPrefix("/api", api.NewMux(config, machineClient, logging.Memory, segmentClient)), logResponseBodyConditionally))
 		mux.Handle("/events", interceptResponseBodyMiddleware(http.StripPrefix("/events", events.NewEventServer(machineClient)), logResponseBodyConditionally))


### PR DESCRIPTION
- Added `logRequestMiddleware` to log incoming requests, including method, path, and body for POST requests.
- Updated `interceptResponseBodyMiddleware` to utilize the new logging middleware.
- Introduced tests for logging successful and failed requests, ensuring proper log output.
- Enhanced request body reading for logging while maintaining original request functionality.

Assisted-By: Cursor

## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

Fixes: #N

Relates to: #N, PR #N, ...

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
- Compile new crc binary using this PR
- Perform crc cleanup and crc setup
- Execute following curl command
```
$ curl --unix-socket ~/.crc/crc-http.sock http:/unix/network/services/forwarder/all | jq .
$ curl -X POST -d '{"local": "127.0.0.1:6663", "remote": "192.168.127.2:6663"}'  --unix-socket ~/.crc/crc-http.sock http:/unix/network/services/forwarder/expose
$ tail -f ~/.crc/crcd.log
time="2026-06-10T17:39:37+05:30" level=debug msg="CRC version: 2.61.0+47205c\n"
time="2026-06-10T17:39:37+05:30" level=debug msg="OpenShift version: 4.21.14\n"
time="2026-06-10T17:39:37+05:30" level=debug msg="MicroShift version: 4.21.7\n"
time="2026-06-10T17:39:37+05:30" level=debug msg="Running 'crc daemon'"
time="2026-06-10T17:39:37+05:30" level=info msg="using socket provided by crc-http.socket"
time="2026-06-10T17:39:37+05:30" level=info msg="using socket provided by crc-vsock.socket"
time="2026-06-10T17:39:37+05:30" level=info msg="network request" method=GET path=/network/services/forwarder/all status=200
time="2026-06-10T17:39:46+05:30" level=info msg="network request" method=GET path=/network/services/forwarder/all status=200
time="2026-06-10T17:40:19+05:30" level=info msg="network request" method=GET path=/network/services/forwarder/all status=200
time="2026-06-10T17:47:09+05:30" level=info msg="network request" body="{\"local\": \"127.0.0.1:6663\", \"remote\": \"192.168.127.2:6663\"}" method=POST path=/network/services/forwarder/expose status=200
```

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced API request logging now records HTTP method, path, and final status code
  * POST request bodies are captured and included in logs
  * Requests returning status 400+ are logged at warning level for higher visibility
* **Tests**
  * Added coverage to verify successful, POST, and failed request logging behavior and log severity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->