### PR TITLE
preflight: Ignore "No such process" error during daemon cleanup

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -141,7 +141,7 @@ func killVfkitProcess() error {
 		if errors.As(err, &exitErr) {
 			/* 1: no processes matched */
 			if exitErr.ExitCode() == 1 {
-				logging.Debugf("No running 'vfkit' process started by crc")
+				logging.Debugf("No running 'vfkit' process started by crc, continuing")
 				return nil
 			}
 		}
@@ -204,7 +204,10 @@ func fixDaemonPlistFileExists() error {
 
 func removeDaemonPlistFile() error {
 	if err := launchd.UnloadPlist(constants.DaemonAgentLabel); err != nil {
-		return err
+		if !strings.Contains(err.Error(), "No such process") {
+			return err
+		}
+		logging.Debugf("Daemon plist not loaded, continuing")
 	}
 	return launchd.RemovePlist(constants.DaemonAgentLabel)
 }


### PR DESCRIPTION
Fixes #5359

Updated removeDaemonPlistFile() to treat "No such process" from launchctl as success and continue with removing the plist file, similar to how killVfkitProcess() handles the case where no vfkit process is running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS cleanup handling when CRC-started processes are not present.
  * Daemon cleanup now continues when the service is already unloaded, ensuring its configuration is still removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->