### PR TITLE
[qe] e2e: Fix disk resize test

### DIFF
--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -82,9 +82,9 @@ var _ = Describe("vary VM parameters: memory cpus, disk", Serial, Ordered, Label
 		})
 
 		It("check VM's disk size", func() {
-			out, err := util.SendCommandToVM("df -h | grep sysroot")
+			out, err := util.SendCommandToVM("lsblk -d -n -e 7 -o SIZE")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+			Expect(out).Should(MatchRegexp(`^ *40G`))
 		})
 
 		It("stop CRC", func() {
@@ -125,9 +125,9 @@ var _ = Describe("vary VM parameters: memory cpus, disk", Serial, Ordered, Label
 		})
 
 		It("check VM's disk size", func() {
-			out, err := util.SendCommandToVM("df -h | grep sysroot")
+			out, err := util.SendCommandToVM("lsblk -d -n -e 7 -o SIZE")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`.*50G[\s].*[\s]/sysroot`))
+			Expect(out).Should(MatchRegexp(`^ *50G`))
 		})
 
 		It("stop CRC", func() {
@@ -196,9 +196,9 @@ var _ = Describe("vary VM parameters: memory cpus, disk", Serial, Ordered, Label
 
 		if runtime.GOOS != "darwin" {
 			It("check VM's disk size", func() {
-				out, err := util.SendCommandToVM("df -h | grep sysroot")
+				out, err := util.SendCommandToVM("lsblk -d -n -e 7 -o SIZE")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`.*50G[\s].*[\s]/sysroot`))
+				Expect(out).Should(MatchRegexp(`^ *50G`))
 			})
 		}
 


### PR DESCRIPTION
## Description

Previous check with df is not valid anymore, lsblk is easier and more accurate

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes

Use lsblk to test resizes

## Testing

```
go test \
  -timeout=90m \
  -tags "build containers_image_openpgp" \
  github.com/crc-org/crc/v2/test/integration \
  --pull-secret-path=/home/alberto/.crc/pull-secret.txt \
  --bundle-path=/home/alberto/.crc/cache/crc_libvirt_4.22.1_amd64.crcbundle \
  -v --ginkgo.label-filter="vm-resize"
```

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved disk size verification by switching from `df`-based matching to `lsblk`-based size checks.
  * Updated assertions to validate expected capacities across the default and custom disk size scenarios (including repeated default runs), making the tests more reliable and less dependent on `df` formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->