### PR TITLE
test: Configurable memory and disk size on test suites

### DIFF
--- a/images/build-e2e/lib/darwin/run.sh
+++ b/images/build-e2e/lib/darwin/run.sh
@@ -4,6 +4,7 @@
 bundleLocation=""
 e2eTagExpression=""
 crcMemory=""
+crcDiskSize=""
 crcBinaryDir="/usr/local/bin"
 targetFolder="crc-e2e"
 junitFilename="e2e-junit.xml"
@@ -35,6 +36,11 @@ while [[ $# -gt 0 ]]; do
         shift 
         shift 
         ;;
+        -crcDiskSize)
+        crcDiskSize="$2"
+        shift
+        shift
+        ;;
         -crcBinaryDir)
         crcBinaryDir="$2"
         shift
@@ -57,7 +63,7 @@ then
     tags="$tags && $e2eTagExpression"
 fi
 cd $targetFolder/bin
-./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --crc-binary=$crcBinaryDir --cleanup-home=false --crc-memory=$crcMemory --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
+./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --crc-binary=$crcBinaryDir --cleanup-home=false --crc-memory=$crcMemory --crc-disk-size=$crcDiskSize --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
 
 # Transform results to junit
 cd ..

--- a/images/build-e2e/lib/linux/run.sh
+++ b/images/build-e2e/lib/linux/run.sh
@@ -4,6 +4,7 @@
 bundleLocation=""
 e2eTagExpression=""
 crcMemory=""
+crcDiskSize=""
 crcBinaryDir="/usr/local/bin"
 targetFolder="crc-e2e"
 junitFilename="e2e-junit.xml"
@@ -35,6 +36,11 @@ while [[ $# -gt 0 ]]; do
         shift 
         shift 
         ;;
+        -crcDiskSize)
+        crcDiskSize="$2"
+        shift
+        shift
+        ;;
         -crcBinaryDir)
         crcBinaryDir="$2"
         shift
@@ -57,7 +63,7 @@ then
     tags="$tags && $e2eTagExpression"
 fi
 cd $targetFolder/bin
-./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --crc-binary=$crcBinaryDir --cleanup-home=false --crc-memory=$crcMemory --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
+./e2e.test --bundle-location=$bundleLocation --pull-secret-file="${HOME}/$targetFolder/pull-secret" --crc-binary=$crcBinaryDir --cleanup-home=false --crc-memory=$crcMemory --crc-disk-size=$crcDiskSize --godog.tags="$tags" --godog.format=junit > "${HOME}/$targetFolder/results/e2e.results"
 
 # Transform results to junit
 cd ..

--- a/images/build-e2e/lib/windows/run.ps1
+++ b/images/build-e2e/lib/windows/run.ps1
@@ -9,6 +9,8 @@ param(
     $junitFilename="e2e-junit.xml",
     [Parameter(HelpMessage='Customize memory for the cluster to run the tests')]
     $crcMemory="",
+    [Parameter(HelpMessage='Customize disk size for the cluster to run the tests')]
+    $crcDiskSize="",
     [Parameter(HelpMessage='Customize crc binary location')]
     $crcBinaryDir="C:\Program Files\Red Hat OpenShift Local"
 )
@@ -30,7 +32,7 @@ if ($e2eTagExpression) {
 }
 $dir = "$PWD"
 cd $targetFolder\bin
-e2e.test.exe --bundle-location=$bundleLocation --pull-secret-file=$targetFolderdir\pull-secret --crc-binary=$crcBinaryDir --crc-memory=$crcMemory --cleanup-home=false --godog.tags="$tags" --godog.format=junit > $resultsDir\e2e.results
+e2e.test.exe --bundle-location=$bundleLocation --pull-secret-file=$targetFolderdir\pull-secret --crc-binary=$crcBinaryDir --crc-memory=$crcMemory --crc-disk-size=$crcDiskSize --cleanup-home=false --godog.tags="$tags" --godog.format=junit > $resultsDir\e2e.results
 
 # Transform results to junit
 cd ..

--- a/images/build-integration/lib/darwin/run.sh
+++ b/images/build-integration/lib/darwin/run.sh
@@ -6,6 +6,8 @@ targetFolder="crc-integration"
 junitFilename="integration-junit.xml"
 suiteTimeout="90m"
 labelFilter=""
+crcMemory=""
+crcDiskSize=""
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
@@ -31,9 +33,19 @@ while [[ $# -gt 0 ]]; do
         ;;
         -labelFilter)
         labelFilter="$2"
-        shift 
         shift
-        ;; 
+        shift
+        ;;
+        -crcMemory)
+        crcMemory="$2"
+        shift
+        shift
+        ;;
+        -crcDiskSize)
+        crcDiskSize="$2"
+        shift
+        shift
+        ;;
         *)    # unknown option
         shift 
         ;;
@@ -46,11 +58,18 @@ mkdir -p $targetFolder/results
 # Run tests
 export PATH="$PATH:${HOME}/$targetFolder/bin"
 cd $targetFolder/bin
+extraFlags=""
+if [ ! -z "$crcMemory" ]; then
+    extraFlags="$extraFlags --crc-memory=$crcMemory"
+fi
+if [ ! -z "$crcDiskSize" ]; then
+    extraFlags="$extraFlags --crc-disk-size=$crcDiskSize"
+fi
 if [ ! -z "$labelFilter" ]
 then
-    ./integration.test --pull-secret-path="${HOME}/$targetFolder/pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout --ginkgo.label-filter "$labelFilter" > integration.results
+    ./integration.test --pull-secret-path="${HOME}/$targetFolder/pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout --ginkgo.label-filter "$labelFilter" $extraFlags > integration.results
 else
-    ./integration.test --pull-secret-path="${HOME}/$targetFolder/pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout > integration.results
+    ./integration.test --pull-secret-path="${HOME}/$targetFolder/pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout $extraFlags > integration.results
 fi
 
 # Copy results

--- a/images/build-integration/lib/linux/run.sh
+++ b/images/build-integration/lib/linux/run.sh
@@ -6,6 +6,8 @@ targetFolder="crc-integration"
 junitFilename="integration-junit.xml"
 suiteTimeout="90m"
 labelFilter=""
+crcMemory=""
+crcDiskSize=""
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
@@ -31,8 +33,18 @@ while [[ $# -gt 0 ]]; do
         ;;
         -labelFilter)
         labelFilter="$2"
-        shift 
-        shift 
+        shift
+        shift
+        ;;
+        -crcMemory)
+        crcMemory="$2"
+        shift
+        shift
+        ;;
+        -crcDiskSize)
+        crcDiskSize="$2"
+        shift
+        shift
         ;;
         *)    # unknown option
         shift 
@@ -47,11 +59,18 @@ mkdir -p $targetFolder/results
 export PATH="$PATH:${HOME}/$targetFolder/bin"
 
 cd $targetFolder/bin
+extraFlags=""
+if [ ! -z "$crcMemory" ]; then
+    extraFlags="$extraFlags --crc-memory=$crcMemory"
+fi
+if [ ! -z "$crcDiskSize" ]; then
+    extraFlags="$extraFlags --crc-disk-size=$crcDiskSize"
+fi
 if [ ! -z "$labelFilter" ]
 then
-    ./integration.test --pull-secret-path="${HOME}/$targetFolder/pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout --ginkgo.label-filter "$labelFilter" > integration.results
+    ./integration.test --pull-secret-path="${HOME}/$targetFolder/pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout --ginkgo.label-filter "$labelFilter" $extraFlags > integration.results
 else
-    ./integration.test --pull-secret-path="${HOME}/$targetFolder/pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout > integration.results
+    ./integration.test --pull-secret-path="${HOME}/$targetFolder/pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout $extraFlags > integration.results
 fi
 
 # Copy results

--- a/images/build-integration/lib/windows/run.ps1
+++ b/images/build-integration/lib/windows/run.ps1
@@ -8,7 +8,11 @@ param(
     [Parameter(HelpMessage='Test suite fails if it does not complete within the specified timeout. Default 90m')]
     $suiteTimeout="90m",
     [Parameter(HelpMessage='Filter tests to be executed based on label expression')]
-    $labelFilter=""
+    $labelFilter="",
+    [Parameter(HelpMessage='Customize memory for the cluster to run the tests')]
+    $crcMemory="",
+    [Parameter(HelpMessage='Customize disk size for the cluster to run the tests')]
+    $crcDiskSize=""
 )
 
 # Prepare run e2e
@@ -25,10 +29,18 @@ New-Item -ItemType directory -Path "$resultsDir" -Force
 # Run tests
 cd $targetFolder\bin
 
+$extraFlags = @()
+if ($crcMemory) {
+    $extraFlags += "--crc-memory=$crcMemory"
+}
+if ($crcDiskSize) {
+    $extraFlags += "--crc-disk-size=$crcDiskSize"
+}
+
 if ($labelFilter) {
-    integration.test.exe --pull-secret-path="$targetFolderDir\pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout --ginkgo.label-filter "$labelFilter" > integration.results
+    integration.test.exe --pull-secret-path="$targetFolderDir\pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout --ginkgo.label-filter "$labelFilter" @extraFlags > integration.results
 } else {
-    integration.test.exe --pull-secret-path="$targetFolderDir\pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout > integration.results
+    integration.test.exe --pull-secret-path="$targetFolderDir\pull-secret" --bundle-path=$bundleLocation --ginkgo.timeout $suiteTimeout @extraFlags > integration.results
 }
 
 

--- a/test/e2e/testsuite/testsuite.go
+++ b/test/e2e/testsuite/testsuite.go
@@ -44,6 +44,7 @@ var (
 	testWithShell      string
 	CRCVersion         string
 	CRCMemory          string
+	CRCDiskSize        string
 
 	GodogTags string
 )
@@ -63,6 +64,7 @@ func ParseFlags() {
 	pflag.BoolVar(&cleanupHome, "cleanup-home", false, "Try to remove crc home folder before starting the suite") // TODO: default=true
 	pflag.StringVar(&CRCVersion, "crc-version", defaultCRCVersion(), "Version of CRC to be tested")
 	pflag.StringVar(&CRCMemory, "crc-memory", "", "Memory for CRC VM in MiB")
+	pflag.StringVar(&CRCDiskSize, "crc-disk-size", "", "Disk size for CRC VM in GiB")
 }
 
 func InitializeTestSuite(tctx *godog.TestSuiteContext) {
@@ -890,6 +892,13 @@ func EnsureCRCIsRunning() error {
 		// set up and start the cluster with lots of memory, if specified
 		if CRCMemory != "" {
 			err = SetConfigPropertyToValueSucceedsOrFails("memory", CRCMemory, "succeeds")
+			if err != nil {
+				return err
+			}
+		}
+
+		if CRCDiskSize != "" {
+			err = SetConfigPropertyToValueSucceedsOrFails("disk-size", CRCDiskSize, "succeeds")
 			if err != nil {
 				return err
 			}

--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -29,6 +29,8 @@ var versionInfo VersionAnswer
 
 var bundlePath string
 var pullSecretPath string
+var crcMemory string
+var crcDiskSize string
 
 func TestMain(m *testing.M) {
 	RegisterFlags(flag.CommandLine)
@@ -41,6 +43,8 @@ func TestMain(m *testing.M) {
 func RegisterFlags(flags *flag.FlagSet) {
 	flags.StringVar(&bundlePath, "bundle-path", "", "Path to the bundle to be used in tests.")
 	flags.StringVar(&pullSecretPath, "pull-secret-path", "", "Path to the file containing pull secret.")
+	flags.StringVar(&crcMemory, "crc-memory", "", "Memory for CRC VM in MiB.")
+	flags.StringVar(&crcDiskSize, "crc-disk-size", "", "Disk size for CRC VM in GiB.")
 }
 
 func TestTest(t *testing.T) {
@@ -77,6 +81,14 @@ var _ = BeforeSuite(func() {
 	// remove config file crc.json
 	err = util.RemoveCRCConfig()
 	Expect(err).NotTo(HaveOccurred())
+
+	if crcMemory != "" {
+		Expect(RunCRCExpectSuccess("config", "set", "memory", crcMemory)).To(ContainSubstring("Successfully configured memory"))
+	}
+
+	if crcDiskSize != "" {
+		Expect(RunCRCExpectSuccess("config", "set", "disk-size", crcDiskSize)).To(ContainSubstring("Successfully configured disk-size"))
+	}
 
 	// start shell instance
 	err = util.StartHostShellInstance("")


### PR DESCRIPTION
Allow both test suite to manage memory and disk-size properties without relay on default values, as bundles might force a change still not present in crc

## Description

Configurable properties for both test suites

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes

CI can configure memory or disk-size

## Testing

Use new defined properties

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [x] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * E2E test runners now support customizable CRC disk size configuration across all platforms
  * Integration test runners now support customizable CRC memory and disk size settings across all platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->