### PR TITLE
macos: delay check for keyring accessible

### DIFF
--- a/pkg/crc/api/helpers.go
+++ b/pkg/crc/api/helpers.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sync"
 
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 )
@@ -45,8 +44,7 @@ func (c *context) Code(code int) error {
 }
 
 type server struct {
-	routes     map[string]map[string]func(*context) error
-	routesLock sync.RWMutex
+	routes map[string]map[string]func(*context) error
 }
 
 func newServer() *server {
@@ -56,8 +54,6 @@ func newServer() *server {
 }
 
 func (s *server) GET(pattern string, handler func(c *context) error) {
-	s.routesLock.Lock()
-	defer s.routesLock.Unlock()
 	if _, ok := s.routes[pattern]; !ok {
 		s.routes[pattern] = make(map[string]func(*context) error)
 	}
@@ -65,8 +61,6 @@ func (s *server) GET(pattern string, handler func(c *context) error) {
 }
 
 func (s *server) POST(pattern string, handler func(c *context) error) {
-	s.routesLock.Lock()
-	defer s.routesLock.Unlock()
 	if _, ok := s.routes[pattern]; !ok {
 		s.routes[pattern] = make(map[string]func(*context) error)
 	}
@@ -74,8 +68,6 @@ func (s *server) POST(pattern string, handler func(c *context) error) {
 }
 
 func (s *server) DELETE(pattern string, handler func(c *context) error) {
-	s.routesLock.Lock()
-	defer s.routesLock.Unlock()
 	if _, ok := s.routes[pattern]; !ok {
 		s.routes[pattern] = make(map[string]func(*context) error)
 	}
@@ -98,22 +90,18 @@ func (s *server) Handler() http.Handler {
 			entry.Info("api request")
 		}()
 
-		s.routesLock.RLock()
 		route, ok := s.routes[r.URL.Path]
 		if !ok {
-			s.routesLock.RUnlock()
 			status = http.StatusNotFound
 			http.Error(w, "Not Found", status)
 			return
 		}
 		handler, ok := route[r.Method]
 		if !ok {
-			s.routesLock.RUnlock()
 			status = http.StatusNotFound
 			http.Error(w, "Not Found", status)
 			return
 		}
-		s.routesLock.RUnlock()
 
 		requestBody, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/pkg/crc/config/secret_config.go
+++ b/pkg/crc/config/secret_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/crc-org/crc/v2/pkg/crc/logging"
 	"github.com/spf13/cast"
@@ -22,16 +23,23 @@ func (s Secret) String() string {
 type SecretStorage struct {
 	secretService   string
 	storeAccessible bool
+	once            sync.Once
 }
 
 func NewSecretStorage() *SecretStorage {
 	return &SecretStorage{
-		secretService:   secretServiceName,
-		storeAccessible: keyringAccessible(),
+		secretService: secretServiceName,
 	}
 }
 
+func (c *SecretStorage) ensureInitialized() {
+	c.once.Do(func() {
+		c.storeAccessible = keyringAccessible()
+	})
+}
+
 func (c *SecretStorage) Get(key string) interface{} {
+	c.ensureInitialized()
 	if !c.storeAccessible {
 		return nil
 	}
@@ -43,6 +51,7 @@ func (c *SecretStorage) Get(key string) interface{} {
 }
 
 func (c *SecretStorage) Set(key string, value interface{}) error {
+	c.ensureInitialized()
 	if !c.storeAccessible {
 		return ErrSecretsNotAccessible
 	}
@@ -54,6 +63,7 @@ func (c *SecretStorage) Set(key string, value interface{}) error {
 }
 
 func (c *SecretStorage) Unset(key string) error {
+	c.ensureInitialized()
 	if !c.storeAccessible {
 		return ErrSecretsNotAccessible
 	}
@@ -76,8 +86,11 @@ func keyringAccessible() bool {
 
 func NewEmptyInMemorySecretStorage() *SecretStorage {
 	keyring.MockInit()
-	return &SecretStorage{
+	s := &SecretStorage{
 		secretService:   secretServiceName,
 		storeAccessible: true,
 	}
+	// Consume the once so ensureInitialized won't overwrite storeAccessible.
+	s.once.Do(func() {})
+	return s
 }


### PR DESCRIPTION
## Description

this does the check for if keyring accessible
at the time of get/unset/set of config values
and avoids doing the check for all commands


## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Secret storage now checks keyring availability only when first accessed, helping applications start without performing an unnecessary keyring check upfront.
  - In-memory secret storage continues to work reliably without being affected by keyring availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->