### PR TITLE
Add networkpolicy for routes-controller

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -63,6 +63,30 @@ const (
 	Plan9HvsockPort = 36864
 )
 
+const RoutesNetworkPolicyYAML = `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: routes-controller
+  name: routes-controller
+  namespace: openshift-ingress
+spec:
+  egress:
+  - {}
+  ingress:
+  - ports:
+    - port: http
+      protocol: TCP
+    - port: https
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: routes-controller
+  policyTypes:
+  - Ingress
+  - Egress
+`
+
 var adminHelperExecutableForOs = map[string]string{
 	"darwin":  "crc-admin-helper-darwin",
 	"linux":   fmt.Sprintf("crc-admin-helper-linux-%s", runtime.GOARCH),

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -858,6 +858,17 @@ func ensureRoutesControllerIsRunning(sshRunner *crcssh.Runner, ocConfig oc.Confi
 		return err
 	}
 	_, _, err = ocConfig.RunOcCommand("apply", "-f", "/opt/crc/routes-controller.yaml")
+	if err != nil {
+		return err
+	}
+	return ensureRoutesNetworkPolicy(sshRunner, ocConfig)
+}
+
+func ensureRoutesNetworkPolicy(sshRunner *crcssh.Runner, ocConfig oc.Config) error {
+	if err := sshRunner.CopyDataPrivileged([]byte(constants.RoutesNetworkPolicyYAML), "/opt/crc/routes-networkpolicy.yaml", 0o644); err != nil {
+		return err
+	}
+	_, _, err := ocConfig.RunOcCommand("apply", "-f", "/opt/crc/routes-networkpolicy.yaml")
 	return err
 }
 


### PR DESCRIPTION
From OCP-4.22 openshift-dns, openshift-ingress ..etc. core namespaces have default network policy so any pod which is created on these namespace will not have access to even internal dns. This PR add the network policy for routes-controller which is deployed in openshift-ingress

- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/network_security/network-policy

We will revert this once bundle is created after merging https://github.com/crc-org/snc/pull/1248 one.


Fixes: #5277 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Routes controller startup now automatically applies network policy configuration. The policy defines ingress rules for HTTP and HTTPS ports and establishes egress rules for the routes controller component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->