### PR TITLE
Update content gateway file link after migration

### DIFF
--- a/.agents/skills/release-notes/examples/sample.md
+++ b/.agents/skills/release-notes/examples/sample.md
@@ -16,7 +16,7 @@ The most notable changes since the previous release are:
 - In preflight checks don't error out when check fails [5]
 
 
-[0] https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/2.53.0
+[0] https://developers.redhat.com/content-gateway/rest/mirror/pub/cgw/crc/2.53.0
 [1] https://github.com/crc-org/crc/issues
 [2] https://crc.dev/docs
 [3] https://github.com/crc-org/crc/releases/tag/v2.53.0

--- a/.agents/skills/release-notes/template.md
+++ b/.agents/skills/release-notes/template.md
@@ -16,7 +16,7 @@ The most notable changes since the previous release are:
 - <notable change 2>
 
 
-[0] https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/<crc-version>
+[0] https://developers.redhat.com/content-gateway/rest/mirror/pub/cgw/crc/<crc-version>
 [1] https://github.com/crc-org/crc/issues
 [2] https://crc.dev/docs
 [3] https://github.com/crc-org/crc/releases/tag/<crc-tag>

--- a/gh-release.sh
+++ b/gh-release.sh
@@ -24,7 +24,7 @@ fi
 
 function prepare_release_notes() {
 	read -r -d '' rn_template << EOF
-Downloads are available at: https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/%s
+Downloads are available at: https://developers.redhat.com/content-gateway/rest/mirror/pub/cgw/crc/%s
 To use these binaries follow the instructions at https://console.redhat.com/openshift/create/local to obtain the needed pull-secret.
 
 -------

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -421,7 +421,7 @@ type ReleaseInfo struct {
 }
 
 func FetchLatestReleaseInfo() (*ReleaseInfo, error) {
-	const releaseInfoLink = "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/release-info.json"
+	const releaseInfoLink = "https://developers.redhat.com/content-gateway/rest/mirror/pub/cgw/crc/latest/release-info.json"
 	response, err := download.InMemory(releaseInfoLink)
 	if err != nil {
 		return nil, err

--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -349,7 +349,7 @@ func TestGetBundleNameFromURI(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("crc_%s_4.17.3_%s.crcbundle", osVirt, runtime.GOARCH), bundleName)
 
 	// HTTPs
-	bundleName, err = GetBundleNameFromURI("https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/bundles/openshift/4.17.3/crc_libvirt_4.17.3_amd64.crcbundle")
+	bundleName, err = GetBundleNameFromURI("https://developers.redhat.com/content-gateway/file/pub/cgw/crc/bundles/openshift/4.17.3/crc_libvirt_4.17.3_amd64.crcbundle")
 	assert.Nil(t, err)
 	assert.Equal(t, "crc_libvirt_4.17.3_amd64.crcbundle", bundleName)
 

--- a/release-info.json.sample
+++ b/release-info.json.sample
@@ -5,8 +5,8 @@
 		"openshiftVersion": "@OPENSHIFT_VERSION@"
 	},
 	"links": {
-	    "linux": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/@CRC_VERSION@/crc-linux-amd64.tar.xz",
-	    "darwin": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/@CRC_VERSION@/crc-macos-installer.pkg",
-	    "windows": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/@CRC_VERSION@/crc-windows-installer.zip"
+	    "linux": "https://developers.redhat.com/content-gateway/file/pub/cgw/crc/@CRC_VERSION@/crc-linux-amd64.tar.xz",
+	    "darwin": "https://developers.redhat.com/content-gateway/file/pub/cgw/crc/@CRC_VERSION@/crc-macos-installer.pkg",
+	    "windows": "https://developers.redhat.com/content-gateway/file/pub/cgw/crc/@CRC_VERSION@/crc-windows-installer.zip"
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release downloads and release metadata to use the current Content Gateway mirror.
  * Improved access to CRC bundles and release information across supported platforms.
* **Documentation**
  * Updated release-note templates and examples with the current download links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->