### PR TITLE
constants: Move host IPC sockets to ~/.crc/sockets with restricted permissions

### DIFF
--- a/cmd/crc/cmd/daemon_darwin.go
+++ b/cmd/crc/cmd/daemon_darwin.go
@@ -16,20 +16,28 @@ import (
 func vsockListener() (net.Listener, error) {
 	_ = os.Remove(constants.TapSocketPath)
 	ln, err := net.Listen("unix", constants.TapSocketPath)
-	logging.Infof("listening %s", constants.TapSocketPath)
 	if err != nil {
 		return nil, err
 	}
+	if err = constants.EnsureSocketFilesPermissions(constants.TapSocketPath); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	logging.Infof("listening %s", constants.TapSocketPath)
 	return ln, nil
 }
 
 func httpListener() (net.Listener, error) {
 	_ = os.Remove(constants.DaemonHTTPSocketPath)
 	ln, err := net.Listen("unix", constants.DaemonHTTPSocketPath)
-	logging.Infof("listening %s", constants.DaemonHTTPSocketPath)
 	if err != nil {
 		return nil, err
 	}
+	if err = constants.EnsureSocketFilesPermissions(constants.DaemonHTTPSocketPath); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	logging.Infof("listening %s", constants.DaemonHTTPSocketPath)
 	return ln, nil
 }
 
@@ -38,6 +46,10 @@ func unixgramListener(ctx context.Context, vn *virtualnetwork.VirtualNetwork) (*
 	conn, err := transport.ListenUnixgram(fmt.Sprintf("unixgram://%v", constants.UnixgramSocketPath))
 	if err != nil {
 		return conn, errors.Wrap(err, "failed to listen unixgram")
+	}
+	if err = constants.EnsureSocketFilesPermissions(constants.UnixgramSocketPath); err != nil {
+		_ = conn.Close()
+		return nil, errors.Wrap(err, "failed to set permissions for unixgram socket")
 	}
 	logging.Infof("listening on %s", constants.UnixgramSocketPath)
 	vfkitConn, err := transport.AcceptVfkit(conn)

--- a/cmd/crc/cmd/daemon_linux.go
+++ b/cmd/crc/cmd/daemon_linux.go
@@ -112,6 +112,10 @@ func httpListener() (net.Listener, error) {
 		return nil, err
 	}
 	if ln != nil {
+		if err = constants.EnsureSocketFilesPermissions(constants.DaemonHTTPSocketPath); err != nil {
+			_ = ln.Close()
+			return nil, err
+		}
 		logging.Infof("using socket provided by %s", httpUnitName)
 		return ln, nil
 	}
@@ -119,10 +123,14 @@ func httpListener() (net.Listener, error) {
 	// no socket activation, we need to create the listener
 	_ = os.Remove(constants.DaemonHTTPSocketPath)
 	ln, err = net.Listen("unix", constants.DaemonHTTPSocketPath)
-	logging.Infof("listening %s", constants.DaemonHTTPSocketPath)
 	if err != nil {
 		return nil, err
 	}
+	if err = constants.EnsureSocketFilesPermissions(constants.DaemonHTTPSocketPath); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
+	logging.Infof("listening %s", constants.DaemonHTTPSocketPath)
 	return ln, nil
 }
 

--- a/cmd/crc/cmd/daemon_windows.go
+++ b/cmd/crc/cmd/daemon_windows.go
@@ -27,10 +27,10 @@ func httpListener() (net.Listener, error) {
 		InputBufferSize:  65536, // Use 64kB buffers to improve performance
 		OutputBufferSize: 65536,
 	})
-	logging.Infof("listening %s", constants.DaemonHTTPNamedPipe)
 	if err != nil {
 		return nil, err
 	}
+	logging.Infof("listening %s", constants.DaemonHTTPNamedPipe)
 	return ln, nil
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -123,7 +123,8 @@ var (
 	MachineBaseDir         = CrcBaseDir
 	MachineCacheDir        = filepath.Join(MachineBaseDir, "cache")
 	MachineInstanceDir     = filepath.Join(MachineBaseDir, "machines")
-	DaemonSocketPath       = filepath.Join(CrcBaseDir, "crc.sock")
+	SocketBaseDir          = filepath.Join(CrcBaseDir, "sockets")
+	DaemonSocketPath       = filepath.Join(SocketBaseDir, "crc.sock")
 	KubeconfigFilePath     = filepath.Join(MachineInstanceDir, DefaultName, "kubeconfig")
 	PasswdFilePath         = filepath.Join(MachineInstanceDir, DefaultName, "passwd")
 )
@@ -172,7 +173,7 @@ func GetHomeDir() string {
 	return homeDir
 }
 
-// EnsureBaseDirectoriesExist creates ~/.crc, ~/.crc/bin and ~/.crc/cache directories if it is not present
+// EnsureBaseDirectoriesExist creates ~/.crc, ~/.crc/bin, ~/.crc/cache, and ~/.crc/sockets directories if they are not present
 func EnsureBaseDirectoriesExist() error {
 	baseDirectories := []string{CrcBaseDir, MachineCacheDir, CrcBinDir}
 	for _, baseDir := range baseDirectories {
@@ -181,7 +182,19 @@ func EnsureBaseDirectoriesExist() error {
 			return err
 		}
 	}
-	return nil
+	return ensureSocketDirectoryExists()
+}
+
+func ensureSocketDirectoryExists() error {
+	err := os.MkdirAll(SocketBaseDir, 0700)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(SocketBaseDir, 0700)
+}
+
+func EnsureSocketFilesPermissions(path string) error {
+	return os.Chmod(path, 0600)
 }
 
 func EnsureAdminHelperLogFileExists() error {

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -11,7 +11,7 @@ const (
 )
 
 var (
-	TapSocketPath        = filepath.Join(CrcBaseDir, "tap.sock")
-	DaemonHTTPSocketPath = filepath.Join(CrcBaseDir, "crc-http.sock")
-	UnixgramSocketPath   = filepath.Join(CrcBaseDir, "crc-unixgram.sock")
+	TapSocketPath        = filepath.Join(SocketBaseDir, "tap.sock")
+	DaemonHTTPSocketPath = filepath.Join(SocketBaseDir, "crc-http.sock")
+	UnixgramSocketPath   = filepath.Join(SocketBaseDir, "crc-unixgram.sock")
 )

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -9,4 +9,4 @@ const (
 	TapSocketPath    = ""
 )
 
-var DaemonHTTPSocketPath = filepath.Join(CrcBaseDir, "crc-http.sock")
+var DaemonHTTPSocketPath = filepath.Join(SocketBaseDir, "crc-http.sock")

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -307,8 +307,10 @@ WantedBy=default.target
 Description=CRC HTTP socket
 
 [Socket]
-ListenStream=%h/.crc/crc-http.sock
+ListenStream=%h/.crc/sockets/crc-http.sock
 Service=crc-daemon.service
+SocketMode=0600
+DirectoryMode=0700
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

This PR moves CRC host IPC sockets under `~/.crc/sockets/` (directory mode 0700) and sets socket file mode to `0600` after bind, instead of relying on the default `0666`. Having 0750 on directory and 0666 on sockets can result in another user to misuse the sockets:
```zsh
gvyas@Gunjans-MacBook-Pro ~ % crc status
CRC VM:          Running
OpenShift:       Running (v4.20.1)
RAM Usage:       6.305GB of 16.73GB
Disk Usage:      25.11GB of 68.11GB (Inside the CRC VM)
Cache Usage:     86.79GB
Cache Directory: /Users/gvyas/.crc/cache
gvyas@Gunjans-MacBook-Pro ~ % sudo -u crcattacker curl --unix-socket "/Users/gvyas/.crc/crc-http.sock" "http://unix/api/stop"
gvyas@Gunjans-MacBook-Pro ~ % crc status
CRC VM:          Stopped
OpenShift:       Stopped (v4.20.1)
Disk Usage:      0B of 0B (Inside the CRC VM)
Cache Usage:     86.79GB
Cache Directory: /Users/gvyas/.crc/cache
```
<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [x] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->
1. `crc cleanup && crc setup && crc start` (required after upgrade — old daemon uses old paths)
2. `stat -f '%Lp' ~/.crc/sockets` -> `0700`
3. `stat -f '%Lp' ~/.crc/sockets/*.sock` -> `0600 0600 0600`
4. `ssh` should work

**Note:** This only works after running a cleanup of the old crc instance (including daemon) as the new crc will start processes on different socket paths after this change (`~/.crc/sockets`)

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Unix socket setup so socket filesystem permissions are applied before the daemon reports “listening”.
  * If socket creation fails, the daemon now returns early without emitting misleading “listening” messages.
  * Ensures socket listeners are properly closed when permission setup fails.

* **Refactor**
  * Moved daemon socket files into a dedicated `~/.crc/sockets` directory.
  * Enforced secure permissions for the socket directory (`0700`) and socket files (`0600`) across platforms.

* **Documentation**
  * Updated the Linux systemd user unit template to reference the new HTTP socket path and socket/dir modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->