### PR TITLE
machine: Set socket dir env var for driver plugins

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/crc-org/crc/v2/pkg/crc/manpages"
+	"github.com/crc-org/machine/libmachine/drivers/plugin/localbinary"
 
 	"github.com/spf13/cobra/doc"
 
@@ -53,6 +54,8 @@ func init() {
 	if err := constants.EnsureBaseDirectoriesExist(); err != nil {
 		logging.Fatal(err.Error())
 	}
+	// Set the socket directory for machine driver plugins
+	os.Setenv(localbinary.PluginEnvSocketDir, constants.SocketBaseDir)
 	var err error
 	config, viper, err = newConfig()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containers/libhvee v0.11.0
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/crc-org/admin-helper v0.5.8
-	github.com/crc-org/machine v0.0.0-20260721135927-5bcb8a00e0f1
+	github.com/crc-org/machine v0.0.0-20260805175039-d3388f63e9f9
 	github.com/crc-org/vfkit v0.6.4
 	github.com/cucumber/godog v0.16.0
 	github.com/cucumber/messages-go/v10 v10.0.3

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/crc-org/admin-helper v0.5.8 h1:zXXzBgXrLXA+gNvtS2KdgtaD5WAB23ZNTSMUpfdE5U8=
 github.com/crc-org/admin-helper v0.5.8/go.mod h1:Xx2JCxgAdDSBhJHJ/vaBuioi94oA8Da9yRWBKeH7nic=
-github.com/crc-org/machine v0.0.0-20260721135927-5bcb8a00e0f1 h1:F+m/3LuzDqnGa9z+m8juGb1epcWAfUNsAoODfzIJkDI=
-github.com/crc-org/machine v0.0.0-20260721135927-5bcb8a00e0f1/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
+github.com/crc-org/machine v0.0.0-20260805175039-d3388f63e9f9 h1:gsI8puDdopuAxS/9ebNR+8ScXSy+7SxTGpGki2jVj7I=
+github.com/crc-org/machine v0.0.0-20260805175039-d3388f63e9f9/go.mod h1:trWeQimjfE3dJ8qWOxI4ePtYm13aecK42bf01s6h/Nc=
 github.com/crc-org/vfkit v0.6.4 h1:9UfAGABf0gb9PgRyOGvBeGq/9cQv5DKbJ4qHuN+Eh9k=
 github.com/crc-org/vfkit v0.6.4/go.mod h1:soPLDvhdsPbFasruB9b3lGx25Ahq2bD5CxyRQ0DCO+Y=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/crc-org/machine/libmachine/drivers/plugin/localbinary/plugin.go
+++ b/vendor/github.com/crc-org/machine/libmachine/drivers/plugin/localbinary/plugin.go
@@ -26,6 +26,7 @@ const (
 	PluginEnvKey        = "MACHINE_PLUGIN_TOKEN"
 	PluginEnvVal        = "42"
 	PluginEnvDriverName = "MACHINE_PLUGIN_DRIVER_NAME"
+	PluginEnvSocketDir  = "MACHINE_PLUGIN_SOCKET_DIR"
 )
 
 type McnBinaryExecutor interface {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -143,7 +143,7 @@ github.com/cpuguy83/go-md2man/v2/md2man
 github.com/crc-org/admin-helper/pkg/client
 github.com/crc-org/admin-helper/pkg/hosts
 github.com/crc-org/admin-helper/pkg/types
-# github.com/crc-org/machine v0.0.0-20260721135927-5bcb8a00e0f1
+# github.com/crc-org/machine v0.0.0-20260805175039-d3388f63e9f9
 ## explicit; go 1.17
 github.com/crc-org/machine/drivers/libvirt
 github.com/crc-org/machine/libmachine/drivers


### PR DESCRIPTION
Update machine dependency to use the exported constant for the socket directory environment variable name.

## Description

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
This is a follow-up to the following pull requests:
https://github.com/crc-org/machine/pull/72
https://github.com/crc-org/machine/pull/73

After the above changes, the machine driver plugin uses unix sockets instead of a TCP endpoint to communicate. It reads the `MACHINE_PLUGIN_SOCKET_DIR` environment variable to determine where to create its socket files. This PR sets that variable to `~/.crc/sockets` from crc.

<!--
Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set up a single-node OpenShift cluster on it with one command. It requires blablabla..._
-->

## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Proposed changes
<!--
List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...
-->

## Testing
<!--
What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
-->

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [ ] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine plugin startup by configuring the plugin socket directory during command initialization.
  * Updated the machine integration to a newer version for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->