### PR TITLE
launchd: Fall back to 'remove' when bootout fails to unload an agent

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -213,6 +213,9 @@ func removeDaemonPlistFile() error {
 }
 
 func fixPlistFileExists(agentConfig launchd.AgentConfig) error {
+	// Unload the plist file to unregister the agent from launchd
+	// ignore error if the plist file is not loaded/exists
+	launchd.UnloadPlist(agentConfig.Label) //nolint:errcheck
 	logging.Debugf("Creating plist for %s", agentConfig.Label)
 	err := launchd.CreatePlist(agentConfig)
 	if err != nil {

--- a/pkg/os/darwin/launchd/launchd_darwin.go
+++ b/pkg/os/darwin/launchd/launchd_darwin.go
@@ -127,7 +127,19 @@ func LoadPlist(label string) error {
 // UnloadPlist Unloads a launchd agent's service
 func UnloadPlist(label string) error {
 	target := fmt.Sprintf("user/%d/%s", goos.Getuid(), label)
-	return runLaunchCtl("bootout", target)
+	if err := runLaunchCtl("bootout", target); err != nil {
+		// The agent may be registered in a different launchd domain than
+		// the one targeted above (e.g. 'gui/<uid>', from an older CRC
+		// version or macOS auto-loading the LaunchAgent plist at login).
+		// In that case bootout reports "No such process" here even though
+		// the service is still active in the other domain, so always fall
+		// back to 'launchctl remove', which drops a job by label
+		// regardless of domain and won't conflict with a subsequently
+		// bootstrapped plist.
+		logging.Debugf("failed to bootout launchd agent '%s': %v, falling back to 'remove'", label, err)
+		return Remove(label)
+	}
+	return nil
 }
 
 // RemovePlist removes a launchd agent plist config file


### PR DESCRIPTION
bootout targets a specific domain (user/<uid>/<label>), but the CRC daemon LaunchAgent can end up registered in a different domain than expected -- e.g. an older CRC version bootstrapped it under gui/<uid>, or macOS auto-loaded the plist at login into a session domain. When that happens, bootout fails with "No such process" even though the job is still active elsewhere, leaving a stale agent running and blocking a subsequent bootstrap of the same label.

launchctl remove drops a job by label regardless of which domain it lives in, so use it as a fallback whenever bootout fails, ensuring the agent is actually unloaded before we try to reload it.

Fixes: #5366 

## Testing
- Use any released version of crc on mac and execute `setup` command 
- Switch to main branch (without this PR) and do `crc cleanup` and again `crc setup` which will fail with 
```
DEBU Running 'launchctl error 5'
DEBU failed to load launchd agent 'com.redhat.crc.daemon': 5: Input/output error
ERRO 5: Input/output error
```
- Now use this PR and try again which should remove the old plist file and `crc setup` will not fails.

## Contribution Checklist
- [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Which platform have you tested the code changes on? <!-- Only put an `x` in applicable platforms -->
    - [ ] Linux
    - [ ] Windows
    - [x] MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS service removal by falling back to an alternate cleanup method when the primary unload operation fails.
  * Services can now be removed more reliably across launchd domains.
  * Improved macOS service configuration updates by unloading existing agents before recreating and loading their configuration files.
  * Configuration updates can proceed when an agent is not currently loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->