### PR TITLE
fall back to writing /etc/resolv.conf directly when ovs-if-br-ex isn't found

### DIFF
--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -73,7 +73,11 @@ func updateNetworkManagerConfig(sd *systemd.Commander, sshRunner *ssh.Runner, re
 	if err != nil {
 		// The ovs-if-br-ex NetworkManager connection only exists when OVN's ovs-configuration
 		// builds the br-ex bridge. Bundles using a different CNI (for example Cilium) do not
-		// have this connection, so fall back to writing /etc/resolv.conf directly.
+		// have this connection, so fall back to writing /etc/resolv.conf directly. Only do this
+		// for the missing-connection case; propagate any other nmcli failure.
+		if !strings.Contains(stderr, "unknown connection 'ovs-if-br-ex'") {
+			return fmt.Errorf("failed to update resolv.conf file: %s: %w", stderr, err)
+		}
 		logging.Warnf("Unable to update resolv.conf through NetworkManager (%s), writing /etc/resolv.conf directly", stderr)
 		if fallbackErr := replaceResolvConfFile(sshRunner, resolvFileValues); fallbackErr != nil {
 			return fmt.Errorf("failed to update resolv.conf file: %s: %w", stderr, fallbackErr)

--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/crc/ssh"
 	"github.com/crc-org/crc/v2/pkg/crc/systemd"
 	"github.com/crc-org/crc/v2/pkg/crc/systemd/states"
@@ -70,7 +71,14 @@ func updateNetworkManagerConfig(sd *systemd.Commander, sshRunner *ssh.Runner, re
 	_, stderr, err := sshRunner.RunPrivileged("Update resolv.conf file", "nmcli", "con", "modify", "--temporary", "ovs-if-br-ex",
 		"ipv4.dns", nameservers, "ipv4.dns-search", searchDomains)
 	if err != nil {
-		return fmt.Errorf("failed to update resolv.conf file: %s: %w", stderr, err)
+		// The ovs-if-br-ex NetworkManager connection only exists when OVN's ovs-configuration
+		// builds the br-ex bridge. Bundles using a different CNI (for example Cilium) do not
+		// have this connection, so fall back to writing /etc/resolv.conf directly.
+		logging.Warnf("Unable to update resolv.conf through NetworkManager (%s), writing /etc/resolv.conf directly", stderr)
+		if fallbackErr := replaceResolvConfFile(sshRunner, resolvFileValues); fallbackErr != nil {
+			return fmt.Errorf("failed to update resolv.conf file: %s: %w", stderr, fallbackErr)
+		}
+		return nil
 	}
 	return sd.Restart("NetworkManager.service")
 }


### PR DESCRIPTION
## Description

The ovs-if-br-ex NetworkManager connection only exists when OVN's ovs-configuration builds the br-ex bridge. Bundles using a different CNI (for example Cilium) do not have this connection, so fall back to writing `/etc/resolv.conf` directly.

Issue: When running a custom SNC with a different CNI, it won't start

```
ERRO Error running post start: failed to update resolv.conf file: Error: unknown connection 'ovs-if-br-ex'.
: ssh command error:
command : sudo nmcli con modify --temporary ovs-if-br-ex ipv4.dns 192.168.127.1 ipv4.dns-search crc.testing
err     : Process exited with status 10 
```

Full error trace [HERE](https://gist.github.com/christianh814/fea7d544010b218122676883d53530a4)

With this change, it will start up if running a different CNI  but preserves the current functionality if running the default OVN CNI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS configuration reliability when network connection details are unavailable.
  * Added a fallback that preserves name resolution by applying DNS settings directly when needed.
  * Enhanced error reporting to make DNS setup issues clearer while allowing unrelated network errors to be handled appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->