### PR TITLE
CI: Remove registry.conf which is still on v1

### DIFF
--- a/.github/workflows/test-okd-bundle.yml
+++ b/.github/workflows/test-okd-bundle.yml
@@ -37,6 +37,9 @@ jobs:
         uses: palmsoftware/quick-cleanup@v0
         with:
           cleanup-mode: aggressive
+      - name: Remove the v1 registry conf which is deprecated and blocks okd bundle pull
+        run: |
+          sudo rm -f /etc/containers/registries.conf
       - name: Set the crc config
         run: |
           crc config set preset okd


### PR DESCRIPTION
418476adb064687b6d064e6aa824e1379bd65f70 doesn't work as expected because even with updated packages of podman/skopeo the registry.conf have v1 content, after debugging it on the runner looks like following package owns that file which suppose to have updated config file but looks like due to runner config it is changed to old one (v1) so this is bug on runner images side.

```
$ dpkg -S /etc/containers/registries.conf
golang-github-containers-image: /etc/containers/registries.conf
$ apt policy golang-github-containers-image
golang-github-containers-image: Installed: 5.38.0+ds2-2
```

- https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-container-tools.sh#L30-L31



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OKD bundle retrieval by deleting a deprecated registry configuration file that could block downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->