### PR TITLE
Increase timeout for integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ BUNDLE_PATH = --bundle-path=$(HOME)/Downloads/crc_libvirt_$(OPENSHIFT_VERSION)_$
 endif
 
 integration:
-	@go test -timeout=90m -tags "$(BUILDTAGS)" $(MODULEPATH)/test/integration $(PULL_SECRET_PATH) $(BUNDLE_PATH) -v $(GINKGO_OPTS)
+	@go test -timeout=120m -tags "$(BUILDTAGS)" $(MODULEPATH)/test/integration $(PULL_SECRET_PATH) $(BUNDLE_PATH) -v $(GINKGO_OPTS)
 
 .PHONY: e2e ## Run e2e tests
 e2e:


### PR DESCRIPTION
On github side we are seeing multiple failure for integration test because of timeout, this pr try to fix it.
```
<*errors.errorString | 0xc00011f7a0>:
      not found: running. Timeout
      {
          s: "not found: running. Timeout",
      }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the integration test timeout to allow longer-running test suites to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->