### PR TITLE
update machine-driver-libvirt to 0.13.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containers/libhvee v0.11.0
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/crc-org/admin-helper v0.5.7
-	github.com/crc-org/machine v0.0.0-20240926103419-a943b47fd48b
+	github.com/crc-org/machine v0.0.0-20260721135927-5bcb8a00e0f1
 	github.com/crc-org/vfkit v0.6.4
 	github.com/cucumber/godog v0.15.1
 	github.com/cucumber/messages-go/v10 v10.0.3

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/crc-org/admin-helper v0.5.7 h1:HxzqnukUI/xk3v8kCLiO7ob8BNOeQDOb2tGvZ9iO+9s=
 github.com/crc-org/admin-helper v0.5.7/go.mod h1:7KWa8mm4Ct4bAn7oJm5d8vseNpBlpesmpyz7Bcr2QqI=
-github.com/crc-org/machine v0.0.0-20240926103419-a943b47fd48b h1:5577tKzQcPfd/i0dCekY32R9DUi677sNfhVLYKulBGM=
-github.com/crc-org/machine v0.0.0-20240926103419-a943b47fd48b/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
+github.com/crc-org/machine v0.0.0-20260721135927-5bcb8a00e0f1 h1:F+m/3LuzDqnGa9z+m8juGb1epcWAfUNsAoODfzIJkDI=
+github.com/crc-org/machine v0.0.0-20260721135927-5bcb8a00e0f1/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
 github.com/crc-org/vfkit v0.6.4 h1:9UfAGABf0gb9PgRyOGvBeGq/9cQv5DKbJ4qHuN+Eh9k=
 github.com/crc-org/vfkit v0.6.4/go.mod h1:soPLDvhdsPbFasruB9b3lGx25Ahq2bD5CxyRQ0DCO+Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/pkg/crc/machine/libvirt/constants.go
+++ b/pkg/crc/machine/libvirt/constants.go
@@ -20,7 +20,7 @@ const (
 )
 
 const (
-	MachineDriverVersion = "0.13.10"
+	MachineDriverVersion = "0.13.11"
 )
 
 var (

--- a/vendor/github.com/crc-org/machine/libmachine/drivers/base.go
+++ b/vendor/github.com/crc-org/machine/libmachine/drivers/base.go
@@ -75,7 +75,7 @@ func (d *BaseDriver) GetBundleName() (string, error) {
 	return d.BundleName, nil
 }
 
-func (d *BaseDriver) UpdateConfigRaw(rawData []byte) error {
+func (d *BaseDriver) UpdateConfigRaw(_ []byte) error {
 	return ErrNotImplemented
 }
 

--- a/vendor/github.com/crc-org/machine/libmachine/drivers/rpc/client_driver.go
+++ b/vendor/github.com/crc-org/machine/libmachine/drivers/rpc/client_driver.go
@@ -128,7 +128,7 @@ func (f *DefaultRPCClientDriverFactory) NewRPCClientDriver(driverName string, dr
 		return nil, fmt.Errorf("Error attempting to get plugin server address for RPC: %s", err)
 	}
 
-	rpcclient, err := rpc.DialHTTP("tcp", addr)
+	rpcclient, err := rpc.DialHTTP("unix", addr)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/crc-org/machine/libmachine/drivers/rpc/server_driver.go
+++ b/vendor/github.com/crc-org/machine/libmachine/drivers/rpc/server_driver.go
@@ -8,6 +8,7 @@ import (
 	"github.com/crc-org/machine/libmachine/drivers"
 	"github.com/crc-org/machine/libmachine/state"
 	"github.com/crc-org/machine/libmachine/version"
+	log "github.com/sirupsen/logrus"
 )
 
 type Stacker interface {
@@ -38,12 +39,30 @@ func NewRPCServerDriver(d drivers.Driver) *RPCServerDriver {
 	}
 }
 
+func (r *RPCServerDriver) logRPC(op string, level log.Level, extra log.Fields) {
+	fields := log.Fields{"operation": op}
+	if r.ActualDriver != nil {
+		func() {
+			defer func() { _ = recover() }()
+			if name := r.ActualDriver.GetMachineName(); name != "" {
+				fields["machine"] = name
+			}
+		}()
+	}
+	for k, v := range extra {
+		fields[k] = v
+	}
+	log.WithFields(fields).Log(level, "RPC server invocation")
+}
+
 func (r *RPCServerDriver) Close(_, _ *struct{}) error {
+	r.logRPC("Close", log.InfoLevel, nil)
 	r.CloseCh <- true
 	return nil
 }
 
 func (r *RPCServerDriver) GetVersion(_ *struct{}, reply *int) error {
+	r.logRPC("GetVersion", log.InfoLevel, nil)
 	*reply = version.APIVersion
 	return nil
 }
@@ -55,15 +74,18 @@ func (r *RPCServerDriver) GetConfigRaw(_ *struct{}, reply *[]byte) error {
 	}
 
 	*reply = driverData
+	r.logRPC("GetConfigRaw", log.InfoLevel, log.Fields{"config_bytes": len(driverData)})
 
 	return nil
 }
 
 func (r *RPCServerDriver) UpdateConfigRaw(data []byte, _ *struct{}) error {
+	r.logRPC("UpdateConfigRaw", log.InfoLevel, log.Fields{"config_bytes": len(data)})
 	return r.ActualDriver.UpdateConfigRaw(data)
 }
 
 func (r *RPCServerDriver) SetConfigRaw(data []byte, _ *struct{}) error {
+	r.logRPC("SetConfigRaw", log.InfoLevel, log.Fields{"config_bytes": len(data)})
 	return json.Unmarshal(data, &r.ActualDriver)
 }
 
@@ -74,6 +96,7 @@ func trapPanic(err *error) {
 }
 
 func (r *RPCServerDriver) Create(_, _ *struct{}) (err error) {
+	r.logRPC("Create", log.InfoLevel, nil)
 	// In an ideal world, plugins wouldn't ever panic.  However, panics
 	// have been known to happen and cause issues.  Therefore, we recover
 	// and do not crash the RPC server completely in the case of a panic
@@ -86,50 +109,60 @@ func (r *RPCServerDriver) Create(_, _ *struct{}) (err error) {
 }
 
 func (r *RPCServerDriver) DriverName(_ *struct{}, reply *string) error {
+	r.logRPC("DriverName", log.InfoLevel, nil)
 	*reply = r.ActualDriver.DriverName()
 	return nil
 }
 
 func (r *RPCServerDriver) GetIP(_ *struct{}, reply *string) error {
+	r.logRPC("GetIP", log.InfoLevel, nil)
 	ip, err := r.ActualDriver.GetIP()
 	*reply = ip
 	return err
 }
 
 func (r *RPCServerDriver) GetMachineName(_ *struct{}, reply *string) error {
+	r.logRPC("GetMachineName", log.InfoLevel, nil)
 	*reply = r.ActualDriver.GetMachineName()
 	return nil
 }
 
 func (r *RPCServerDriver) GetBundleName(_ *struct{}, reply *string) error {
+	r.logRPC("GetBundleName", log.InfoLevel, nil)
 	path, err := r.ActualDriver.GetBundleName()
 	*reply = path
 	return err
 }
 
 func (r *RPCServerDriver) GetState(_ *struct{}, reply *state.State) error {
+	r.logRPC("GetState", log.InfoLevel, nil)
 	s, err := r.ActualDriver.GetState()
 	*reply = s
 	return err
 }
 
 func (r *RPCServerDriver) Kill(_ *struct{}, _ *struct{}) error {
+	r.logRPC("Kill", log.InfoLevel, nil)
 	return r.ActualDriver.Kill()
 }
 
 func (r *RPCServerDriver) PreCreateCheck(_ *struct{}, _ *struct{}) error {
+	r.logRPC("PreCreateCheck", log.InfoLevel, nil)
 	return r.ActualDriver.PreCreateCheck()
 }
 
 func (r *RPCServerDriver) Remove(_ *struct{}, _ *struct{}) error {
+	r.logRPC("Remove", log.InfoLevel, nil)
 	return r.ActualDriver.Remove()
 }
 
 func (r *RPCServerDriver) Start(_ *struct{}, _ *struct{}) error {
+	r.logRPC("Start", log.InfoLevel, nil)
 	return r.ActualDriver.Start()
 }
 
 func (r *RPCServerDriver) Stop(_ *struct{}, _ *struct{}) error {
+	r.logRPC("Stop", log.InfoLevel, nil)
 	return r.ActualDriver.Stop()
 }
 
@@ -141,5 +174,8 @@ func (r *RPCServerDriver) Heartbeat(_ *struct{}, _ *struct{}) error {
 func (r *RPCServerDriver) GetSharedDirs(_ *struct{}, reply *[]drivers.SharedDir) error {
 	sharedDirs, err := r.ActualDriver.GetSharedDirs()
 	*reply = sharedDirs
+	if err == nil {
+		r.logRPC("GetSharedDirs", log.InfoLevel, log.Fields{"shared_dirs": len(sharedDirs)})
+	}
 	return err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -142,7 +142,7 @@ github.com/cpuguy83/go-md2man/v2/md2man
 github.com/crc-org/admin-helper/pkg/client
 github.com/crc-org/admin-helper/pkg/hosts
 github.com/crc-org/admin-helper/pkg/types
-# github.com/crc-org/machine v0.0.0-20240926103419-a943b47fd48b
+# github.com/crc-org/machine v0.0.0-20260721135927-5bcb8a00e0f1
 ## explicit; go 1.17
 github.com/crc-org/machine/drivers/libvirt
 github.com/crc-org/machine/libmachine/drivers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured logging for machine-driver RPC operations.

* **Bug Fixes**
  * Updated RPC communication to use Unix domain sockets for improved local connectivity.
  * Updated the machine-driver release to version 0.13.11.

* **Chores**
  * Refreshed the bundled machine dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->