### PR TITLE
CI: Update ubuntu runner from 24.04 to 26.04 for okd testing

### DIFF
--- a/.github/workflows/test-okd-bundle.yml
+++ b/.github/workflows/test-okd-bundle.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Run OKD bundle with crc
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
@@ -31,7 +31,7 @@ jobs:
       - name: Install required virtualization software
         run: |
           sudo apt-get update
-          sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system virtiofsd
+          sudo apt install qemu-system-x86 qemu-utils libvirt-daemon libvirt-daemon-system virtiofsd
           sudo usermod -a -G libvirt $USER
       - name: Free disk space
         uses: palmsoftware/quick-cleanup@v0


### PR DESCRIPTION
Looks like latest update of podman.io/images now require registry-v2 instead v1 and 24.04 version have old version of skopeo installed which have v1 only so upgrading to 26.04. It should fix following CI error

```
level=error msg="initializing source docker://quay.io/crcont/okd-bundle:4.22.0-okd-scos.6: loading registries configuration: loading registries configuration \"/etc/containers/registries.conf\": registries.conf must be in v2 format but is in v1"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated OKD bundle testing workflow to run on a newer Ubuntu runner.
  * Adjusted the virtualization tooling installation to use alternative QEMU-related packages for the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->