### PR TITLE
launchd: Restrict agent plist to Background session type 

### DIFF
--- a/pkg/os/darwin/launchd/launchd_darwin.go
+++ b/pkg/os/darwin/launchd/launchd_darwin.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/crc-org/crc/v2/pkg/crc/constants"
+	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/crc-org/crc/v2/pkg/os"
 )
 
@@ -115,12 +116,18 @@ func CheckPlist(config AgentConfig) error {
 
 // LoadPlist loads a launchd agents' plist file
 func LoadPlist(label string) error {
-	return runLaunchCtl("load", "-w", getPlistPath(label))
+	uid := goos.Getuid()
+	// This is required for migration from older versions
+	if err := runLaunchCtl("enable", fmt.Sprintf("user/%d/%s", uid, label)); err != nil {
+		logging.Debugf("Failed to enable launchd service %s: %v", label, err)
+	}
+	return runLaunchCtl("bootstrap", fmt.Sprintf("user/%d", uid), getPlistPath(label))
 }
 
 // UnloadPlist Unloads a launchd agent's service
 func UnloadPlist(label string) error {
-	return runLaunchCtl("unload", "-w", getPlistPath(label))
+	target := fmt.Sprintf("user/%d/%s", goos.Getuid(), label)
+	return runLaunchCtl("bootout", target)
 }
 
 // RemovePlist removes a launchd agent plist config file

--- a/pkg/os/darwin/launchd/launchd_darwin.go
+++ b/pkg/os/darwin/launchd/launchd_darwin.go
@@ -42,6 +42,8 @@ const (
 	</dict>
 	<key>RunAtLoad</key>
 	<true/>
+	<key>LimitLoadToSessionType</key>
+	<string>Background</string>
 </dict>
 </plist>
 `


### PR DESCRIPTION
## Description

Without an explicit LimitLoadToSessionType, macOS defaults the
LaunchAgent to the Aqua (GUI) session. This causes the CRC daemon
to fail with error 134 (BOOTSTRAP_NOT_PRIVILEGED) when loaded over
SSH or any non-GUI context, since no Aqua session exists.

Set LimitLoadToSessionType to Background, which is a superset that
includes GUI, SSH, and all other login contexts. The daemon is a
headless process with no GUI dependency, so this has no effect on
existing GUI users.


## Type of change
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase;
  test, version modification, documentation, etc.)

## Testing
Try to connect your mac using ssh from another system and logout from the mac and then after `crc cleanup` => `crc setup` . With this PR you are able to run the crc daemon as service.

Without this PR it fails to run the crc daemon.

## Contribution Checklist
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I have performed a self-review of my code
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS background service loading for per-user agents.
  * Improved service removal reliability for the current user session.
  * Activation failures are now logged while setup continues.

* **Enhancements**
  * Restricted launch agents to macOS Background sessions for more predictable behavior.
  * Improved service lifecycle handling across startup and removal operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->