### PR TITLE
pkg: move chmod command from packaging to postinstall script

### DIFF
--- a/packaging/darwin/macos-pkg-build-and-sign.sh
+++ b/packaging/darwin/macos-pkg-build-and-sign.sh
@@ -49,8 +49,6 @@ sign "${crcBinDir}/crc"
 sign "${crcBinDir}/crc-admin-helper-darwin"
 sign "${crcBinDir}/vfkit"
 
-chmod +sx "${crcBinDir}/crc-admin-helper-darwin"
-
 pkgbuild --identifier com.redhat.crc --version ${version} \
   --scripts "${BASEDIR}/scripts" \
   --root "${crcRootDir}" \

--- a/packaging/darwin/postinstall.in
+++ b/packaging/darwin/postinstall.in
@@ -7,6 +7,7 @@ rm -fr /Applications/Red\ Hat\ OpenShift\ Local.app || true
 rm -fr  /Applications/CodeReady\ Containers.app || true
 
 chmod 755 "__INSTALL_PATH__"/crc
+chmod u+s,g+x "__INSTALL_PATH__"/crc-admin-helper-darwin
 
 [ -d /usr/local/bin ] || mkdir /usr/local/bin
 


### PR DESCRIPTION
## Description

we are going to build the installer in konflux in a hermetic env, where we use sandbox-exec to restrict network access it also blocks any setuid/setgid operations and the build fails when 'chmod +sx' is ran

we need the setuid bit set on the admin-helper binary on the user's machine which can be done in the post-install  script


Relates to: https://github.com/crc-org/crc-internal/issues/210



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS installation permission handling for the bundled admin helper: executable permission changes now occur during post-install rather than during package building.
  * The post-install step sets the required setuid bit and ensures the helper has appropriate group execute permissions after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->