### PR TITLE
[qe] e2e: Fix expected pods

### DIFF
--- a/test/e2e/features/story_openshift.feature
+++ b/test/e2e/features/story_openshift.feature
@@ -67,7 +67,6 @@ Feature: 4 Openshift stories
 		Then with up to "20" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*certified-operators(.*)1/1(.*)Running.*"
 		Then with up to "4" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*community-operators(.*)1/1(.*)Running.*"
 		Then with up to "4" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*marketplace-operator(.*)1/1(.*)Running.*"
-		Then with up to "4" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*redhat-marketplace(.*)1/1(.*)Running.*"
 		Then with up to "4" retries with wait period of "30s" command "oc get pods -n openshift-marketplace" output matches ".*redhat-operators(.*)1/1(.*)Running.*"
 		When executing "oc apply -f pipeline-sub.yaml" succeeds
 		Then with up to "10" retries with wait period of "30s" command "oc get csv" output matches ".*pipelines-operator(.*)Succeeded$"


### PR DESCRIPTION

## Description

There's no more redhat-marketplace anymore

Fixes: #5275

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
Fix filter for installed pods

## Testing

```
go test \
  -timeout=90m \
  -tags "build containers_image_openpgp" \
  github.com/crc-org/crc/v2/test/e2e \
  --pull-secret-file=/home/alberto/.crc/pull-secret.txt \
  --bundle-location=/home/alberto/.crc/cache/crc_libvirt_4.22.1_amd64.crcbundle \
  -v --godog.tags="@story_marketplace && @linux"
```

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end tests for OpenShift operator marketplace functionality with improved pod readiness verification. Updated assertions to validate multiple operator catalog sources and ensure proper operator deployment across repository sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->